### PR TITLE
perf: tune pg pool sizing for migration concurrency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ Factory: `newSourceDB(sourceType string)` returns the correct implementation bas
 
 - Source names are converted to snake_case by default via `toSnakeCase`; when `snake_case_identifiers=false`, only lowercased; PostgreSQL reserved words are quoted via `pgIdent`
 - Tables are created as UNLOGGED by default during full migrations; set `unlogged_tables=false` for crash-safe WAL logging or when using `resume=true`
+- Target PostgreSQL pools are created via `pgxpool.ParseConfig`; when `[target].dsn` does not set `pool_max_conns`, pgferry raises `MaxConns` to at least the effective migration concurrency (`max(workers, index_workers)`). If `pool_max_conns` is set explicitly, pgferry preserves it and only warns when it is lower than that concurrency.
 - `auto_increment` columns get PG sequences; `ON UPDATE CURRENT_TIMESTAMP` columns get trigger emulation only when `replicate_on_update_current_timestamp=true`
 - `type_mapping.enum_mode` controls enum handling (`text` or `check`); `type_mapping.set_mode` controls set handling (`text` or `text_array`) — MySQL/MariaDB only
 - Some type mapping options are MySQL/MariaDB-only (`tinyint1_as_boolean`, `binary16_as_uuid`, `varchar_as_text`, `widen_unsigned_integers`, `enum_mode`, `set_mode`); some are MSSQL-only (`nvarchar_as_text`, `money_as_numeric`, `xml_as_text`); some are shared (`datetime_as_timestamptz`, `spatial_mode`). Incompatible sources reject these at config validation

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -289,7 +290,14 @@ func runMigrationWithConfig(cfg *MigrationConfig) error {
 
 	// 3. Connect to PostgreSQL
 	log.Printf("connecting to PostgreSQL...")
-	pgPool, err := pgxpool.New(ctx, cfg.Target.DSN)
+	poolCfg, poolWarning, err := buildTargetPoolConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("connect postgres: %w", err)
+	}
+	if poolWarning != "" {
+		log.Printf("WARN: %s", poolWarning)
+	}
+	pgPool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 	if err != nil {
 		return fmt.Errorf("connect postgres: %w", err)
 	}
