### PR TITLE
docs(site): align reference with CLI and config

### DIFF
--- a/site/src/content/docs/get-started/advanced-options.md
+++ b/site/src/content/docs/get-started/advanced-options.md
@@ -40,14 +40,22 @@ One thing to keep in mind: pair `resume = true` with `unlogged_tables = false`. 
 
 ## Plan and preflight
 
-Before you migrate anything, `pgferry plan` tells you what will need manual attention: views, routines, generated columns, skipped indexes, collation warnings, and required extensions like `citext` or PostGIS.
+Before you migrate anything, `pgferry plan` tells you what will need manual attention: views, routines, generated columns, skipped indexes, collation warnings, copy-risk hints (when `copy_risk_analysis` is on), and required extensions like `citext` or PostGIS.
 
 ```bash
 pgferry plan migration.toml
 pgferry plan migration.toml --output-dir hooks
+pgferry plan migration.toml --format json > plan.json
+pgferry plan --input plan.json --format text
 ```
 
-With `--output-dir`, pgferry writes skeleton hook files you can fill in before the real run. If you want to start with a smaller slice, scope it to specific tables:
+With `--output-dir`, pgferry writes skeleton hook files you can fill in before the real run.
+
+**Machine-readable and CI:** `--format json` is for diffing, dashboards, or filing tickets. `--fail-on errors` exits non-zero when there are unsupported column types; `--fail-on warnings` also fails on high-severity copy-risk findings. Your CI pipeline will finally care about migrations.
+
+**Replay without the source:** `--input saved.json` renders a previous JSON report (text or JSON) without connecting to the database. You cannot combine `--input` with a TOML path or `--config` — pick one story.
+
+If you want to start with a smaller slice, scope it to specific tables:
 
 ```toml
 include_tables = ["orders", "order_items"]

--- a/site/src/content/docs/get-started/quick-start.md
+++ b/site/src/content/docs/get-started/quick-start.md
@@ -38,6 +38,8 @@ The wizard will prompt you for both of these, so you don't need to get the forma
 pgferry wizard
 ```
 
+Same wizard, different spellings: `pgferry generate` and `pgferry init` do the same thing if your fingers prefer those words.
+
 In an interactive terminal, plain `pgferry` also opens the wizard. It asks the useful questions, writes the config, and gets you out of the “blank TOML file staring contest” phase quickly.
 
 Use the wizard to generate `migration.toml`.
@@ -64,6 +66,8 @@ This step is technically optional — the same way riding your bike without chec
 ```bash
 pgferry migrate migration.toml
 ```
+
+`pgferry run migration.toml` is identical — choose whichever verb feels right that day.
 
 If you ran `plan` first, this step shouldn't have any surprises — you've already seen what's coming.
 

--- a/site/src/content/docs/operations/how-to-read-plan-output.md
+++ b/site/src/content/docs/operations/how-to-read-plan-output.md
@@ -14,6 +14,7 @@ description: Treat pgferry plan output as a worklist, not a warning dump.
 - views, routines, and source triggers
 - required PostgreSQL extensions
 - collation warnings
+- copy risk findings (when `copy_risk_analysis` is enabled — large or awkward tables worth a second look before COPY day)
 
 ## How to respond
 
@@ -25,3 +26,12 @@ description: Treat pgferry plan output as a worklist, not a warning dump.
 | unsupported index warning | decide whether PostgreSQL needs an equivalent or a different design |
 | view/routine/trigger warning | write `after_all` hook SQL or separate DDL |
 | extension requirement | install it up front or let pgferry create it when supported |
+| copy risk finding | sanity-check chunking strategy, `chunk_size`, or table shape before the long run |
+
+## JSON output and replays
+
+`--format json` emits the full report as JSON — great for archives, diffs, or feeding something that isn't a human.
+
+`--input previous.json` reprints or re-checks a saved report without talking to the source. Pair with `--fail-on` in CI so the pipeline fails on unsupported columns or high-severity copy risks even when the database is asleep.
+
+`--fail-on` levels: `none` (always exit 0 if parsing works), `errors` (unsupported types), `warnings` (errors plus high-severity copy risks). Pick your own adventure.

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -15,6 +15,8 @@ If you want the fastest safe starting point, use the wizard first:
 pgferry wizard
 ```
 
+Shorthand: `pgferry run` is the same as `migrate`, and `generate` / `init` are aliases for `wizard` — use whichever muscle memory you have.
+
 ## Minimal config
 
 ```toml
