### PR TITLE
feat(validate): add standalone validation command

### DIFF
--- a/cli_helpers.go
+++ b/cli_helpers.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/errgroup"
+)
+
+type pingContextDB interface {
+	PingContext(context.Context) error
+}
+
+func resolveOptionalConfigPath(flagPath string, args []string) (string, error) {
+	posPath := ""
+	if len(args) > 0 {
+		posPath = strings.TrimSpace(args[0])
+	}
+	flagPath = strings.TrimSpace(flagPath)
+	if flagPath != "" && posPath != "" {
+		return "", fmt.Errorf("provide either a positional migration.toml path or --config, not both")
+	}
+	if posPath != "" {
+		return posPath, nil
+	}
+	return flagPath, nil
+}
+
+func pingSourceAndTarget(ctx context.Context, src SourceDB, sourceDB pingContextDB, pgPool *pgxpool.Pool) error {
+	srcLabel := strings.ToLower(src.Name())
+	log.Printf("pinging %s and PostgreSQL...", srcLabel)
+
+	pingCtx, pingCancel := context.WithTimeout(ctx, connectivityPingTimeout)
+	defer pingCancel()
+
+	var srcPingErr error
+	var pgPingErr error
+	var g errgroup.Group
+	g.Go(func() error {
+		if err := sourceDB.PingContext(pingCtx); err != nil {
+			srcPingErr = fmt.Errorf("ping %s: %w", srcLabel, err)
+		}
+		return nil
+	})
+	g.Go(func() error {
+		if err := pgPool.Ping(pingCtx); err != nil {
+			pgPingErr = fmt.Errorf("ping postgres: %w", err)
+		}
+		return nil
+	})
+	g.Wait()
+
+	if err := errors.Join(srcPingErr, pgPingErr); err != nil {
+		return err
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 )
 
 // connectivityPingTimeout bounds the parallel source/target connectivity check.
@@ -109,7 +108,10 @@ func runRoot(cmd *cobra.Command, args []string) error {
 }
 
 func runMigration(cmd *cobra.Command, args []string) error {
-	cfgPath := resolveMigrationConfigPath(args)
+	cfgPath, err := resolveOptionalConfigPath(configPath, args)
+	if err != nil {
+		return err
+	}
 	if cfgPath == "" {
 		return missingMigrationConfigError()
 	}
@@ -127,10 +129,11 @@ func runMigration(cmd *cobra.Command, args []string) error {
 }
 
 func resolveMigrationConfigPath(args []string) string {
-	if len(args) > 0 {
-		return args[0]
+	cfgPath, err := resolveOptionalConfigPath(configPath, args)
+	if err != nil {
+		return ""
 	}
-	return configPath
+	return cfgPath
 }
 
 func missingMigrationConfigError() error {
@@ -236,27 +239,7 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 	}
 	defer pgPool.Close()
 
-	srcLabel := strings.ToLower(src.Name())
-	log.Printf("pinging %s and PostgreSQL...", srcLabel)
-	pingCtx, pingCancel := context.WithTimeout(ctx, connectivityPingTimeout)
-	defer pingCancel()
-	var srcPingErr, pgPingErr error
-	var g errgroup.Group
-	g.Go(func() error {
-		if err := sourceDB.PingContext(pingCtx); err != nil {
-			srcPingErr = fmt.Errorf("ping %s: %w", srcLabel, err)
-		}
-		return nil
-	})
-	g.Go(func() error {
-		// pgxpool.Ping honors the context deadline (network I/O is cancellable).
-		if err := pgPool.Ping(pingCtx); err != nil {
-			pgPingErr = fmt.Errorf("ping postgres: %w", err)
-		}
-		return nil
-	})
-	g.Wait()
-	if err := errors.Join(srcPingErr, pgPingErr); err != nil {
+	if err := pingSourceAndTarget(ctx, src, sourceDB, pgPool); err != nil {
 		return err
 	}
 

--- a/site/src/content/docs/get-started/advanced-options.md
+++ b/site/src/content/docs/get-started/advanced-options.md
@@ -91,7 +91,15 @@ Trust, but verify. pgferry can compare source and target after the load to make 
 - `validation = "row_count"` — fast per-table count comparison. Good enough for most runs.
 - `validation = "sampled_hash"` — checks counts plus a bounded deterministic content sample on primary-key-addressable rows. Stronger, but still not a full proof of correctness.
 
-Note that validation runs after `after_data` hooks and re-reads the current source state, not the earlier COPY snapshot. If the source is live, keep that in mind.
+During `pgferry migrate`, validation runs after `after_data` hooks and re-reads the current source state, not the earlier COPY snapshot. If the source is live, keep that in mind.
+
+If you want to rerun the same built-in validation later without touching schema or data load again:
+
+```bash
+pgferry validate migration.toml
+```
+
+That command uses the existing TOML config, connects to the source and target, introspects the selected tables again, and runs the configured validation mode only. It does not rerun hooks, COPY, checkpoints, or post-load DDL.
 
 ## Guides
 

--- a/site/src/content/docs/get-started/quick-start.md
+++ b/site/src/content/docs/get-started/quick-start.md
@@ -81,6 +81,16 @@ The migrate command runs the full pipeline:
 6. add primary keys, indexes, foreign keys, and sequences
 7. run remaining hooks and finalize
 
+## Re-run validation
+
+If you want to re-check source vs target later without rerunning DDL or COPY:
+
+```bash
+pgferry validate migration.toml
+```
+
+That reuses the same `validation = "row_count"` or `validation = "sampled_hash"` setting from the TOML file and compares the current source state against the already-loaded PostgreSQL target.
+
 ## Next step
 
 After the first run, move to:

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -3,10 +3,11 @@ title: Configuration
 description: Full TOML reference for pgferry migration configs, including defaults, safe starting points, and source-specific constraints.
 ---
 
-Every migration is driven by a single TOML file:
+Every migration run is driven by a single TOML file:
 
 ```bash
 pgferry migrate migration.toml
+pgferry validate migration.toml
 ```
 
 If you want the fastest safe starting point, use the wizard first:
@@ -86,7 +87,7 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | `chunk_size` | int | `100000` | Key-range width for chunkable single-column numeric PK tables. Actual rows per chunk vary with key density. |
 | `copy_risk_analysis` | bool | `true` | Lightweight COUNT/MIN/MAX probes to flag awkward COPY chunking (huge tables, sparse keys, etc.). Feeds `plan` copy-risk output and optional migrate warnings. Turn off for quieter runs when you already know the shape. |
 | `resume` | bool | `false` | Reuse `pgferry_checkpoint.json` after interruptions. |
-| `validation` | string | `"none"` | `"row_count"` compares per-table counts after load. `"sampled_hash"` adds bounded content fingerprints for deterministic primary-key-addressable rows. |
+| `validation` | string | `"none"` | `"row_count"` compares per-table counts after load. `"sampled_hash"` adds bounded content fingerprints for deterministic primary-key-addressable rows. `pgferry validate` reuses this setting without rerunning migration stages. |
 
 ### `[source]`
 
@@ -211,6 +212,7 @@ The `database` parameter is required because pgferry extracts the DB name for in
 ## Practical guidance
 
 - Run `pgferry plan migration.toml` before the first real migration.
+- Use `pgferry validate migration.toml` when you need to rerun built-in validation later without rerunning schema creation or data copy.
 - Use [Operator tuning](/operations/operator-tuning/) when runtime is dominated by PostgreSQL settings, source pressure, or network distance rather than config shape alone.
 - Use `unlogged_tables = false` whenever you also need `resume = true`.
 - Use `source_snapshot_mode = "single_tx"` when the source stays live during the migration and you need one consistent read view.

--- a/site/src/content/docs/reference/index.md
+++ b/site/src/content/docs/reference/index.md
@@ -18,6 +18,7 @@ Use the reference section when you already understand the basic flow and need ex
 | Question | Start here |
 | --- | --- |
 | Which flags matter for a first production run? | [Configuration](/reference/configuration/#recommended-starting-points) |
+| How do I rerun built-in validation without migrating again? | [Migration Pipeline](/reference/migration-pipeline/#standalone-validate) and [Configuration](/reference/configuration/#full-reference) |
 | Which options only apply to MySQL-family or MSSQL sources? | [Configuration](/reference/configuration/#source-specific-constraints) and [Type Mapping](/reference/type-mapping/) |
 | What happens in `schema_only` or `data_only` mode? | [Migration Pipeline](/reference/migration-pipeline/#modes) |
 | When do hook files run? | [Hooks](/reference/hooks/#phases) |

--- a/site/src/content/docs/reference/migration-pipeline.md
+++ b/site/src/content/docs/reference/migration-pipeline.md
@@ -153,6 +153,24 @@ This is intentional:
 - hook-driven cleanup or transforms can run first
 - expensive post-load objects are not built yet if validation finds a mismatch
 
+## Standalone validate
+
+```bash
+pgferry validate migration.toml
+```
+
+This command is outside the migrate pipeline. It loads the same TOML config, reconnects to the source and target, introspects the selected tables, and reruns the configured validation mode only.
+
+It skips:
+
+- schema creation
+- data COPY
+- hooks
+- checkpoints
+- post-load DDL like indexes, foreign keys, and sequence reset
+
+Use it when you want to compare the current source state against an already-loaded target after cutover or on a later check.
+
 ## Practical operating advice
 
 - Use the full pipeline for most rehearsals and first production attempts.

--- a/validate_cmd.go
+++ b/validate_cmd.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 )
 
 var validateConfigPath string
@@ -34,9 +32,9 @@ func init() {
 }
 
 func runValidate(_ *cobra.Command, args []string) error {
-	cfgPath := validateConfigPath
-	if len(args) > 0 {
-		cfgPath = args[0]
+	cfgPath, err := resolveOptionalConfigPath(validateConfigPath, args)
+	if err != nil {
+		return err
 	}
 	if cfgPath == "" {
 		return missingValidateConfigError()
@@ -69,48 +67,19 @@ func runValidateWithConfig(cfg *MigrationConfig) error {
 
 	log.Printf("pgferry validate — %s source vs PostgreSQL target", src.Name())
 
-	sourceDB, err := src.OpenDB(cfg.Source.DSN)
-	if err != nil {
-		return err
-	}
-	defer sourceDB.Close()
-	sourceDB.SetMaxOpenConns(1)
-
 	pgPool, err := openValidateTargetPool(ctx, cfg)
 	if err != nil {
 		return err
 	}
 	defer pgPool.Close()
 
-	if err := pingValidateConnections(ctx, src, sourceDB, pgPool); err != nil {
-		return err
-	}
-
-	dbName, err := src.ExtractDBName(cfg.Source.DSN)
+	schema, err := loadValidateSchema(ctx, src, pgPool, cfg)
 	if err != nil {
 		return err
-	}
-
-	log.Printf("introspecting %s schema '%s'...", src.Name(), dbName)
-	schema, err := src.IntrospectSchema(sourceDB, dbName)
-	if err != nil {
-		return fmt.Errorf("introspect schema: %w", err)
-	}
-	filteredSchema, filterReport, err := filterSchemaTables(schema, cfg)
-	if err != nil {
-		return fmt.Errorf("filter schema tables: %w", err)
-	}
-	schema = filteredSchema
-	if hasTableFilters(cfg) {
-		logTableFilterReport(filterReport)
 	}
 
 	typeMap := effectiveTypeMapping(cfg)
-
-	// Release the introspection handle before validation opens its own source connections.
-	sourceDB.Close()
-
-	logValidationPlan(mode, cfg.SourceSnapshotMode)
+	logStandaloneValidationPlan(mode)
 	log.Printf("running standalone validation (mode=%s)...", mode)
 	if _, err := validateMigration(ctx, src, cfg.Source.DSN, pgPool, schema, cfg.Schema, mode, cfg.Workers, typeMap); err != nil {
 		return fmt.Errorf("validation: %w", err)
@@ -135,36 +104,46 @@ func openValidateTargetPool(ctx context.Context, cfg *MigrationConfig) (*pgxpool
 	return pgPool, nil
 }
 
-func pingValidateConnections(ctx context.Context, src SourceDB, sourceDB pingContextDB, pgPool *pgxpool.Pool) error {
-	srcLabel := strings.ToLower(src.Name())
-	log.Printf("pinging %s and PostgreSQL...", srcLabel)
-
-	pingCtx, pingCancel := context.WithTimeout(ctx, connectivityPingTimeout)
-	defer pingCancel()
-
-	var srcPingErr error
-	var pgPingErr error
-	var g errgroup.Group
-	g.Go(func() error {
-		if err := sourceDB.PingContext(pingCtx); err != nil {
-			srcPingErr = fmt.Errorf("ping %s: %w", srcLabel, err)
-		}
-		return nil
-	})
-	g.Go(func() error {
-		if err := pgPool.Ping(pingCtx); err != nil {
-			pgPingErr = fmt.Errorf("ping postgres: %w", err)
-		}
-		return nil
-	})
-	g.Wait()
-
-	if err := errors.Join(srcPingErr, pgPingErr); err != nil {
-		return err
+func loadValidateSchema(ctx context.Context, src SourceDB, pgPool *pgxpool.Pool, cfg *MigrationConfig) (*Schema, error) {
+	sourceDB, err := src.OpenDB(cfg.Source.DSN)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	defer sourceDB.Close()
+	sourceDB.SetMaxOpenConns(1)
+
+	if err := pingSourceAndTarget(ctx, src, sourceDB, pgPool); err != nil {
+		return nil, err
+	}
+
+	dbName, err := src.ExtractDBName(cfg.Source.DSN)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("introspecting %s schema '%s'...", src.Name(), dbName)
+	schema, err := src.IntrospectSchema(sourceDB, dbName)
+	if err != nil {
+		return nil, fmt.Errorf("introspect schema: %w", err)
+	}
+	filteredSchema, filterReport, err := filterSchemaTables(schema, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("filter schema tables: %w", err)
+	}
+	if hasTableFilters(cfg) {
+		logTableFilterReport(filterReport)
+	}
+	return filteredSchema, nil
 }
 
-type pingContextDB interface {
-	PingContext(context.Context) error
+func logStandaloneValidationPlan(mode string) {
+	log.Printf("validation mode: %s", validationModeSummary(mode))
+	log.Printf("validation caveat: standalone validate compares the current source state against already-loaded target data; if the source changed after migrate, mismatches may reflect drift after the original load")
+	log.Printf("validation caveat: standalone validate does not rerun after_data hooks; validate the same target state those hooks already produced")
+	switch mode {
+	case validationModeRowCount:
+		log.Printf("validation caveat: row_count does not compare row contents, transformed values, or per-row semantics")
+	case validationModeSampledHash:
+		log.Printf("validation caveat: sampled_hash is intentionally bounded: it samples deterministic rows and only compares columns with supported canonical fingerprints")
+	}
 }

--- a/validate_cmd_test.go
+++ b/validate_cmd_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,6 +59,24 @@ func TestRunValidate_UsesConfigFlag(t *testing.T) {
 	}
 }
 
+func TestRunValidate_RejectsConfigFlagAndPositionalPathTogether(t *testing.T) {
+	cfgPath := writeValidateTestConfig(t, "validation = \"row_count\"\n")
+
+	prevConfigPath := validateConfigPath
+	t.Cleanup(func() {
+		validateConfigPath = prevConfigPath
+	})
+	validateConfigPath = cfgPath
+
+	err := runValidate(&cobra.Command{}, []string{"other.toml"})
+	if err == nil {
+		t.Fatal("runValidate() error = nil, want conflict error")
+	}
+	if !strings.Contains(err.Error(), "provide either a positional migration.toml path or --config, not both") {
+		t.Fatalf("runValidate() error = %q, want config conflict", err.Error())
+	}
+}
+
 func TestRunValidate_MissingConfig(t *testing.T) {
 	prevConfigPath := validateConfigPath
 	t.Cleanup(func() {
@@ -75,6 +94,22 @@ func TestRunValidate_MissingConfig(t *testing.T) {
 	}
 }
 
+func TestRunValidate_NonexistentConfigFile(t *testing.T) {
+	prevConfigPath := validateConfigPath
+	t.Cleanup(func() {
+		validateConfigPath = prevConfigPath
+	})
+	validateConfigPath = ""
+
+	err := runValidate(&cobra.Command{}, []string{"does-not-exist.toml"})
+	if err == nil {
+		t.Fatal("runValidate() error = nil, want read config error")
+	}
+	if !strings.Contains(err.Error(), "read config") {
+		t.Fatalf("runValidate() error = %q, want read config error", err.Error())
+	}
+}
+
 func TestRunValidateWithConfig_RejectsDisabledValidation(t *testing.T) {
 	err := runValidateWithConfig(&MigrationConfig{Validation: validationModeNone})
 	if err == nil {
@@ -82,6 +117,35 @@ func TestRunValidateWithConfig_RejectsDisabledValidation(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "validation disabled") {
 		t.Fatalf("runValidateWithConfig() error = %q, want disabled validation message", err.Error())
+	}
+}
+
+func TestLogStandaloneValidationPlan(t *testing.T) {
+	var buf strings.Builder
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+
+	logStandaloneValidationPlan(validationModeSampledHash)
+
+	out := buf.String()
+	for _, want := range []string{
+		"validation mode: sampled_hash",
+		"current source state",
+		"does not rerun after_data hooks",
+		"samples deterministic rows",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("log output missing %q:\n%s", want, out)
+		}
+	}
+	for _, notWant := range []string{
+		"single_tx applies only to the COPY phase",
+		"re-reads the source after COPY",
+	} {
+		if strings.Contains(out, notWant) {
+			t.Fatalf("log output unexpectedly contains %q:\n%s", notWant, out)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated `pgferry validate` subcommand that re-runs post-load validation from an existing TOML config
- reuse the existing validation engine after source introspection and table filtering, without running DDL, COPY, hooks, checkpoints, or post-migrate steps
- cover config resolution and `validation = none` behavior with unit tests

Closes #146.

## Test Plan
- go fmt ./...
- go test ./... -count=1
- go vet ./...
- go build -o build/pgferry .
- ./build/pgferry validate --help