@@ -400,6 +408,57 @@ func runMigrationWithConfig(cfg *MigrationConfig) error {
 
 	log.Printf("migration completed in %s", time.Since(start).Round(time.Millisecond))
 	return nil
+}
+
+func buildTargetPoolConfig(cfg *MigrationConfig) (*pgxpool.Config, string, error) {
+	connCfg, err := pgx.ParseConfig(cfg.Target.DSN)
+	if err != nil {
+		return nil, "", fmt.Errorf("parse postgres pool config: %w", err)
+	}
+
+	explicitMaxConns := int32(0)
+	explicitPoolMaxConns := false
+	if s, ok := connCfg.Config.RuntimeParams["pool_max_conns"]; ok {
+		explicitPoolMaxConns = true
+		n, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return nil, "", fmt.Errorf("parse postgres pool config: pool_max_conns=%q: %w", s, err)
+		}
+		explicitMaxConns = int32(n)
+	}
+
+	poolCfg, err := pgxpool.ParseConfig(cfg.Target.DSN)
+	if err != nil {
+		return nil, "", fmt.Errorf("parse postgres pool config: %w", err)
+	}
+
+	peak := effectiveTargetPoolConcurrency(cfg)
+	if explicitPoolMaxConns {
+		if explicitMaxConns < peak {
+			return poolCfg, fmt.Sprintf(
+				"target DSN sets pool_max_conns=%d below effective migration concurrency %d; parallel COPY and index creation may wait on the PostgreSQL pool",
+				explicitMaxConns,
+				peak,
+			), nil
+		}
+		return poolCfg, "", nil
+	}
+
+	if poolCfg.MaxConns < peak {
+		poolCfg.MaxConns = peak
+	}
+	return poolCfg, "", nil
+}
+
+func effectiveTargetPoolConcurrency(cfg *MigrationConfig) int32 {
+	peak := cfg.Workers
+	if cfg.IndexWorkers > peak {
+		peak = cfg.IndexWorkers
+	}
+	if peak < 1 {
+		peak = 1
+	}
+	return int32(peak)
 }
 
 func runDataMigrationPhase(

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -88,5 +89,65 @@ func TestRunMigration_UsesConfigFlag(t *testing.T) {
 	got := resolveMigrationConfigPath(nil)
 	if got != "migration.toml" {
 		t.Fatalf("resolveMigrationConfigPath(nil) = %q, want migration.toml", got)
+	}
+}
+
+func TestBuildTargetPoolConfig_AutoSizesMaxConnsWhenUnset(t *testing.T) {
+	cfg := &MigrationConfig{
+		Target:       TargetConfig{DSN: "postgres://postgres:postgres@127.0.0.1:5432/target?sslmode=disable"},
+		Workers:      12,
+		IndexWorkers: 4,
+	}
+
+	poolCfg, warning, err := buildTargetPoolConfig(cfg)
+	if err != nil {
+		t.Fatalf("buildTargetPoolConfig() error = %v", err)
+	}
+	if got, want := poolCfg.MaxConns, int32(12); got != want {
+		t.Fatalf("MaxConns = %d, want %d", got, want)
+	}
+	if warning != "" {
+		t.Fatalf("warning = %q, want empty", warning)
+	}
+}
+
+func TestBuildTargetPoolConfig_PreservesExplicitMaxConnsWhenHigher(t *testing.T) {
+	cfg := &MigrationConfig{
+		Target:       TargetConfig{DSN: "user=postgres password=postgres host=127.0.0.1 port=5432 dbname=target sslmode=disable pool_max_conns=50"},
+		Workers:      4,
+		IndexWorkers: 6,
+	}
+
+	poolCfg, warning, err := buildTargetPoolConfig(cfg)
+	if err != nil {
+		t.Fatalf("buildTargetPoolConfig() error = %v", err)
+	}
+	if got, want := poolCfg.MaxConns, int32(50); got != want {
+		t.Fatalf("MaxConns = %d, want %d", got, want)
+	}
+	if warning != "" {
+		t.Fatalf("warning = %q, want empty", warning)
+	}
+}
+
+func TestBuildTargetPoolConfig_PreservesExplicitMaxConnsWhenLowerAndWarns(t *testing.T) {
+	cfg := &MigrationConfig{
+		Target:       TargetConfig{DSN: "postgres://postgres:postgres@127.0.0.1:5432/target?sslmode=disable&pool_max_conns=5"},
+		Workers:      8,
+		IndexWorkers: 12,
+	}
+
+	poolCfg, warning, err := buildTargetPoolConfig(cfg)
+	if err != nil {
+		t.Fatalf("buildTargetPoolConfig() error = %v", err)
+	}
+	if got, want := poolCfg.MaxConns, int32(5); got != want {
+		t.Fatalf("MaxConns = %d, want %d", got, want)
+	}
+	if !strings.Contains(warning, "pool_max_conns=5") {
+		t.Fatalf("warning = %q, want explicit pool_max_conns value", warning)
+	}
+	if !strings.Contains(warning, "12") {
+		t.Fatalf("warning = %q, want effective concurrency", warning)
 	}
 }

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -94,7 +94,7 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 
 | Key | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `dsn` | string | required | PostgreSQL connection string. |
+| `dsn` | string | required | PostgreSQL connection string. If it does not set `pool_max_conns`, pgferry raises target pool `MaxConns` to at least `max(workers, index_workers)`. If `pool_max_conns` is set explicitly, pgferry preserves it and warns when it is lower than that concurrency. |
 
 ### `[type_mapping]`
 


### PR DESCRIPTION
## Summary
- size the PostgreSQL pgx pool from effective migration concurrency when `pool_max_conns` is not set
- preserve explicit `pool_max_conns` values and warn when they undersize parallel COPY or index creation
- document the target DSN pool sizing rule in repo guidance and user-facing configuration docs

## Test Plan
- [x] `go test ./... -count=1`

Closes #113