### PR TITLE
feat(migrate): structured JSON summary for migrate runs (#149)

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,10 +18,11 @@ import (
 
 var configPath string
 
-// migrateLogFormatFlagDesc documents --log-format for migrate and root-with-config.
-const migrateLogFormatFlagDesc = `With json, one JSON object is written to stdout when the run finishes; human messages remain on stderr. JSON fields: version, duration_ms, mode, validation, success, error, stage (on failure), tables_migrated.`
+// migrateLogFormatFlagShort is the short --help line; full JSON field list is in migrateCmd.Long.
+const migrateLogFormatFlagShort = "migrate progress: text or json"
 
-var migrateLogFormat string
+// migrateLogFormatFlagDesc documents JSON mode for migrateCmd.Long and site docs.
+const migrateLogFormatFlagDesc = `With json, one JSON object is written to stdout when the run finishes; human messages remain on stderr. JSON fields: version, duration_ms, mode, validation, success, error, stage (on failure), tables_migrated (omitted when zero).`
 
 var rootCmd = &cobra.Command{
 	Use:   "pgferry [migration.toml]",
@@ -64,9 +65,8 @@ func init() {
 	rootCmd.Version = versionString()
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 	rootCmd.Flags().StringVar(&configPath, "config", "", "path to migration TOML config file")
-	rootCmd.Flags().StringVar(&migrateLogFormat, "log-format", "text", "migrate progress logs: text or json. "+migrateLogFormatFlagDesc)
+	rootCmd.PersistentFlags().String("log-format", "text", migrateLogFormatFlagShort)
 	migrateCmd.Flags().StringVar(&configPath, "config", "", "path to migration TOML config file")
-	migrateCmd.Flags().StringVar(&migrateLogFormat, "log-format", "text", "migrate progress logs: text or json. "+migrateLogFormatFlagDesc)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(migrateCmd)
 	rootCmd.AddCommand(generateCmd)
@@ -107,11 +107,11 @@ func runMigration(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	logFormat, err := parseMigrateLogFormat(migrateLogFormat)
+	opts, err := migrateOptionsFromCmd(cmd)
 	if err != nil {
 		return err
 	}
-	return runMigrationWithConfig(cfg, MigrateOptions{LogFormat: logFormat})
+	return runMigrationWithConfig(cfg, opts)
 }
 
 func resolveMigrationConfigPath(args []string) string {
@@ -223,6 +223,7 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 	if err != nil {
 		return fmt.Errorf("introspect schema: %w", err)
 	}
+	stage = "filter"
 	filteredSchema, filterReport, err := filterSchemaTables(schema, cfg)
 	if err != nil {
 		return fmt.Errorf("filter schema tables: %w", err)

--- a/migrate_summary.go
+++ b/migrate_summary.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 // MigrateOptions configures migrate execution (CLI passes flags; wizard uses zero value).
@@ -25,6 +27,24 @@ type migrateJSONSummary struct {
 	Error          string `json:"error,omitempty"`
 	Stage          string `json:"stage,omitempty"`
 	TablesMigrated int    `json:"tables_migrated,omitempty"`
+}
+
+// migrateOptionsFromCmd reads --log-format (default text). cmd may be nil (tests).
+// If the flag is not registered on cmd (e.g. bare cobra.Command in tests), text is used.
+func migrateOptionsFromCmd(cmd *cobra.Command) (MigrateOptions, error) {
+	s := "text"
+	if cmd != nil && cmd.Flags().Lookup("log-format") != nil {
+		v, err := cmd.Flags().GetString("log-format")
+		if err != nil {
+			return MigrateOptions{}, err
+		}
+		s = v
+	}
+	lf, err := parseMigrateLogFormat(s)
+	if err != nil {
+		return MigrateOptions{}, err
+	}
+	return MigrateOptions{LogFormat: lf}, nil
 }
 
 func parseMigrateLogFormat(s string) (string, error) {
@@ -74,7 +94,10 @@ func writeMigrateJSONSummaryLine(w io.Writer, opts MigrateOptions, cfg *Migratio
 	if err != nil {
 		return fmt.Errorf("migrate json summary: %w", err)
 	}
-	if _, err := fmt.Fprintln(w, string(b)); err != nil {
+	if _, err := w.Write(b); err != nil {
+		return fmt.Errorf("write migrate json summary: %w", err)
+	}
+	if _, err := w.Write([]byte("\n")); err != nil {
 		return fmt.Errorf("write migrate json summary: %w", err)
 	}
 	return nil

--- a/migrate_summary_test.go
+++ b/migrate_summary_test.go
@@ -7,7 +7,26 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
 )
+
+func TestMigrateOptionsFromCmd(t *testing.T) {
+	opts, err := migrateOptionsFromCmd(nil)
+	if err != nil {
+		t.Fatalf("nil cmd: %v", err)
+	}
+	if opts.LogFormat != "text" {
+		t.Fatalf("nil cmd: LogFormat = %q, want text", opts.LogFormat)
+	}
+	opts, err = migrateOptionsFromCmd(&cobra.Command{})
+	if err != nil {
+		t.Fatalf("bare cmd: %v", err)
+	}
+	if opts.LogFormat != "text" {
+		t.Fatalf("bare cmd: LogFormat = %q, want text", opts.LogFormat)
+	}
+}
 
 func TestParseMigrateLogFormat(t *testing.T) {
 	tests := []struct {

--- a/wizard.go
+++ b/wizard.go
@@ -20,8 +20,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var generatedConfigRunner = func(cfg *MigrationConfig) error {
-	return runMigrationWithConfig(cfg, MigrateOptions{})
+// generatedConfigRunner runs the wizard’s post-generation migration; callers pass
+// MigrateOptions from migrateOptionsFromCmd(cmd) so --log-format matches migrate.
+var generatedConfigRunner = func(cfg *MigrationConfig, opts MigrateOptions) error {
+	return runMigrationWithConfig(cfg, opts)
 }
 
 type plannerFunc func(*MigrationConfig, io.Writer, PlanOptions) error
@@ -137,7 +139,11 @@ func runGenerateWizard(cmd *cobra.Command, _ []string) error {
 
 	if nextStep == "run" {
 		fmt.Fprintln(w.out, w.styles.accent("Starting migration..."))
-		if err := generatedConfigRunner(cfg); err != nil {
+		opts, err := migrateOptionsFromCmd(cmd)
+		if err != nil {
+			return err
+		}
+		if err := generatedConfigRunner(cfg, opts); err != nil {
 			return err
 		}
 	}

--- a/wizard_test.go
+++ b/wizard_test.go
@@ -91,7 +91,7 @@ func TestRunGenerateWizardRunsGeneratedConfig(t *testing.T) {
 
 	var gotCfg *MigrationConfig
 	prevRunner := generatedConfigRunner
-	generatedConfigRunner = func(cfg *MigrationConfig) error {
+	generatedConfigRunner = func(cfg *MigrationConfig, _ MigrateOptions) error {
 		gotCfg = cfg
 		return nil
 	}
@@ -243,7 +243,7 @@ func TestRunGenerateWizardTestsConnectionsByDefault(t *testing.T) {
 	})
 
 	prevRunner := generatedConfigRunner
-	generatedConfigRunner = func(cfg *MigrationConfig) error { return nil }
+	generatedConfigRunner = func(cfg *MigrationConfig, _ MigrateOptions) error { return nil }
 	t.Cleanup(func() {
 		generatedConfigRunner = prevRunner
 	})


### PR DESCRIPTION
## Summary

Implements [issue #149](https://github.com/Limetric/pgferry/issues/149): optional machine-readable output for `migrate` (and `pgferry <migration.toml>`).

## Behavior

- **`--log-format text`** (default): unchanged — standard library `log` output on stderr.
- **`--log-format json`**: after the run finishes, one JSON object is written to **stdout** (newline-terminated). Human diagnostics remain on **stderr**.

## JSON fields

| Field | Description |
|-------|-------------|
| `version` | pgferry version string |
| `duration_ms` | wall-clock duration |
| `mode` | `full`, `schema_only`, or `data_only` |
| `validation` | configured validation mode |
| `success` | whether migration completed without error |
| `error` | present on failure |
| `stage` | present on failure (e.g. `source`, `introspect`, `target`, `schema`, `data`, `validation`, `post_migrate`) |
| `tables_migrated` | table count after filtering (omitted when 0) |

Non-zero exit code is preserved on failure; JSON includes `success: false` and `error`.

## Tests

- Unit tests for flag parsing, JSON line writer, and mode strings.
- `go test ./... -count=1`

Closes #149

Made with [Cursor](https://cursor.com)