### PR TITLE
plan: remove dead buildBeforeFkSkeleton (#130)

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -652,11 +652,6 @@ func writeHookSkeletons(dir string, report *PlanReport, schema string) error {
 		files = append(files, hookFile{"after_data.sql", body})
 	}
 
-	// before_fk: rarely needed, skip unless there's content
-	if body := buildBeforeFkSkeleton(); body != "" {
-		files = append(files, hookFile{"before_fk.sql", body})
-	}
-
 	// after_all: views, routines, triggers, skipped indexes
 	if body := buildAfterAllSkeleton(report); body != "" {
 		files = append(files, hookFile{"after_all.sql", body})
@@ -699,12 +694,6 @@ func buildBeforeDataSkeleton(report *PlanReport) string {
 	}
 
 	return b.String()
-}
-
-// before_fk is reserved for future plan-generated remediation that must run
-// after data load but before foreign keys are added.
-func buildBeforeFkSkeleton() string {
-	return ""
 }
 
 func buildAfterDataSkeleton(report *PlanReport) string {

--- a/plan_test.go
+++ b/plan_test.go
@@ -750,12 +750,6 @@ func TestWriteHookSkeletons_SanitizesCommentText(t *testing.T) {
 	}
 }
 
-func TestBuildBeforeFkSkeleton_Empty(t *testing.T) {
-	if got := buildBeforeFkSkeleton(); got != "" {
-		t.Fatalf("buildBeforeFkSkeleton() = %q, want empty string", got)
-	}
-}
-
 func TestWriteHookSkeletons_CreatesDir(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "nested", "hooks")
 	report := &PlanReport{


### PR DESCRIPTION
## Summary
Implements [issue #130](https://github.com/Limetric/pgferry/issues/130) (Option B after #125 landed): remove `buildBeforeFkSkeleton` and its call site in `writeHookSkeletons`, plus the trivial test. `buildBeforeDataSkeleton` remains for extension skeletons.

## Verification
- `go fmt ./...`
- `go test ./... -count=1`
- `go vet ./...`


Made with [Cursor](https://cursor.com)