### PR TITLE
feat(plan): add markdown report output

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -1334,6 +1334,7 @@ func writeMarkdownTable(w io.Writer, headers []string, rows [][]string) {
 	}
 	fmt.Fprintln(w)
 	for _, row := range rows {
+		row = normalizeMarkdownTableRow(row, len(headers))
 		fmt.Fprint(w, "|")
 		for _, cell := range row {
 			fmt.Fprintf(w, " %s |", markdownEscape(cell))
@@ -1343,14 +1344,26 @@ func writeMarkdownTable(w io.Writer, headers []string, rows [][]string) {
 	fmt.Fprintln(w)
 }
 
+func normalizeMarkdownTableRow(row []string, width int) []string {
+	if len(row) > width {
+		return row[:width]
+	}
+	if len(row) == width {
+		return row
+	}
+	out := make([]string, width)
+	copy(out, row)
+	return out
+}
+
 func markdownEscape(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\r", " ")
 	s = strings.TrimSpace(s)
 	replacer := strings.NewReplacer(
-		`\\`, `\\\\`,
 		`|`, `\|`,
+		"`", "\\`",
 		"*", `\*`,
 		"[", `\[`,
 		"]", `\]`,
@@ -1372,10 +1385,11 @@ func formatMarkdownChunking(risk PlanCopyRiskFinding) string {
 	if !risk.Chunkable {
 		return "full copy"
 	}
-	parts := []string{risk.ChunkKey}
+	first := risk.ChunkKey
 	if risk.ChunkKeyType != "" {
-		parts[0] += " (" + risk.ChunkKeyType + ")"
+		first += " (" + risk.ChunkKeyType + ")"
 	}
+	parts := []string{first}
 	if risk.MinPK != nil && risk.MaxPK != nil {
 		parts = append(parts, fmt.Sprintf("range=%d..%d", *risk.MinPK, *risk.MaxPK))
 	}

--- a/plan_test.go
+++ b/plan_test.go
@@ -1046,6 +1046,56 @@ func TestRenderPlanReport_MarkdownShortAlias(t *testing.T) {
 	}
 }
 
+func TestWritePlanMarkdown_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	writePlanMarkdown(&buf, &PlanReport{})
+	got := buf.String()
+	if !strings.Contains(got, "# Migration Plan Report") {
+		t.Fatalf("missing markdown document heading:\n%s", got)
+	}
+	if !strings.Contains(got, "No manual follow-up items detected.") {
+		t.Fatalf("missing empty markdown message:\n%s", got)
+	}
+}
+
+func TestMarkdownEscape_BackticksAndBackslashes(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "concat(`first`,`last`)", want: "concat(\\`first\\`,\\`last\\`)"},
+		{in: `\|`, want: `\\|`},
+		{in: `path\name`, want: `path\name`},
+	}
+
+	for _, tt := range tests {
+		if got := markdownEscape(tt.in); got != tt.want {
+			t.Fatalf("markdownEscape(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestWriteMarkdownTable_PadsAndTruncatesRows(t *testing.T) {
+	var buf bytes.Buffer
+	writeMarkdownTable(&buf, []string{"A", "B"}, [][]string{
+		{"left"},
+		{"x", "y", "z"},
+	})
+	got := buf.String()
+	for _, want := range []string{
+		"| A | B |",
+		"| left |  |",
+		"| x | y |",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("table output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "| x | y | z |") {
+		t.Fatalf("table output should truncate extra cells:\n%s", got)
+	}
+}
+
 func TestWritePlanText_TableChunkPlan(t *testing.T) {
 	report := &PlanReport{
 		TableChunkPlan: []PlanTableChunkInfo{


### PR DESCRIPTION
## Summary
- add `plan --format markdown` support, including the `md` alias
- render plan reports as Markdown with section parity across summary, findings, and follow-up tables/lists
- keep `--fail-on` and `--input` replay behavior aligned with existing text/json paths

Closes #150.

## Testing
- `go test ./... -count=1`
- `go build -o build/pgferry .`