### PR TITLE
feat(cli): config path introspection command (#151)

### DIFF
--- a/config_paths.go
+++ b/config_paths.go
@@ -24,7 +24,9 @@ var configPathsCmd = &cobra.Command{
 	Short: "Print resolved paths for the config file, checkpoint, and hook SQL files",
 	Long: `Load a migration TOML (same validation as migrate) and print absolute paths for
 the config file, the config directory, the resume checkpoint file, and each hook
-SQL path. Does not connect to any database.`,
+SQL path. Does not connect to any database.
+
+Pass the config as a positional argument or via --config, not both.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runConfigPaths,
 }
@@ -37,11 +39,19 @@ func init() {
 }
 
 func runConfigPaths(cmd *cobra.Command, args []string) error {
-	cfgPath := configPathsConfigPath
+	flagPath := strings.TrimSpace(configPathsConfigPath)
+	var posPath string
 	if len(args) > 0 {
-		cfgPath = args[0]
+		posPath = strings.TrimSpace(args[0])
 	}
-	if strings.TrimSpace(cfgPath) == "" {
+	if flagPath != "" && posPath != "" {
+		return fmt.Errorf("provide either a positional migration.toml path or --config, not both")
+	}
+	cfgPath := flagPath
+	if cfgPath == "" {
+		cfgPath = posPath
+	}
+	if cfgPath == "" {
 		return fmt.Errorf("migration config path required: pgferry config paths <migration.toml> or pgferry config paths --config <path>")
 	}
 
@@ -97,10 +107,7 @@ func writeConfigPathsJSON(out io.Writer, absCfg string, cfg *MigrationConfig, ch
 
 	enc := json.NewEncoder(out)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(doc); err != nil {
-		return err
-	}
-	return nil
+	return enc.Encode(doc)
 }
 
 func hookPathEntries(cfg *MigrationConfig, rels []string) []hookPathEntry {
@@ -120,22 +127,10 @@ func hookPathEntries(cfg *MigrationConfig, rels []string) []hookPathEntry {
 }
 
 func writeConfigPathsText(out io.Writer, absCfg string, cfg *MigrationConfig, checkpoint string) error {
-	w := func(format string, a ...any) error {
-		_, err := fmt.Fprintf(out, format, a...)
-		return err
-	}
-	if err := w("config_file: %s\n", absCfg); err != nil {
-		return err
-	}
-	if err := w("config_dir: %s\n", cfg.configDir); err != nil {
-		return err
-	}
-	if err := w("checkpoint: %s  exists: %s\n", checkpoint, yesNo(pathExists(checkpoint))); err != nil {
-		return err
-	}
-	if err := w("\n"); err != nil {
-		return err
-	}
+	fmt.Fprintf(out, "config_file: %s\n", absCfg)
+	fmt.Fprintf(out, "config_dir: %s\n", cfg.configDir)
+	fmt.Fprintf(out, "checkpoint: %s  exists: %s\n", checkpoint, yesNo(pathExists(checkpoint)))
+	fmt.Fprintln(out)
 
 	phases := []struct {
 		name  string
@@ -147,20 +142,14 @@ func writeConfigPathsText(out io.Writer, absCfg string, cfg *MigrationConfig, ch
 		{"hooks.after_all", cfg.Hooks.AfterAll},
 	}
 	for _, ph := range phases {
-		if err := w("%s:\n", ph.name); err != nil {
-			return err
-		}
+		fmt.Fprintf(out, "%s:\n", ph.name)
 		if len(ph.files) == 0 {
-			if err := w("  (none)\n"); err != nil {
-				return err
-			}
+			fmt.Fprint(out, "  (none)\n")
 			continue
 		}
 		for _, f := range ph.files {
 			resolved := cfg.resolvePath(f)
-			if err := w("  %s  %s  exists: %s\n", f, resolved, yesNo(pathExists(resolved))); err != nil {
-				return err
-			}
+			fmt.Fprintf(out, "  %s  %s  exists: %s\n", f, resolved, yesNo(pathExists(resolved)))
 		}
 	}
 	return nil

--- a/config_paths_test.go
+++ b/config_paths_test.go
@@ -60,12 +60,6 @@ after_all = []
 		rootCmd.SetArgs(nil)
 		configPathsJSON = prevJSON
 		configPathsConfigPath = prevCfg
-		if err := configPathsCmd.Flags().Set("json", "false"); err != nil {
-			t.Fatal(err)
-		}
-		if err := configPathsCmd.Flags().Set("config", ""); err != nil {
-			t.Fatal(err)
-		}
 	})
 
 	rootCmd.SetOut(&buf)
@@ -130,7 +124,10 @@ before_data = ["a.sql"]
 	var buf bytes.Buffer
 	prevJSON := configPathsJSON
 	prevCfg := configPathsConfigPath
-	if err := configPathsCmd.Flags().Set("json", "true"); err != nil {
+	if err := configPathsCmd.Flags().Set("json", "false"); err != nil {
+		t.Fatal(err)
+	}
+	if err := configPathsCmd.Flags().Set("config", ""); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
@@ -139,9 +136,6 @@ before_data = ["a.sql"]
 		rootCmd.SetArgs(nil)
 		configPathsJSON = prevJSON
 		configPathsConfigPath = prevCfg
-		if err := configPathsCmd.Flags().Set("json", "false"); err != nil {
-			t.Fatal(err)
-		}
 	})
 
 	rootCmd.SetOut(&buf)
@@ -156,14 +150,23 @@ before_data = ["a.sql"]
 	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
 		t.Fatalf("json decode: %v\n%s", err, buf.String())
 	}
-	if doc.ConfigFile != cfgFile {
-		t.Fatalf("config_file = %q, want %q", doc.ConfigFile, cfgFile)
+	wantCfgAbs, err := filepath.Abs(cfgFile)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if doc.ConfigDir != dir {
-		t.Fatalf("config_dir = %q, want %q", doc.ConfigDir, dir)
+	if doc.ConfigFile != wantCfgAbs {
+		t.Fatalf("config_file = %q, want %q", doc.ConfigFile, wantCfgAbs)
 	}
-	if doc.Checkpoint.Path != filepath.Join(dir, "pgferry_checkpoint.json") {
-		t.Fatalf("checkpoint path = %q", doc.Checkpoint.Path)
+	wantDirAbs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.ConfigDir != wantDirAbs {
+		t.Fatalf("config_dir = %q, want %q", doc.ConfigDir, wantDirAbs)
+	}
+	wantCheckpoint := filepath.Join(wantDirAbs, "pgferry_checkpoint.json")
+	if doc.Checkpoint.Path != wantCheckpoint {
+		t.Fatalf("checkpoint path = %q, want %q", doc.Checkpoint.Path, wantCheckpoint)
 	}
 	if len(doc.Hooks.BeforeData) != 1 || doc.Hooks.BeforeData[0].ConfigPath != "a.sql" || !doc.Hooks.BeforeData[0].Exists {
 		t.Fatalf("hooks.before_data = %+v", doc.Hooks.BeforeData)
@@ -189,13 +192,20 @@ dsn = "postgres://u:p@h:5432/db"
 	}
 
 	var buf bytes.Buffer
+	prevJSON := configPathsJSON
+	prevCfg := configPathsConfigPath
 	if err := configPathsCmd.Flags().Set("json", "false"); err != nil {
+		t.Fatal(err)
+	}
+	if err := configPathsCmd.Flags().Set("config", ""); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
 		rootCmd.SetOut(nil)
 		rootCmd.SetErr(nil)
 		rootCmd.SetArgs(nil)
+		configPathsJSON = prevJSON
+		configPathsConfigPath = prevCfg
 	})
 
 	rootCmd.SetOut(&buf)
@@ -208,5 +218,53 @@ dsn = "postgres://u:p@h:5432/db"
 	}
 	if !strings.Contains(err.Error(), "unknown config keys") {
 		t.Fatalf("error = %v, want unknown config keys", err)
+	}
+}
+
+func TestConfigPaths_ConfigAndPositionalExclusive(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "m.toml")
+	content := `
+schema = "s"
+
+[source]
+type = "mysql"
+dsn = "root:root@tcp(127.0.0.1:3306)/db"
+
+[target]
+dsn = "postgres://u:p@h:5432/db"
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	other := filepath.Join(dir, "other.toml")
+
+	var buf bytes.Buffer
+	prevJSON := configPathsJSON
+	prevCfg := configPathsConfigPath
+	if err := configPathsCmd.Flags().Set("json", "false"); err != nil {
+		t.Fatal(err)
+	}
+	if err := configPathsCmd.Flags().Set("config", ""); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+		configPathsJSON = prevJSON
+		configPathsConfigPath = prevCfg
+	})
+
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"config", "paths", "--config", cfgFile, other})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when both --config and positional path are set")
+	}
+	if !strings.Contains(err.Error(), "not both") {
+		t.Fatalf("error = %v, want mutual exclusivity message", err)
 	}
 }


### PR DESCRIPTION
## Summary

Implements [#151](https://github.com/Limetric/pgferry/issues/151): a read-only `pgferry config paths` command that loads a migration TOML (same `loadConfig` / unknown-keys behavior as `migrate`) and prints resolved paths without connecting to databases or printing DSNs.

## Output

- **Text (default):** `config_file`, `config_dir`, `checkpoint` with `exists: yes|no`, then each hook phase (`before_data`, `after_data`, `before_fk`, `after_all`) listing config-relative paths, resolved absolute paths, and existence.
- **`--json`:** Structured JSON for the same fields.

## Tests

- Unit tests with a temp dir, TOML, hook files, and a deliberately missing hook path.
- Asserts DSN secrets do not appear in stdout.
- Asserts unknown TOML keys are rejected like `migrate`.

Closes #151

Made with [Cursor](https://cursor.com)