### PR TITLE
plan: add --input for offline JSON report re-analysis (#129)

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -14,20 +15,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// errInvalidPlanFormat is returned when plan output format is not text or json.
+var errInvalidPlanFormat = errors.New("--format must be text or json")
+
 var planOutputDir string
 var planFormat string
 var planFailOn string
 var planInputPath string
 
 var planCmd = &cobra.Command{
-	Use:   "plan [migration.toml]",
+	Use:   "plan [migration.toml] | plan --input <report.json>",
 	Short: "Analyze source schema and generate a migration plan report",
 	Long: `Analyze the source database schema and produce a report of objects that
 require manual follow-up: views, routines, triggers, generated columns,
 and skipped indexes.
 
 Use --input with a JSON report from a previous --format json run to re-render
-or apply --fail-on checks without connecting to the source.
+or apply --fail-on checks without connecting to the source. --input cannot be
+combined with a migration config (--config or a positional TOML path); use one
+or the other.
 
 Optionally generates hook skeleton files in the specified output directory.`,
 	Args: cobra.MaximumNArgs(1),
@@ -197,7 +203,7 @@ func runPlan(cmd *cobra.Command, args []string) error {
 	switch planFormat {
 	case "text", "json":
 	default:
-		return fmt.Errorf("--format must be text or json")
+		return errInvalidPlanFormat
 	}
 
 	failOn, err := parsePlanFailOn(planFailOn)
@@ -248,7 +254,7 @@ func runPlanWithConfig(cfg *MigrationConfig, out io.Writer, opts PlanOptions) er
 	switch format {
 	case "text", "json":
 	default:
-		return fmt.Errorf("plan format must be text or json")
+		return errInvalidPlanFormat
 	}
 	failOn, err := parsePlanFailOn(opts.FailOn)
 	if err != nil {
@@ -339,7 +345,7 @@ func writePlanReportOutput(report *PlanReport, out io.Writer, format string) err
 		writePlanText(out, report)
 		return nil
 	default:
-		return fmt.Errorf("plan format must be text or json")
+		return errInvalidPlanFormat
 	}
 }
 
@@ -362,6 +368,8 @@ func applyPlanFailOn(report *PlanReport, out io.Writer, format string, failOn st
 }
 
 // renderPlanReport writes the plan report in the requested format and applies --fail-on.
+// It validates format and fail-on again so callers other than runPlan (e.g. tests) get
+// the same checks as the CLI path; runPlan already validates before runPlanFromInput.
 func renderPlanReport(report *PlanReport, out io.Writer, opts PlanOptions) error {
 	format := opts.Format
 	if format == "" {
@@ -374,7 +382,7 @@ func renderPlanReport(report *PlanReport, out io.Writer, opts PlanOptions) error
 	switch format {
 	case "text", "json":
 	default:
-		return fmt.Errorf("--format must be text or json")
+		return errInvalidPlanFormat
 	}
 	if err := writePlanReportOutput(report, out, format); err != nil {
 		return err
@@ -388,6 +396,8 @@ func runPlanFromInput(path string, out io.Writer, opts PlanOptions) error {
 		return fmt.Errorf("read plan input: %w", err)
 	}
 	var report PlanReport
+	// Unknown JSON fields are ignored so newer pgferry versions can extend PlanReport
+	// without breaking older binaries re-reading saved reports.
 	if err := json.Unmarshal(data, &report); err != nil {
 		return fmt.Errorf("decode plan input: %w", err)
 	}

--- a/plan_test.go
+++ b/plan_test.go
@@ -15,6 +15,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// snapshotPlanGlobals saves plan CLI package vars and restores them after the test.
+func snapshotPlanGlobals(t *testing.T) {
+	t.Helper()
+	prevInput := planInputPath
+	prevFormat := planFormat
+	prevFail := planFailOn
+	prevConfig := planConfigPath
+	prevOut := planOutputDir
+	t.Cleanup(func() {
+		planInputPath = prevInput
+		planFormat = prevFormat
+		planFailOn = prevFail
+		planConfigPath = prevConfig
+		planOutputDir = prevOut
+	})
+}
+
 func TestBuildPlanReport_Empty(t *testing.T) {
 	schema := &Schema{}
 	cfg := &MigrationConfig{TypeMapping: defaultTypeMappingConfig()}
@@ -1045,18 +1062,7 @@ func TestRunPlan_InvalidFailOn(t *testing.T) {
 }
 
 func TestRunPlanFromInput_Text(t *testing.T) {
-	prevInput := planInputPath
-	prevFormat := planFormat
-	prevFail := planFailOn
-	prevConfig := planConfigPath
-	prevOut := planOutputDir
-	t.Cleanup(func() {
-		planInputPath = prevInput
-		planFormat = prevFormat
-		planFailOn = prevFail
-		planConfigPath = prevConfig
-		planOutputDir = prevOut
-	})
+	snapshotPlanGlobals(t)
 
 	dbPath := filepath.Join(t.TempDir(), "plan-from-input.sqlite")
 	db, err := sql.Open("sqlite", dbPath)
@@ -1109,18 +1115,7 @@ func TestRunPlanFromInput_Text(t *testing.T) {
 }
 
 func TestRunPlanFromInput_FailOn(t *testing.T) {
-	prevInput := planInputPath
-	prevFormat := planFormat
-	prevFail := planFailOn
-	prevConfig := planConfigPath
-	prevOut := planOutputDir
-	t.Cleanup(func() {
-		planInputPath = prevInput
-		planFormat = prevFormat
-		planFailOn = prevFail
-		planConfigPath = prevConfig
-		planOutputDir = prevOut
-	})
+	snapshotPlanGlobals(t)
 
 	jsonPath := filepath.Join(t.TempDir(), "report.json")
 	report := PlanReport{
@@ -1159,18 +1154,7 @@ func TestRunPlanFromInput_FailOn(t *testing.T) {
 }
 
 func TestRunPlanFromInput_RejectsOutputDir(t *testing.T) {
-	prevInput := planInputPath
-	prevFormat := planFormat
-	prevFail := planFailOn
-	prevConfig := planConfigPath
-	prevOut := planOutputDir
-	t.Cleanup(func() {
-		planInputPath = prevInput
-		planFormat = prevFormat
-		planFailOn = prevFail
-		planConfigPath = prevConfig
-		planOutputDir = prevOut
-	})
+	snapshotPlanGlobals(t)
 
 	planInputPath = filepath.Join(t.TempDir(), "report.json")
 	planFormat = "text"
@@ -1188,18 +1172,7 @@ func TestRunPlanFromInput_RejectsOutputDir(t *testing.T) {
 }
 
 func TestRunPlanFromInput_InvalidJSON(t *testing.T) {
-	prevInput := planInputPath
-	prevFormat := planFormat
-	prevFail := planFailOn
-	prevConfig := planConfigPath
-	prevOut := planOutputDir
-	t.Cleanup(func() {
-		planInputPath = prevInput
-		planFormat = prevFormat
-		planFailOn = prevFail
-		planConfigPath = prevConfig
-		planOutputDir = prevOut
-	})
+	snapshotPlanGlobals(t)
 
 	jsonPath := filepath.Join(t.TempDir(), "bad.json")
 	if err := os.WriteFile(jsonPath, []byte("{not json"), 0o644); err != nil {
@@ -1217,6 +1190,42 @@ func TestRunPlanFromInput_InvalidJSON(t *testing.T) {
 		t.Fatal("runPlan() error = nil, want decode error")
 	}
 	if !strings.Contains(err.Error(), "decode plan input") {
+		t.Fatalf("runPlan() error = %q", err.Error())
+	}
+}
+
+func TestRunPlanFromInput_RejectsConfig(t *testing.T) {
+	snapshotPlanGlobals(t)
+
+	planInputPath = filepath.Join(t.TempDir(), "report.json")
+	planFormat = "text"
+	planFailOn = "none"
+	planConfigPath = filepath.Join(t.TempDir(), "migration.toml")
+	planOutputDir = ""
+
+	err := runPlan(&cobra.Command{}, nil)
+	if err == nil {
+		t.Fatal("runPlan() error = nil, want --config rejected")
+	}
+	if !strings.Contains(err.Error(), "--config") {
+		t.Fatalf("runPlan() error = %q", err.Error())
+	}
+}
+
+func TestRunPlanFromInput_RejectsPositionalArg(t *testing.T) {
+	snapshotPlanGlobals(t)
+
+	planInputPath = filepath.Join(t.TempDir(), "report.json")
+	planFormat = "text"
+	planFailOn = "none"
+	planConfigPath = ""
+	planOutputDir = ""
+
+	err := runPlan(&cobra.Command{}, []string{"migration.toml"})
+	if err == nil {
+		t.Fatal("runPlan() error = nil, want positional config rejected")
+	}
+	if !strings.Contains(err.Error(), "config file when using --input") {
 		t.Fatalf("runPlan() error = %q", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary

Implements #129: `pgferry plan --input report.json` reads a previously saved JSON plan report (from `--format json`) without connecting to the source. Output respects `--format` and `--fail-on`.

## Behavior

- **`--input`** is mutually exclusive with a config file (positional or `--config`) and with `--output-dir` (hook skeletons still require a live plan with config/schema).
- Shared helpers: `writePlanReportOutput`, `applyPlanFailOn`, `renderPlanReport`; live path still writes hook skeletons between report output and fail-on, preserving prior behavior.

## Tests

- `TestRunPlanFromInput_Text`, `TestRunPlanFromInput_FailOn`, `TestRunPlanFromInput_RejectsOutputDir`, `TestRunPlanFromInput_InvalidJSON`

Made with [Cursor](https://cursor.com)