### PR TITLE
perf: preallocate planChunks; buffer migration work channel (#92, #93)

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -29,6 +30,29 @@ type ChunkPlan struct {
 	ChunkSize int64
 }
 
+// estimatedChunkCount returns how many chunks planChunks produces for [min, max]
+// with the given positive chunkSize. For rangeSize < chunkSize it returns 1 (single
+// chunk path). Returns 0 if the count does not fit in int or would overflow int64
+// arithmetic (caller should skip preallocation).
+func estimatedChunkCount(min, max, chunkSize int64) int {
+	if chunkSize <= 0 {
+		return 0
+	}
+	rangeSize := max - min
+	if rangeSize < chunkSize {
+		return 1
+	}
+	q := rangeSize / chunkSize
+	if q > math.MaxInt64-1 {
+		return 0
+	}
+	n := q + 1
+	if n < 0 || n > int64(math.MaxInt) {
+		return 0
+	}
+	return int(n)
+}
+
 // planChunks divides the [min, max] key range into chunks of approximately chunkSize.
 // Returns a single chunk covering the full range if the range is smaller than chunkSize.
 func planChunks(min, max, chunkSize int64) []Chunk {
@@ -49,6 +73,11 @@ func planChunks(min, max, chunkSize int64) []Chunk {
 	}
 
 	var chunks []Chunk
+	if wantCap := estimatedChunkCount(min, max, chunkSize); wantCap > 0 {
+		chunks = make([]Chunk, 0, wantCap)
+	} else {
+		chunks = make([]Chunk, 0)
+	}
 	for lower := min; lower <= max; {
 		upper := lower + chunkSize
 		isLast := upper > max

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,6 +1,45 @@
 package main
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
+
+func TestEstimatedChunkCount(t *testing.T) {
+	tests := []struct {
+		min, max, chunkSize int64
+		want                int
+	}{
+		{1, 100, 1000, 1},
+		{1, 300, 100, 3},
+		{1, 250, 100, 3},
+		{42, 42, 100, 1},
+		{0, 999999, 100000, 10},
+		{-50, 50, 100, 2},
+		{1, 101, 100, 2},
+		{0, 200, 100, 3},
+		{0, 0, 1, 1},
+		{1, 10, 0, 0},
+	}
+	for _, tt := range tests {
+		got := estimatedChunkCount(tt.min, tt.max, tt.chunkSize)
+		if got != tt.want {
+			t.Errorf("estimatedChunkCount(%d,%d,%d) = %d, want %d", tt.min, tt.max, tt.chunkSize, got, tt.want)
+		}
+		if tt.chunkSize > 0 {
+			if len(planChunks(tt.min, tt.max, tt.chunkSize)) != got {
+				t.Errorf("len(planChunks(%d,%d,%d)) != estimatedChunkCount = %d", tt.min, tt.max, tt.chunkSize, got)
+			}
+		}
+	}
+}
+
+func TestEstimatedChunkCount_OverflowReturnsZero(t *testing.T) {
+	// q+1 would overflow int64; must not preallocate with a bogus cap.
+	if got := estimatedChunkCount(0, math.MaxInt64, 1); got != 0 {
+		t.Fatalf("estimatedChunkCount(0, MaxInt64, 1) = %d, want 0", got)
+	}
+}
 
 func TestPlanChunks_SingleChunkWhenSmall(t *testing.T) {
 	chunks := planChunks(1, 100, 1000)

--- a/migrate.go
+++ b/migrate.go
@@ -149,7 +149,16 @@ func runParallelMigrationWorkers(ctx context.Context, workers int, openSource fu
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	workCh := make(chan migrationWorkItem)
+	// Buffered channel decouples enqueue from workers; size is bounded by work list
+	// and a small multiple of workers for light prefetch (correctness unchanged).
+	bufSize := workers * 2
+	if bufSize > len(workItems) {
+		bufSize = len(workItems)
+	}
+	if bufSize < 1 {
+		bufSize = 1
+	}
+	workCh := make(chan migrationWorkItem, bufSize)
 	var wg sync.WaitGroup
 
 	var firstErr error


### PR DESCRIPTION
## Summary

Implements [\#92](https://github.com/Limetric/pgferry/issues/92) and [\#93](https://github.com/Limetric/pgferry/issues/93).

### #92 — `planChunks` slice capacity
- Add `estimatedChunkCount(min, max, chunkSize)` with overflow-safe arithmetic; `planChunks` uses `make([]Chunk, 0, cap)` on the multi-chunk path.
- Unit tests assert the estimate matches `len(planChunks(...))` and cover the int64 overflow guard.

### #93 — Buffered migration worker channel
- `runParallelMigrationWorkers` uses `make(chan migrationWorkItem, bufSize)` with `bufSize = min(workers*2, len(workItems))` (minimum 1). Correctness unchanged; reduces producer/consumer sync on many small work items.

## Testing
- `go test ./... -count=1`
- `go vet ./...`

Made with [Cursor](https://cursor.com)