### PR TITLE
feat: generate plan hook skeletons for extensions and unsupported columns

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -531,7 +531,7 @@ func writeHookSkeletons(dir string, report *PlanReport, schema string) error {
 	}
 
 	// after_data: generated columns
-	if body := buildAfterDataSkeleton(report, schema); body != "" {
+	if body := buildAfterDataSkeleton(report); body != "" {
 		files = append(files, hookFile{"after_data.sql", body})
 	}
 
@@ -541,7 +541,7 @@ func writeHookSkeletons(dir string, report *PlanReport, schema string) error {
 	}
 
 	// after_all: views, routines, triggers, skipped indexes
-	if body := buildAfterAllSkeleton(report, schema); body != "" {
+	if body := buildAfterAllSkeleton(report); body != "" {
 		files = append(files, hookFile{"after_all.sql", body})
 	}
 
@@ -570,13 +570,14 @@ func buildBeforeDataSkeleton(report *PlanReport) string {
 	b.WriteString("-- pgferry requires these extensions for the configured type mappings.\n")
 
 	for _, req := range report.RequiredExtensions {
+		feature := sanitizeSQLCommentText(req.Feature)
 		switch req.Mode {
 		case "create_if_missing":
-			fmt.Fprintf(&b, "CREATE EXTENSION IF NOT EXISTS %s; -- %s\n", pgIdent(req.Name), req.Feature)
+			fmt.Fprintf(&b, "CREATE EXTENSION IF NOT EXISTS %s; -- %s\n", pgIdent(req.Name), feature)
 		case "require_existing":
-			fmt.Fprintf(&b, "-- Extension %q must already exist before running pgferry. (%s)\n", req.Name, req.Feature)
+			fmt.Fprintf(&b, "-- Extension %s must already exist before running pgferry. (%s)\n", pgIdent(req.Name), feature)
 		default:
-			fmt.Fprintf(&b, "-- Extension %q is required for %s.\n", req.Name, req.Feature)
+			fmt.Fprintf(&b, "-- Extension %s is required for %s.\n", pgIdent(req.Name), feature)
 		}
 	}
 
@@ -589,7 +590,7 @@ func buildBeforeFkSkeleton() string {
 	return ""
 }
 
-func buildAfterDataSkeleton(report *PlanReport, schema string) string {
+func buildAfterDataSkeleton(report *PlanReport) string {
 	if len(report.GeneratedColumns) == 0 {
 		return ""
 	}
@@ -608,7 +609,9 @@ func buildAfterDataSkeleton(report *PlanReport, schema string) string {
 		fmt.Fprintf(&b, "-- Table: %s\n", table)
 		for _, gc := range cols {
 			fmt.Fprintf(&b, "-- TODO: ALTER TABLE %s.%s\n", pgIdent("{{schema}}"), pgIdent(gc.Table))
-			fmt.Fprintf(&b, "--        ALTER COLUMN %s SET EXPRESSION AS (...);\n", pgIdent(gc.Column))
+			fmt.Fprintf(&b, "--        DROP COLUMN %s;\n", pgIdent(gc.Column))
+			fmt.Fprintf(&b, "-- TODO: ALTER TABLE %s.%s\n", pgIdent("{{schema}}"), pgIdent(gc.Table))
+			fmt.Fprintf(&b, "--        ADD COLUMN %s <type> GENERATED ALWAYS AS (...) STORED;\n", pgIdent(gc.Column))
 			fmt.Fprintf(&b, "-- Source expression: %s\n", gc.Expression)
 		}
 		b.WriteByte('\n')
@@ -617,7 +620,7 @@ func buildAfterDataSkeleton(report *PlanReport, schema string) string {
 	return b.String()
 }
 
-func buildAfterAllSkeleton(report *PlanReport, schema string) string {
+func buildAfterAllSkeleton(report *PlanReport) string {
 	objs := &report.SourceObjects
 	hasObjects := len(objs.Views) > 0 || len(objs.Routines) > 0 || len(objs.Triggers) > 0
 	hasIndexes := len(report.SkippedIndexes) > 0
@@ -672,14 +675,23 @@ func buildAfterAllSkeleton(report *PlanReport, schema string) string {
 		b.WriteString("-- Unsupported Columns\n")
 		b.WriteString("-- These columns could not be migrated automatically.\n")
 		for _, uc := range report.UnsupportedColumns {
+			sourceType := sanitizeSQLCommentText(uc.SourceType)
+			reason := sanitizeSQLCommentText(uc.Reason)
 			fmt.Fprintf(&b, "-- TODO: ALTER TABLE %s.%s ADD COLUMN %s ...;\n", pgIdent("{{schema}}"), pgIdent(uc.Table), pgIdent(uc.Column))
-			fmt.Fprintf(&b, "--   Source type: %s\n", uc.SourceType)
-			fmt.Fprintf(&b, "--   Reason: %s\n", uc.Reason)
+			fmt.Fprintf(&b, "--   Source type: %s\n", sourceType)
+			fmt.Fprintf(&b, "--   Reason: %s\n", reason)
 		}
 		b.WriteByte('\n')
 	}
 
 	return b.String()
+}
+
+func sanitizeSQLCommentText(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return strings.Join(strings.Fields(s), " ")
 }
 
 func groupGeneratedColumnsByTable(cols []PlanGeneratedColumn) map[string][]PlanGeneratedColumn {

--- a/plan_test.go
+++ b/plan_test.go
@@ -582,6 +582,18 @@ func TestWriteHookSkeletons_GeneratedColumns(t *testing.T) {
 	if !strings.Contains(content, "concat(`first`,`last`)") {
 		t.Error("after_data.sql should mention the source expression")
 	}
+	if strings.Contains(content, "SET EXPRESSION AS") {
+		t.Error("after_data.sql should not suggest unsupported PostgreSQL generated-column syntax")
+	}
+	for _, want := range []string{
+		`DROP COLUMN "display_name";`,
+		`ADD COLUMN "display_name"`,
+		"GENERATED ALWAYS AS (...) STORED",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("after_data.sql missing %q", want)
+		}
+	}
 }
 
 func TestWriteHookSkeletons_AfterAll(t *testing.T) {
@@ -687,6 +699,56 @@ func TestWriteHookSkeletons_UnsupportedColumns(t *testing.T) {
 		if !strings.Contains(content, want) {
 			t.Errorf("after_all.sql missing %q", want)
 		}
+	}
+}
+
+func TestWriteHookSkeletons_SanitizesCommentText(t *testing.T) {
+	dir := t.TempDir()
+	report := &PlanReport{
+		RequiredExtensions: []PlanRequiredExtension{
+			{Name: "citext", Feature: "ci_as_citext\nSELECT 1;", Mode: "create_if_missing"},
+			{Name: "postgis", Feature: "postgis\r\nALTER ROLE", Mode: "require_existing"},
+		},
+		UnsupportedColumns: []PlanUnsupportedColumn{
+			{
+				Table:      "mystery",
+				Column:     "payload",
+				SourceType: "geometry\nline2",
+				Reason:     "unsupported\r\ntype",
+			},
+		},
+	}
+
+	if err := writeHookSkeletons(dir, report, "app"); err != nil {
+		t.Fatalf("writeHookSkeletons: %v", err)
+	}
+
+	beforeData, err := os.ReadFile(filepath.Join(dir, "before_data.sql"))
+	if err != nil {
+		t.Fatalf("read before_data.sql: %v", err)
+	}
+	afterAll, err := os.ReadFile(filepath.Join(dir, "after_all.sql"))
+	if err != nil {
+		t.Fatalf("read after_all.sql: %v", err)
+	}
+
+	for _, content := range []string{string(beforeData), string(afterAll)} {
+		for _, unwanted := range []string{
+			"\nSELECT 1;",
+			"\nALTER ROLE",
+			"\nline2",
+			"\ntype",
+		} {
+			if strings.Contains(content, unwanted) {
+				t.Fatalf("generated skeleton should flatten embedded newlines, found %q in:\n%s", unwanted, content)
+			}
+		}
+	}
+}
+
+func TestBuildBeforeFkSkeleton_Empty(t *testing.T) {
+	if got := buildBeforeFkSkeleton(); got != "" {
+		t.Fatalf("buildBeforeFkSkeleton() = %q, want empty string", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- generate `before_data.sql` hook skeletons from plan-required PostgreSQL extensions
- append unsupported-column TODO stubs to `after_all.sql`
- document `before_fk` as an intentional reserved hook and add hook-skeleton coverage

Closes #125

## Test Plan
- `go fmt ./...`
- `go test ./... -count=1`
- `go test ./... -count=1 -run 'TestWriteHookSkeletons_|TestBuildPlanReport_RequiredExtensionsAndUnsupportedColumns|TestBuildPlanReport_PostGISDisabledMarksSpatialUnsupported'`