@@ -65,6 +67,8 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `schema` | string | required | Target PostgreSQL schema name. |
+| `include_tables` | array of strings | `[]` | If non-empty, only migrate these source tables. Exact names only — no globs. |
+| `exclude_tables` | array of strings | `[]` | Source tables to skip. Applied together with `include_tables` when both are set. |
 | `on_schema_exists` | string | `"error"` | `"error"` aborts if the schema exists. `"recreate"` drops and recreates it. |
 | `schema_only` | bool | `false` | Create schema objects only. Skip data COPY. |
 | `data_only` | bool | `false` | Load data into an existing schema, then reset sequences. Requires the target role to disable and re-enable triggers on the selected target tables during the load. |
@@ -74,10 +78,13 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | `preserve_defaults` | bool | `true` | Keep source column defaults in the created PostgreSQL schema. |
 | `add_unsigned_checks` | bool | `false` | Add `CHECK` constraints for MySQL-family unsigned ranges. |
 | `clean_orphans` | bool | `true` | Automatically delete or null invalid child rows before FK creation. |
+| `clean_orphans_mode` | string | `"apply"` | `"apply"` fixes rows before FKs. `"report"` logs what would happen and stops before FK creation (dry-run style). |
+| `clean_orphans_max_rows` | int | `0` | Safety cap: abort if orphan rows to fix would exceed this total. `0` means no cap. |
 | `replicate_on_update_current_timestamp` | bool | `false` | Create PostgreSQL trigger emulation for MySQL-family `ON UPDATE CURRENT_TIMESTAMP`. |
 | `workers` | int | `min(runtime.NumCPU(), 8)` | Parallel worker count for data loading. SQLite is internally capped at 1. |
 | `index_workers` | int | `workers` | Concurrent index builds during post-migration. |
 | `chunk_size` | int | `100000` | Key-range width for chunkable single-column numeric PK tables. Actual rows per chunk vary with key density. |
+| `copy_risk_analysis` | bool | `true` | Lightweight COUNT/MIN/MAX probes to flag awkward COPY chunking (huge tables, sparse keys, etc.). Feeds `plan` copy-risk output and optional migrate warnings. Turn off for quieter runs when you already know the shape. |
 | `resume` | bool | `false` | Reuse `pgferry_checkpoint.json` after interruptions. |
 | `validation` | string | `"none"` | `"row_count"` compares per-table counts after load. `"sampled_hash"` adds bounded content fingerprints for deterministic primary-key-addressable rows. |
 

--- a/site/src/content/docs/reference/conventions-and-limitations.md
+++ b/site/src/content/docs/reference/conventions-and-limitations.md
@@ -36,7 +36,11 @@ Cleanup behavior:
 - `ON DELETE SET NULL` foreign keys are repaired by setting the child columns to `NULL`.
 - Other delete rules cause the orphaned child rows to be deleted.
 
-Disable this when you want FK creation to fail naturally so you can inspect the data problem yourself or fix it with `before_fk` hooks.
+`clean_orphans_mode = "apply"` (the default) actually does the work. `"report"` only inspects and logs — handy when you want a preview without touching rows, but the migration stops before FK creation so you can react first.
+
+Set `clean_orphans_max_rows` to a positive number when you want a fuse: if the total orphan rows across all FKs would exceed that cap, pgferry aborts instead of deleting half the internet. `0` means no fuse.
+
+Disable orphan cleanup entirely when you want FK creation to fail naturally so you can inspect the data problem yourself or fix it with `before_fk` hooks.
 
 ## Generated columns
 


### PR DESCRIPTION
## Summary

Updates the docs site so the published reference matches what the binary actually supports.

## Changes

- **Configuration reference:** `include_tables` / `exclude_tables`, `copy_risk_analysis`, `clean_orphans_mode`, `clean_orphans_max_rows`; short note on CLI aliases (`run`, `generate`, `init`).
- **Conventions:** clearer orphan cleanup modes and the max-rows safety cap.
- **Advanced options / plan output:** `--format json`, `--input`, `--fail-on`, and copy-risk context.
- **Quick start:** brief mention of wizard and migrate aliases.

## Verification

- `bunx astro build` and `node ./scripts/verify-build.mjs` in `site/` succeeded locally.

Made with [Cursor](https://cursor.com)