### PR TITLE
Quote PostgreSQL collation identifiers

### DIFF
--- a/ddl_test.go
+++ b/ddl_test.go
@@ -104,6 +104,24 @@ func TestGenerateCreateTable_ReservedWords(t *testing.T) {
 	}
 }
 
+func TestGenerateCreateTable_QuotesCollationIdentifier(t *testing.T) {
+	table := Table{
+		PGName: "articles",
+		Columns: []Column{
+			{PGName: "collation", DataType: "varchar", CharMaxLen: 64, Nullable: false},
+		},
+	}
+
+	ddl, err := generateCreateTable(table, "app", false, false, defaultTypeMappingConfig(), mysqlSrc)
+	if err != nil {
+		t.Fatalf("generateCreateTable() error: %v", err)
+	}
+
+	if !strings.Contains(ddl, `"collation" varchar(64) NOT NULL`) {
+		t.Fatalf("DDL should quote reserved word 'collation', got:\n%s", ddl)
+	}
+}
+
 func TestGenerateCreateTable_UnknownTypeErrors(t *testing.T) {
 	table := Table{
 		PGName: "mystery",

--- a/schema.go
+++ b/schema.go
@@ -11,7 +11,7 @@ var pgReservedWords = map[string]bool{
 	"all": true, "analyse": true, "analyze": true, "and": true, "any": true,
 	"array": true, "as": true, "asc": true, "authorization": true, "between": true,
 	"binary": true, "both": true, "case": true, "cast": true, "check": true,
-	"collate": true, "column": true, "constraint": true, "create": true, "cross": true,
+	"collate": true, "collation": true, "column": true, "constraint": true, "create": true, "cross": true,
 	"current_date": true, "current_role": true, "current_time": true,
 	"current_timestamp": true, "current_user": true, "default": true, "deferrable": true,
 	"desc": true, "distinct": true, "do": true, "else": true, "end": true, "except": true,

--- a/schema_test.go
+++ b/schema_test.go
@@ -32,6 +32,7 @@ func TestPgIdent(t *testing.T) {
 	}{
 		{"user", `"user"`},
 		{"order", `"order"`},
+		{"collation", `"collation"`},
 		{"table", `"table"`},
 		{"users", "users"},
 		{"match_id", "match_id"},

--- a/sequence_sql_test.go
+++ b/sequence_sql_test.go
@@ -40,3 +40,16 @@ func TestResetSequenceStatements_QuotesNonTrivialSequenceName(t *testing.T) {
 		t.Fatalf("nextval statement = %q", stmts[2])
 	}
 }
+
+func TestResetSequenceStatements_QuotesReservedColumnName(t *testing.T) {
+	table := Table{PGName: "audit"}
+	col := Column{PGName: "collation", Extra: "auto_increment"}
+
+	stmts := resetSequenceStatements("app", table, col)
+	if !strings.Contains(stmts[1], `SELECT MAX("collation") FROM app.audit`) {
+		t.Fatalf("setval statement = %q", stmts[1])
+	}
+	if !strings.Contains(stmts[2], `ALTER TABLE app.audit ALTER COLUMN "collation" SET DEFAULT`) {
+		t.Fatalf("nextval statement = %q", stmts[2])
+	}
+}


### PR DESCRIPTION
## Summary
- add `collation` to the PostgreSQL reserved-word set used by `pgIdent`
- add regression coverage for `pgIdent("collation")`
- verify generated DDL and post-migration sequence SQL quote `collation` identifiers

## Testing
- `GOCACHE=/tmp/go-build-cache go test ./... -count=1`

Closes #49