### PR TITLE
Add README.md files for each example configuration

### DIFF
--- a/examples/data-only/README.md
+++ b/examples/data-only/README.md
@@ -1,0 +1,25 @@
+# Data-Only Migration
+
+Copies data without creating or modifying schema objects. The target tables must
+already exist in PostgreSQL.
+
+## Key settings
+
+| Setting | Value | Why |
+|---|---|---|
+| `data_only` | `true` | Skips schema introspection, table creation, and post-migration (PKs, FKs, indexes, sequences) |
+| `workers` | `8` | Parallel COPY workers for throughput |
+
+## When to use
+
+- The PostgreSQL schema was created manually or by another tool.
+- You only need to backfill or refresh data from the source database.
+- Schema objects (constraints, indexes, sequences) are already in place.
+
+## Usage
+
+```bash
+pgferry -config examples/data-only/migration.toml
+```
+
+Edit the `[source]` and `[target]` DSNs to match your environment before running.

--- a/examples/hooks/README.md
+++ b/examples/hooks/README.md
@@ -1,0 +1,30 @@
+# Hooks Example
+
+Demonstrates all four hook phases with example SQL files.
+
+## Hook phases
+
+Hooks are SQL files executed at specific points during migration. All occurrences
+of `{{schema}}` are replaced with the configured schema name at runtime.
+
+| Phase | File | Runs when |
+|---|---|---|
+| `before_data` | `before_data.sql` | After table creation, before data COPY. Good for installing extensions or creating helper functions. |
+| `after_data` | `after_data.sql` | After data COPY, before post-migration constraints. Good for ANALYZE or data transforms. |
+| `before_fk` | `before_fk.sql` | After PKs and indexes, before FK creation. Good for orphan cleanup. |
+| `after_all` | `after_all.sql` | After FKs, sequences, and triggers. Good for views, materialized views, or validation queries. |
+
+## Files
+
+- **`before_data.sql`** — Installs the `pgcrypto` extension.
+- **`after_data.sql`** — Runs `ANALYZE` on the schema for fresh planner stats.
+- **`before_fk.sql`** — Placeholder for orphan cleanup statements.
+- **`after_all.sql`** — Placeholder for views and validation queries.
+
+## Usage
+
+```bash
+pgferry -config examples/hooks/migration.toml
+```
+
+Edit the `[source]` and `[target]` DSNs to match your environment before running.

--- a/examples/minimal-safe/README.md
+++ b/examples/minimal-safe/README.md
@@ -1,0 +1,26 @@
+# Minimal Safe Migration
+
+A conservative starting template for first-time migrations.
+
+## Key settings
+
+| Setting | Value | Why |
+|---|---|---|
+| `on_schema_exists` | `error` | Prevents accidentally overwriting an existing schema |
+| `clean_orphans` | `false` | No automatic deletion of orphaned rows |
+| `unlogged_tables` | `false` | Tables are fully WAL-logged for crash safety |
+| `preserve_defaults` | `true` | Column defaults are carried over to PostgreSQL |
+
+## When to use
+
+- You are migrating for the first time and want the safest defaults.
+- The target PostgreSQL database does not yet contain the schema.
+- You prefer to handle orphan cleanup manually (or via hooks) rather than automatically.
+
+## Usage
+
+```bash
+pgferry -config examples/minimal-safe/migration.toml
+```
+
+Edit the `[source]` and `[target]` DSNs to match your environment before running.

--- a/examples/recreate-fast/README.md
+++ b/examples/recreate-fast/README.md
@@ -1,0 +1,27 @@
+# Recreate Fast Migration
+
+Optimized for speed on repeatable dev/staging loads. Drops and recreates the
+schema each run and uses UNLOGGED tables to skip WAL overhead during bulk copy.
+
+## Key settings
+
+| Setting | Value | Why |
+|---|---|---|
+| `on_schema_exists` | `recreate` | Drops the schema and starts fresh every run |
+| `unlogged_tables` | `true` | Skips WAL writes during COPY for faster loads |
+| `clean_orphans` | `true` | Automatically deletes orphaned child rows before FK creation |
+| `workers` | `8` | Maximizes parallelism for data copy |
+
+## When to use
+
+- Repeatable loads into a dev or staging database.
+- You don't mind losing the data if PostgreSQL crashes mid-migration (UNLOGGED tables are truncated on crash recovery).
+- You want the fastest possible migration and can re-run if something goes wrong.
+
+## Usage
+
+```bash
+pgferry -config examples/recreate-fast/migration.toml
+```
+
+Edit the `[source]` and `[target]` DSNs to match your environment before running.

--- a/examples/sakila/README.md
+++ b/examples/sakila/README.md
@@ -1,0 +1,32 @@
+# Sakila Sample Database Migration
+
+A real-world example migrating the [MySQL Sakila sample database](https://dev.mysql.com/doc/sakila/en/)
+to PostgreSQL.
+
+## Key settings
+
+| Setting | Value | Why |
+|---|---|---|
+| `on_schema_exists` | `error` | Fail if the schema already exists |
+| `clean_orphans` | `true` | Automatically remove orphaned rows before FK creation |
+| `workers` | `4` | Parallel COPY workers |
+
+## Hook files
+
+- **`cleanup.sql`** (`before_fk`) — NULLs out dangling optional references and
+  deletes orphaned child rows so FK constraints can be created cleanly.
+- **`post.sql`** (`after_all`) — Creates a `film_list` convenience view and runs
+  `ANALYZE` on all tables for fresh planner statistics.
+
+## Prerequisites
+
+- MySQL with the Sakila sample database loaded ([installation guide](https://dev.mysql.com/doc/sakila/en/sakila-installation.html)).
+- A target PostgreSQL database.
+
+## Usage
+
+```bash
+pgferry -config examples/sakila/migration.toml
+```
+
+Edit the `[source]` and `[target]` DSNs to match your environment before running.

--- a/examples/schema-only/README.md
+++ b/examples/schema-only/README.md
@@ -1,0 +1,25 @@
+# Schema-Only Migration
+
+Creates the PostgreSQL schema (tables, constraints, indexes, sequences) without
+copying any row data.
+
+## Key settings
+
+| Setting | Value | Why |
+|---|---|---|
+| `schema_only` | `true` | Creates tables and post-migration objects but skips data COPY |
+| `on_schema_exists` | `recreate` | Drops and recreates the schema for a clean start |
+
+## When to use
+
+- You want to validate the generated PostgreSQL schema before committing to a full data migration.
+- You plan to load data separately (e.g., via `data_only` mode or a custom ETL pipeline).
+- You need a quick way to iterate on type mappings and hooks without waiting for data transfer.
+
+## Usage
+
+```bash
+pgferry -config examples/schema-only/migration.toml
+```
+
+Edit the `[source]` and `[target]` DSNs to match your environment before running.


### PR DESCRIPTION
Each README explains the key settings, when to use the example, and how to run it, so users can quickly find the right starting template.