### PR TITLE
perf: throttle time.Now() in rowSource progress checks (#89)

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -498,6 +498,14 @@ func buildChunkPlans(ctx context.Context, src SourceDB, srcDSN string, schema *S
 	return plans, nil
 }
 
+// progressLogTimeSampleRows controls how often rowSource.Next samples wall time
+// for the ~10s progress log. time.Now() is not called on every row.
+const progressLogTimeSampleRows int64 = 1024
+
+func shouldSampleProgressLogTime(copied int64) bool {
+	return copied == 1 || copied%progressLogTimeSampleRows == 0
+}
+
 // rowSource implements pgx.CopyFromSource by reading from source rows.
 type rowSource struct {
 	rows        *sql.Rows
@@ -555,9 +563,11 @@ func (r *rowSource) Next() bool {
 	}
 
 	r.copied++
-	if now := time.Now(); now.Sub(r.lastLog) >= 10*time.Second {
-		log.Printf("  [%s] progress: %d rows copied", r.tableName, r.copied)
-		r.lastLog = now
+	if shouldSampleProgressLogTime(r.copied) {
+		if now := time.Now(); now.Sub(r.lastLog) >= 10*time.Second {
+			log.Printf("  [%s] progress: %d rows copied", r.tableName, r.copied)
+			r.lastLog = now
+		}
 	}
 	return true
 }

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -11,6 +11,26 @@ import (
 	"testing"
 )
 
+func TestShouldSampleProgressLogTime(t *testing.T) {
+	tests := []struct {
+		copied int64
+		want   bool
+	}{
+		{1, true},
+		{2, false},
+		{1023, false},
+		{1024, true},
+		{1025, false},
+		{2048, true},
+		{2049, false},
+	}
+	for _, tt := range tests {
+		if got := shouldSampleProgressLogTime(tt.copied); got != tt.want {
+			t.Errorf("shouldSampleProgressLogTime(%d) = %v, want %v", tt.copied, got, tt.want)
+		}
+	}
+}
+
 func TestNewRowSourcePreallocatesBuffers(t *testing.T) {
 	table := Table{
 		SourceName: "users",


### PR DESCRIPTION
## Summary
Implements #89: avoid calling `time.Now()` on every row in `(*rowSource).Next` when checking whether to emit the ~10s progress log during data copy.

## Approach
- `progressLogTimeSampleRows = 1024` — sample wall time at row 1 and every 1024 rows.
- Progress messages still use a **10s wall-clock** threshold vs `lastLog`; sampling only limits how often we read the clock.

## Testing
- `go vet ./...`
- `go test ./... -count=1` (includes `TestShouldSampleProgressLogTime`)

## Notes
Very low row rates may see coarser log timing (same tradeoff as discussed on the issue).

Made with [Cursor](https://cursor.com)