### PR TITLE
feat: identifier_case enum with "preserve" mode

### DIFF
--- a/checkpoint_compat.go
+++ b/checkpoint_compat.go
@@ -17,19 +17,19 @@ type checkpointCompatibility struct {
 }
 
 type checkpointCompatibilitySummary struct {
-	SourceType           string                         `json:"source_type"`
-	SourceDBName         string                         `json:"source_db_name,omitempty"`
-	SourceSchema         string                         `json:"source_schema,omitempty"`
-	TargetSchema         string                         `json:"target_schema"`
-	SourceSnapshotMode   string                         `json:"source_snapshot_mode"`
-	SnakeCaseIdentifiers bool                           `json:"snake_case_identifiers"`
-	SchemaOnly           bool                           `json:"schema_only"`
-	DataOnly             bool                           `json:"data_only"`
-	UnloggedTables       bool                           `json:"unlogged_tables"`
-	ChunkSize            int64                          `json:"chunk_size"`
-	TypeMapping          TypeMappingConfig              `json:"type_mapping"`
-	Hooks                []checkpointCompatibilityHook  `json:"hooks,omitempty"`
-	Tables               []checkpointCompatibilityTable `json:"tables,omitempty"`
+	SourceType         string                         `json:"source_type"`
+	SourceDBName       string                         `json:"source_db_name,omitempty"`
+	SourceSchema       string                         `json:"source_schema,omitempty"`
+	TargetSchema       string                         `json:"target_schema"`
+	SourceSnapshotMode string                         `json:"source_snapshot_mode"`
+	IdentifierCase     string                         `json:"identifier_case"`
+	SchemaOnly         bool                           `json:"schema_only"`
+	DataOnly           bool                           `json:"data_only"`
+	UnloggedTables     bool                           `json:"unlogged_tables"`
+	ChunkSize          int64                          `json:"chunk_size"`
+	TypeMapping        TypeMappingConfig              `json:"type_mapping"`
+	Hooks              []checkpointCompatibilityHook  `json:"hooks,omitempty"`
+	Tables             []checkpointCompatibilityTable `json:"tables,omitempty"`
 }
 
 type checkpointCompatibilityHook struct {
@@ -47,14 +47,14 @@ type checkpointCompatibilityTable struct {
 
 func buildCheckpointCompatibility(cfg *MigrationConfig, schema *Schema, src SourceDB, sourceDBName string, typeMap TypeMappingConfig) (checkpointCompatibility, error) {
 	summary := checkpointCompatibilitySummary{
-		SourceType:           cfg.Source.Type,
-		SourceDBName:         sourceDBName,
-		SourceSchema:         cfg.Source.SourceSchema,
-		TargetSchema:         cfg.Schema,
-		SourceSnapshotMode:   cfg.SourceSnapshotMode,
-		SnakeCaseIdentifiers: cfg.SnakeCaseIdentifiers,
-		SchemaOnly:           cfg.SchemaOnly,
-		DataOnly:             cfg.DataOnly,
+		SourceType:         cfg.Source.Type,
+		SourceDBName:       sourceDBName,
+		SourceSchema:       cfg.Source.SourceSchema,
+		TargetSchema:       cfg.Schema,
+		SourceSnapshotMode: cfg.SourceSnapshotMode,
+		IdentifierCase:     cfg.IdentifierCase,
+		SchemaOnly:         cfg.SchemaOnly,
+		DataOnly:           cfg.DataOnly,
 		// Track settings that affect the data-copy stage or target table state
 		// around resume. Pure schema-creation-only flags such as
 		// preserve_defaults are intentionally excluded because resume starts
@@ -250,8 +250,8 @@ func validateCheckpointCompatibility(path string, state *CheckpointState, expect
 	if saved.ChunkSize != current.ChunkSize {
 		reasons = append(reasons, fmt.Sprintf("chunk_size changed: was %d, now %d", saved.ChunkSize, current.ChunkSize))
 	}
-	if saved.SnakeCaseIdentifiers != current.SnakeCaseIdentifiers {
-		reasons = append(reasons, fmt.Sprintf("snake_case_identifiers changed: was %t, now %t", saved.SnakeCaseIdentifiers, current.SnakeCaseIdentifiers))
+	if saved.IdentifierCase != current.IdentifierCase {
+		reasons = append(reasons, fmt.Sprintf("identifier_case changed: was %q, now %q", saved.IdentifierCase, current.IdentifierCase))
 	}
 	if saved.SchemaOnly != current.SchemaOnly {
 		reasons = append(reasons, fmt.Sprintf("schema_only changed: was %t, now %t", saved.SchemaOnly, current.SchemaOnly))

--- a/checkpoint_compat_test.go
+++ b/checkpoint_compat_test.go
@@ -202,14 +202,7 @@ func TestValidateCheckpointCompatibility_IdentifierCaseChanged(t *testing.T) {
 	state := newCheckpointStateWithCompatibility(&compat)
 
 	changed := *compat.Summary
-	if changed.IdentifierCase == "" {
-		changed.IdentifierCase = "snake"
-	}
-	if changed.IdentifierCase == "snake" {
-		changed.IdentifierCase = "lower"
-	} else {
-		changed.IdentifierCase = "snake"
-	}
+	changed.IdentifierCase = "lower"
 	changedCompat := testCheckpointCompatibilityWithSummary(changed)
 
 	err := validateCheckpointCompatibility(filepath.Join(t.TempDir(), "cp.json"), state, changedCompat)

--- a/checkpoint_compat_test.go
+++ b/checkpoint_compat_test.go
@@ -197,20 +197,27 @@ func TestValidateCheckpointCompatibility_TargetSchemaChanged(t *testing.T) {
 	}
 }
 
-func TestValidateCheckpointCompatibility_SnakeCaseChanged(t *testing.T) {
+func TestValidateCheckpointCompatibility_IdentifierCaseChanged(t *testing.T) {
 	compat := testCheckpointCompatibility()
 	state := newCheckpointStateWithCompatibility(&compat)
 
 	changed := *compat.Summary
-	changed.SnakeCaseIdentifiers = !changed.SnakeCaseIdentifiers
+	if changed.IdentifierCase == "" {
+		changed.IdentifierCase = "snake"
+	}
+	if changed.IdentifierCase == "snake" {
+		changed.IdentifierCase = "lower"
+	} else {
+		changed.IdentifierCase = "snake"
+	}
 	changedCompat := testCheckpointCompatibilityWithSummary(changed)
 
 	err := validateCheckpointCompatibility(filepath.Join(t.TempDir(), "cp.json"), state, changedCompat)
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "snake_case_identifiers changed") {
-		t.Fatalf("expected snake_case change message, got: %v", err)
+	if !strings.Contains(err.Error(), "identifier_case changed") {
+		t.Fatalf("expected identifier_case change message, got: %v", err)
 	}
 }
 
@@ -261,7 +268,7 @@ func TestValidateCheckpointCompatibility_MaxReasonsLimited(t *testing.T) {
 	changed.TargetSchema = "other"
 	changed.SourceSnapshotMode = "single_tx"
 	changed.ChunkSize = 1
-	changed.SnakeCaseIdentifiers = true
+	changed.IdentifierCase = "lower"
 	changed.UnloggedTables = true
 	changed.TypeMapping.TinyInt1AsBoolean = true
 	changed.TypeMapping.Binary16AsUUID = true

--- a/checkpoint_status.go
+++ b/checkpoint_status.go
@@ -113,7 +113,7 @@ func writeCheckpointStatusText(out io.Writer, path string, state *CheckpointStat
 	}
 	fmt.Fprintf(out, "  target_schema: %s\n", summary.TargetSchema)
 	fmt.Fprintf(out, "  source_snapshot_mode: %s\n", summary.SourceSnapshotMode)
-	fmt.Fprintf(out, "  snake_case_identifiers: %s\n", yesNo(summary.SnakeCaseIdentifiers))
+	fmt.Fprintf(out, "  identifier_case: %s\n", summary.IdentifierCase)
 	fmt.Fprintf(out, "  schema_only: %s\n", yesNo(summary.SchemaOnly))
 	fmt.Fprintf(out, "  data_only: %s\n", yesNo(summary.DataOnly))
 	fmt.Fprintf(out, "  unlogged_tables: %s\n", yesNo(summary.UnloggedTables))

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -16,6 +16,7 @@ func testCheckpointCompatibility() checkpointCompatibility {
 		TargetSchema:       "public",
 		SourceSnapshotMode: "none",
 		ChunkSize:          100000,
+		IdentifierCase:     "snake",
 		TypeMapping:        defaultTypeMappingConfig(),
 		Tables: []checkpointCompatibilityTable{
 			{SourceName: "users", PGName: "users", TableHash: "users-hash"},

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ type MigrationConfig struct {
 	CleanOrphans                      bool              `toml:"clean_orphans"`
 	CleanOrphansMode                  string            `toml:"clean_orphans_mode"`     // apply|report
 	CleanOrphansMaxRows               int64             `toml:"clean_orphans_max_rows"` // 0 disables threshold
-	SnakeCaseIdentifiers              bool              `toml:"snake_case_identifiers"`
+	IdentifierCase                    string            `toml:"identifier_case"`        // snake|lower|preserve
 	ReplicateOnUpdateCurrentTimestamp bool              `toml:"replicate_on_update_current_timestamp"`
 	Workers                           int               `toml:"workers"`
 	IndexWorkers                      int               `toml:"index_workers"`
@@ -150,16 +150,16 @@ func applyConfigEnvOverrides(cfg *MigrationConfig) {
 
 func defaultMigrationConfig() MigrationConfig {
 	return MigrationConfig{
-		OnSchemaExists:       "error",
-		TableFilterMode:      "exact",
-		SourceSnapshotMode:   "none",
-		UnloggedTables:       true,
-		PreserveDefaults:     true,
-		CleanOrphans:         true,
-		CleanOrphansMode:     "apply",
-		SnakeCaseIdentifiers: true,
-		CopyRiskAnalysis:     true,
-		TypeMapping:          defaultTypeMappingConfig(),
+		OnSchemaExists:     "error",
+		TableFilterMode:    "exact",
+		SourceSnapshotMode: "none",
+		UnloggedTables:     true,
+		PreserveDefaults:   true,
+		CleanOrphans:       true,
+		CleanOrphansMode:   "apply",
+		IdentifierCase:     "snake",
+		CopyRiskAnalysis:   true,
+		TypeMapping:        defaultTypeMappingConfig(),
 	}
 }
 
@@ -203,6 +203,17 @@ func finalizeConfig(cfg *MigrationConfig, configDir string) error {
 	case "exact", "glob":
 	default:
 		return fmt.Errorf("table_filter_mode must be one of: exact, glob")
+	}
+	cfg.IdentifierCase = strings.ToLower(strings.TrimSpace(cfg.IdentifierCase))
+	if cfg.IdentifierCase == "" {
+		cfg.IdentifierCase = "snake"
+	}
+	switch cfg.IdentifierCase {
+	case "snake", "lower":
+		// "preserve" is added in Task 2; until then, reject explicitly so the
+		// refactor does not ship the new surface prematurely.
+	default:
+		return fmt.Errorf("identifier_case must be one of: snake, lower")
 	}
 	includeTables, err := normalizeTableFilterEntries("include_tables", cfg.TableFilterMode, cfg.IncludeTables)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -209,11 +209,9 @@ func finalizeConfig(cfg *MigrationConfig, configDir string) error {
 		cfg.IdentifierCase = "snake"
 	}
 	switch cfg.IdentifierCase {
-	case "snake", "lower":
-		// "preserve" is added in Task 2; until then, reject explicitly so the
-		// refactor does not ship the new surface prematurely.
+	case "snake", "lower", "preserve":
 	default:
-		return fmt.Errorf("identifier_case must be one of: snake, lower")
+		return fmt.Errorf("identifier_case must be one of: snake, lower, preserve")
 	}
 	includeTables, err := normalizeTableFilterEntries("include_tables", cfg.TableFilterMode, cfg.IncludeTables)
 	if err != nil {

--- a/config_edge_test.go
+++ b/config_edge_test.go
@@ -486,23 +486,18 @@ func TestFinalizeConfig_IdentifierCaseInvalid(t *testing.T) {
 	}
 }
 
-// TestFinalizeConfig_IdentifierCasePreserveRejected documents Task-1 scope:
-// "preserve" is not yet a valid value and must be rejected. Task 2 will add
-// the "preserve" arm to the validation switch, at which point this test
-// should be updated to assert that "preserve" is accepted.
-func TestFinalizeConfig_IdentifierCasePreserveRejected(t *testing.T) {
+func TestFinalizeConfig_IdentifierCasePreserveAccepted(t *testing.T) {
 	cfg := defaultMigrationConfig()
 	cfg.Schema = "public"
 	cfg.Source = SourceConfig{Type: "mysql", DSN: "root@tcp(localhost)/test"}
 	cfg.Target = TargetConfig{DSN: "postgres://localhost/test"}
 	cfg.IdentifierCase = "preserve"
 
-	err := finalizeConfig(&cfg, t.TempDir())
-	if err == nil {
-		t.Fatal("expected error for identifier_case=preserve in Task 1")
+	if err := finalizeConfig(&cfg, t.TempDir()); err != nil {
+		t.Fatalf("finalizeConfig: %v", err)
 	}
-	if !strings.Contains(err.Error(), "identifier_case must be one of: snake, lower") {
-		t.Fatalf("expected identifier_case error, got: %v", err)
+	if cfg.IdentifierCase != "preserve" {
+		t.Fatalf("IdentifierCase = %q, want %q", cfg.IdentifierCase, "preserve")
 	}
 }
 

--- a/config_edge_test.go
+++ b/config_edge_test.go
@@ -470,22 +470,6 @@ func TestFinalizeConfig_IdentifierCaseLower(t *testing.T) {
 	}
 }
 
-func TestFinalizeConfig_IdentifierCaseInvalid(t *testing.T) {
-	cfg := defaultMigrationConfig()
-	cfg.Schema = "public"
-	cfg.Source = SourceConfig{Type: "mysql", DSN: "root@tcp(localhost)/test"}
-	cfg.Target = TargetConfig{DSN: "postgres://localhost/test"}
-	cfg.IdentifierCase = "bogus"
-
-	err := finalizeConfig(&cfg, t.TempDir())
-	if err == nil {
-		t.Fatal("expected error for invalid identifier_case")
-	}
-	if !strings.Contains(err.Error(), "identifier_case must be one of: snake, lower") {
-		t.Fatalf("expected identifier_case error, got: %v", err)
-	}
-}
-
 func TestFinalizeConfig_IdentifierCasePreserveAccepted(t *testing.T) {
 	cfg := defaultMigrationConfig()
 	cfg.Schema = "public"

--- a/config_edge_test.go
+++ b/config_edge_test.go
@@ -440,6 +440,87 @@ func TestFinalizeConfig_PostGISMariaDBRejected(t *testing.T) {
 	}
 }
 
+func TestFinalizeConfig_IdentifierCaseSnake(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Schema = "public"
+	cfg.Source = SourceConfig{Type: "mysql", DSN: "root@tcp(localhost)/test"}
+	cfg.Target = TargetConfig{DSN: "postgres://localhost/test"}
+	cfg.IdentifierCase = "snake"
+
+	if err := finalizeConfig(&cfg, t.TempDir()); err != nil {
+		t.Fatalf("finalizeConfig: %v", err)
+	}
+	if cfg.IdentifierCase != "snake" {
+		t.Fatalf("IdentifierCase = %q, want %q", cfg.IdentifierCase, "snake")
+	}
+}
+
+func TestFinalizeConfig_IdentifierCaseLower(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Schema = "public"
+	cfg.Source = SourceConfig{Type: "mysql", DSN: "root@tcp(localhost)/test"}
+	cfg.Target = TargetConfig{DSN: "postgres://localhost/test"}
+	cfg.IdentifierCase = "lower"
+
+	if err := finalizeConfig(&cfg, t.TempDir()); err != nil {
+		t.Fatalf("finalizeConfig: %v", err)
+	}
+	if cfg.IdentifierCase != "lower" {
+		t.Fatalf("IdentifierCase = %q, want %q", cfg.IdentifierCase, "lower")
+	}
+}
+
+func TestFinalizeConfig_IdentifierCaseInvalid(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Schema = "public"
+	cfg.Source = SourceConfig{Type: "mysql", DSN: "root@tcp(localhost)/test"}
+	cfg.Target = TargetConfig{DSN: "postgres://localhost/test"}
+	cfg.IdentifierCase = "bogus"
+
+	err := finalizeConfig(&cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for invalid identifier_case")
+	}
+	if !strings.Contains(err.Error(), "identifier_case must be one of: snake, lower") {
+		t.Fatalf("expected identifier_case error, got: %v", err)
+	}
+}
+
+// TestFinalizeConfig_IdentifierCasePreserveRejected documents Task-1 scope:
+// "preserve" is not yet a valid value and must be rejected. Task 2 will add
+// the "preserve" arm to the validation switch, at which point this test
+// should be updated to assert that "preserve" is accepted.
+func TestFinalizeConfig_IdentifierCasePreserveRejected(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Schema = "public"
+	cfg.Source = SourceConfig{Type: "mysql", DSN: "root@tcp(localhost)/test"}
+	cfg.Target = TargetConfig{DSN: "postgres://localhost/test"}
+	cfg.IdentifierCase = "preserve"
+
+	err := finalizeConfig(&cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for identifier_case=preserve in Task 1")
+	}
+	if !strings.Contains(err.Error(), "identifier_case must be one of: snake, lower") {
+		t.Fatalf("expected identifier_case error, got: %v", err)
+	}
+}
+
+func TestFinalizeConfig_IdentifierCaseNormalization(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Schema = "public"
+	cfg.Source = SourceConfig{Type: "mysql", DSN: "root@tcp(localhost)/test"}
+	cfg.Target = TargetConfig{DSN: "postgres://localhost/test"}
+	cfg.IdentifierCase = "  SNAKE  "
+
+	if err := finalizeConfig(&cfg, t.TempDir()); err != nil {
+		t.Fatalf("finalizeConfig: %v", err)
+	}
+	if cfg.IdentifierCase != "snake" {
+		t.Fatalf("IdentifierCase = %q, want %q (whitespace + case normalization)", cfg.IdentifierCase, "snake")
+	}
+}
+
 func TestNormalizeTableFilterEntries_Empty(t *testing.T) {
 	got, err := normalizeTableFilterEntries("include_tables", "exact", nil)
 	if err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -2183,3 +2183,39 @@ dsn = "postgres://u:p@h:5432/db"
 		t.Errorf("ChunkSize = %d, want 100000 (default)", cfg.ChunkSize)
 	}
 }
+
+func TestIdentifierCase_AcceptsPreserve(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Source.Type = "mysql"
+	cfg.Source.DSN = "user:pass@tcp(127.0.0.1:3306)/db"
+	cfg.Target.DSN = "postgres://u:p@127.0.0.1/db?sslmode=disable"
+	cfg.Schema = "public"
+	cfg.IdentifierCase = "preserve"
+
+	if err := finalizeConfig(&cfg, t.TempDir()); err != nil {
+		t.Fatalf("finalizeConfig error: %v", err)
+	}
+	if cfg.IdentifierCase != "preserve" {
+		t.Fatalf("IdentifierCase after finalize = %q, want preserve", cfg.IdentifierCase)
+	}
+}
+
+func TestIdentifierCase_RejectsInvalid(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Source.Type = "mysql"
+	cfg.Source.DSN = "user:pass@tcp(127.0.0.1:3306)/db"
+	cfg.Target.DSN = "postgres://u:p@127.0.0.1/db?sslmode=disable"
+	cfg.Schema = "public"
+	cfg.IdentifierCase = "camel"
+
+	err := finalizeConfig(&cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for identifier_case = camel")
+	}
+	if !strings.Contains(err.Error(), "identifier_case must be one of") {
+		t.Fatalf("error = %q, want identifier_case validation message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "preserve") {
+		t.Fatalf("error = %q, want it to list preserve as a valid value", err.Error())
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -140,8 +140,8 @@ dsn = "postgres://u:p@h:5432/db"
 	if cfg.CleanOrphansMaxRows != 0 {
 		t.Errorf("default CleanOrphansMaxRows = %d, want 0", cfg.CleanOrphansMaxRows)
 	}
-	if !cfg.SnakeCaseIdentifiers {
-		t.Errorf("default SnakeCaseIdentifiers = %t, want true", cfg.SnakeCaseIdentifiers)
+	if cfg.IdentifierCase != "snake" {
+		t.Errorf("default IdentifierCase = %q, want %q", cfg.IdentifierCase, "snake")
 	}
 	wantWorkers := runtime.NumCPU()
 	if wantWorkers < 1 {

--- a/identifier_validation.go
+++ b/identifier_validation.go
@@ -348,7 +348,7 @@ func validateGeneratedIdentifiers(schema *Schema, cfg *MigrationConfig, typeMap 
 		b.WriteString(strings.Join(collision.origins, "; "))
 		b.WriteByte('\n')
 	}
-	b.WriteString("Hint: rename the conflicting source objects, set identifier_case = \"lower\" if normalization caused the collision, or migrate the conflicting objects manually with hooks.")
+	b.WriteString("Hint: rename the conflicting source objects, set identifier_case = \"preserve\" to keep original casing (PostgreSQL will quote them), fall back to identifier_case = \"lower\" if normalization caused the collision, or migrate the conflicting objects manually with hooks.")
 
 	return errors.New(b.String())
 }

--- a/identifier_validation.go
+++ b/identifier_validation.go
@@ -348,7 +348,7 @@ func validateGeneratedIdentifiers(schema *Schema, cfg *MigrationConfig, typeMap 
 		b.WriteString(strings.Join(collision.origins, "; "))
 		b.WriteByte('\n')
 	}
-	b.WriteString("Hint: rename the conflicting source objects, disable snake_case_identifiers if normalization caused the collision, or migrate the conflicting objects manually with hooks.")
+	b.WriteString("Hint: rename the conflicting source objects, set identifier_case = \"lower\" if normalization caused the collision, or migrate the conflicting objects manually with hooks.")
 
 	return errors.New(b.String())
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -1326,6 +1326,93 @@ dsn = %q
 	}
 }
 
+func TestIntegration_MSSQL_IdentifierCasePreserve(t *testing.T) {
+	mssqlDSN, pgDSN := requireMSSQLAndPostgresDSNs(t)
+	ctx := context.Background()
+
+	mssqlDB, err := sql.Open("sqlserver", mssqlDSN)
+	if err != nil {
+		t.Fatalf("open mssql: %v", err)
+	}
+	defer mssqlDB.Close()
+
+	seedMSSQL(t, mssqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() {
+		pgPool.Close()
+	})
+
+	pgSchema := integrationSchemaName("inttest_mssql_preserve")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() {
+		dropSchema(t, pgPool, pgSchema)
+	})
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+workers = 2
+identifier_case = "preserve"
+
+[source]
+type = "mssql"
+dsn = %q
+source_schema = "sales"
+
+[type_mapping]
+spatial_mode = "wkt_text"
+
+[target]
+dsn = %q
+`, pgSchema, mssqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	// Source table names are PascalCase (Users, Orders, ExactNumerics, SpecialTypes);
+	// under identifier_case = "preserve" the PG-side names must match byte-for-byte.
+	wantTables := []string{"Users", "Orders", "ExactNumerics", "SpecialTypes"}
+	for _, name := range wantTables {
+		var count int
+		err := pgPool.QueryRow(ctx, `
+			SELECT count(*) FROM information_schema.tables
+			 WHERE table_schema = $1 AND table_name = $2
+		`, pgSchema, name).Scan(&count)
+		if err != nil {
+			t.Fatalf("query table %q: %v", name, err)
+		}
+		if count != 1 {
+			t.Fatalf("expected table %q in schema %q, got count=%d", name, pgSchema, count)
+		}
+	}
+
+	// Spot-check a PascalCase column.
+	var colCount int
+	err = pgPool.QueryRow(ctx, `
+		SELECT count(*) FROM information_schema.columns
+		 WHERE table_schema = $1 AND table_name = $2 AND column_name = $3
+	`, pgSchema, "Users", "DisplayName").Scan(&colCount)
+	if err != nil {
+		t.Fatalf("query column Users.DisplayName: %v", err)
+	}
+	if colCount != 1 {
+		t.Fatalf("expected column DisplayName in %s.Users, got count=%d", pgSchema, colCount)
+	}
+
+	// Sanity: the lowercased form must NOT exist (guards against a silent regression
+	// to lower/snake mode).
+	var lowerCount int
+	err = pgPool.QueryRow(ctx, `
+		SELECT count(*) FROM information_schema.tables
+		 WHERE table_schema = $1 AND table_name = $2
+	`, pgSchema, "users").Scan(&lowerCount)
+	if err != nil {
+		t.Fatalf("query lowercase users: %v", err)
+	}
+	if lowerCount != 0 {
+		t.Fatalf("unexpected lowercased table %q.users present; identifier_case=preserve did not apply", pgSchema)
+	}
+}
+
 func seedSQLite(t *testing.T, dbPath string) {
 	t.Helper()
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -914,7 +914,7 @@ func TestIntegration_MySQL_ResumeAfterChunkFailure(t *testing.T) {
 	seedMySQLResumeFixture(t, mysqlDB)
 
 	src := &mysqlSourceDB{}
-	src.SetSnakeCaseIdentifiers(true)
+	src.SetIdentifierCase("snake")
 
 	sourceDB, err := src.OpenDB(mysqlDSN)
 	if err != nil {
@@ -948,21 +948,21 @@ func TestIntegration_MySQL_ResumeAfterChunkFailure(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	cfg := &MigrationConfig{
-		Source:               SourceConfig{Type: "mysql", DSN: mysqlDSN},
-		Target:               TargetConfig{DSN: pgDSN},
-		Schema:               pgSchema,
-		IncludeTables:        []string{"events"},
-		Workers:              1,
-		ChunkSize:            2,
-		Resume:               true,
-		UnloggedTables:       false,
-		PreserveDefaults:     true,
-		OnSchemaExists:       "error",
-		SourceSnapshotMode:   "none",
-		SnakeCaseIdentifiers: true,
-		Validation:           "none",
-		TypeMapping:          defaultTypeMappingConfig(),
-		configDir:            tmpDir,
+		Source:             SourceConfig{Type: "mysql", DSN: mysqlDSN},
+		Target:             TargetConfig{DSN: pgDSN},
+		Schema:             pgSchema,
+		IncludeTables:      []string{"events"},
+		Workers:            1,
+		ChunkSize:          2,
+		Resume:             true,
+		UnloggedTables:     false,
+		PreserveDefaults:   true,
+		OnSchemaExists:     "error",
+		SourceSnapshotMode: "none",
+		IdentifierCase:     "snake",
+		Validation:         "none",
+		TypeMapping:        defaultTypeMappingConfig(),
+		configDir:          tmpDir,
 	}
 	schema, _, err = filterSchemaTables(schema, cfg)
 	if err != nil {
@@ -2342,7 +2342,7 @@ func introspectMySQLSchemaForTest(t *testing.T, mysqlDSN string) (*mysqlSourceDB
 	t.Helper()
 
 	src := &mysqlSourceDB{}
-	src.SetSnakeCaseIdentifiers(true)
+	src.SetIdentifierCase("snake")
 
 	mysqlDB, err := src.OpenDB(mysqlDSN)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 		mode = "data_only"
 	}
 	log.Printf(
-		"config: mode=%s workers=%d index_workers=%d schema=%s on_schema_exists=%s source_snapshot_mode=%s unlogged_tables=%t preserve_defaults=%t add_unsigned_checks=%t clean_orphans=%t clean_orphans_mode=%s clean_orphans_max_rows=%d snake_case_identifiers=%t replicate_on_update_current_timestamp=%t chunk_size=%d copy_risk_analysis=%t resume=%t validation=%s",
+		"config: mode=%s workers=%d index_workers=%d schema=%s on_schema_exists=%s source_snapshot_mode=%s unlogged_tables=%t preserve_defaults=%t add_unsigned_checks=%t clean_orphans=%t clean_orphans_mode=%s clean_orphans_max_rows=%d identifier_case=%s replicate_on_update_current_timestamp=%t chunk_size=%d copy_risk_analysis=%t resume=%t validation=%s",
 		mode,
 		cfg.Workers,
 		cfg.IndexWorkers,
@@ -205,7 +205,7 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 		cfg.CleanOrphans,
 		cfg.CleanOrphansMode,
 		cfg.CleanOrphansMaxRows,
-		cfg.SnakeCaseIdentifiers,
+		cfg.IdentifierCase,
 		cfg.ReplicateOnUpdateCurrentTimestamp,
 		cfg.ChunkSize,
 		cfg.CopyRiskAnalysis,

--- a/plan.go
+++ b/plan.go
@@ -190,7 +190,7 @@ type PlanSummary struct {
 	CopyRiskAnalysis   bool   `json:"copy_risk_analysis"`
 	PreserveDefaults   bool   `json:"preserve_defaults"`
 	CleanOrphans       bool   `json:"clean_orphans"`
-	SnakeCaseIDs       bool   `json:"snake_case_identifiers"`
+	IdentifierCase     string `json:"identifier_case"`
 }
 
 // PlanReport holds all findings from the plan analysis.
@@ -636,7 +636,7 @@ func buildPlanSummary(schema *Schema, cfg *MigrationConfig, dbName string, copyR
 		CopyRiskAnalysis: cfg.CopyRiskAnalysis,
 		PreserveDefaults: cfg.PreserveDefaults,
 		CleanOrphans:     cfg.CleanOrphans,
-		SnakeCaseIDs:     cfg.SnakeCaseIdentifiers,
+		IdentifierCase:   cfg.IdentifierCase,
 	}
 	if schema != nil {
 		s.TableCount = len(schema.Tables)
@@ -935,8 +935,8 @@ func writePlanText(w io.Writer, report *PlanReport) {
 		}
 		fmt.Fprintf(w, "Config: workers=%d index_workers=%d chunk_size=%d resume=%t validation=%s\n",
 			s.Workers, s.IndexWorkers, s.ChunkSize, s.Resume, s.Validation)
-		fmt.Fprintf(w, "        source_snapshot_mode=%s copy_risk_analysis=%t unlogged_tables=%t preserve_defaults=%t clean_orphans=%t snake_case_identifiers=%t\n",
-			s.SnapshotMode, s.CopyRiskAnalysis, s.UnloggedTables, s.PreserveDefaults, s.CleanOrphans, s.SnakeCaseIDs)
+		fmt.Fprintf(w, "        source_snapshot_mode=%s copy_risk_analysis=%t unlogged_tables=%t preserve_defaults=%t clean_orphans=%t identifier_case=%s\n",
+			s.SnapshotMode, s.CopyRiskAnalysis, s.UnloggedTables, s.PreserveDefaults, s.CleanOrphans, s.IdentifierCase)
 		fmt.Fprintln(w)
 		writePlanETAText(w, report.ETA)
 	}
@@ -1216,7 +1216,7 @@ func writePlanMarkdown(w io.Writer, report *PlanReport) {
 			{"Unlogged Tables", strconv.FormatBool(s.UnloggedTables)},
 			{"Preserve Defaults", strconv.FormatBool(s.PreserveDefaults)},
 			{"Clean Orphans", strconv.FormatBool(s.CleanOrphans)},
-			{"Snake Case Identifiers", strconv.FormatBool(s.SnakeCaseIDs)},
+			{"Identifier Case", s.IdentifierCase},
 		}
 		if s.CopyRiskAnalysis {
 			rows = append(rows, []string{"Estimated Rows", formatInt64Thousands(s.TotalEstimatedRows)})

--- a/plan_test.go
+++ b/plan_test.go
@@ -550,7 +550,7 @@ func TestRenderPlanReport_MarkdownWithContent(t *testing.T) {
 			CopyRiskAnalysis:   true,
 			PreserveDefaults:   true,
 			CleanOrphans:       true,
-			SnakeCaseIDs:       true,
+			IdentifierCase:     "snake",
 		},
 		TableFilterReport: &PlanTableFilterReport{
 			TotalTables:       3,

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -107,7 +107,7 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | `schema_only` | bool | `false` | Create schema objects only. Skip data COPY. |
 | `data_only` | bool | `false` | Load data into an existing schema, then reset sequences. Requires the target role to disable and re-enable triggers on the selected target tables during the load. |
 | `source_snapshot_mode` | string | `"none"` | `"none"` is fastest. `"single_tx"` gives one consistent source snapshot on MySQL, MariaDB, and MSSQL. |
-| `snake_case_identifiers` | bool | `true` | Convert source names to `snake_case`. When false, pgferry lowercases only. |
+| `identifier_case` | string | `"snake"` | How source identifiers map to PostgreSQL names. `"snake"` converts `OrderItems` → `order_items`. `"lower"` lowercases only (`OrderItems` → `orderitems`). `"preserve"` keeps the source casing unchanged (`OrderItems` → `OrderItems`); PostgreSQL DDL is always quoted so mixed-case names are safe. |
 | `unlogged_tables` | bool | `true` | Use `UNLOGGED` tables during full loads, then `SET LOGGED` later. |
 | `preserve_defaults` | bool | `true` | Keep source column defaults in the created PostgreSQL schema. |
 | `add_unsigned_checks` | bool | `false` | Add `CHECK` constraints for MySQL-family unsigned ranges. |

--- a/site/src/content/docs/reference/conventions-and-limitations.md
+++ b/site/src/content/docs/reference/conventions-and-limitations.md
@@ -7,15 +7,24 @@ pgferry tries to be explicit about where it is opinionated and where it delibera
 
 ## Naming
 
-- `snake_case_identifiers = true` converts source identifiers to PostgreSQL-style `snake_case`.
-- `snake_case_identifiers = false` keeps names lowercased only.
-- Generated PostgreSQL SQL uses quoted identifiers.
+The `identifier_case` option controls how source identifiers map to PostgreSQL names:
+
+- `identifier_case = "snake"` (default) converts to PostgreSQL-style `snake_case`.
+- `identifier_case = "lower"` lowercases only — no word-boundary insertion.
+- `identifier_case = "preserve"` keeps the original source casing unchanged.
+
+Generated PostgreSQL DDL always uses quoted identifiers, so mixed-case names produced by `"preserve"` are safe to use in downstream SQL and tooling (referenced as `"SomeProducts"` rather than `someproducts`).
 
 Examples:
 
-- `parentUserId` becomes `parent_user_id`
-- `UserName` becomes `username` when `snake_case_identifiers = false`
-- PostgreSQL SQL is emitted as `"app"."users"` rather than `app.users`
+| Source identifier | `"snake"` | `"lower"` | `"preserve"` |
+| --- | --- | --- | --- |
+| `parentUserId` | `parent_user_id` | `parentuserid` | `parentUserId` |
+| `UserName` | `user_name` | `username` | `UserName` |
+| `SomeProducts` | `some_products` | `someproducts` | `SomeProducts` |
+| `HTMLParser` | `html_parser` | `htmlparser` | `HTMLParser` |
+
+PostgreSQL SQL is emitted as `"app"."users"` rather than `app.users` under all three modes.
 
 ## Auto-increment and sequences
 

--- a/source.go
+++ b/source.go
@@ -50,9 +50,10 @@ type SourceDB interface {
 	// ValidateTypeMapping checks for source-specific type mapping options that are invalid.
 	ValidateTypeMapping(typeMap TypeMappingConfig) error
 
-	// SetSnakeCaseIdentifiers enables or disables snake_case conversion for source identifiers.
-	// When false (default), identifiers are lowercased to match PostgreSQL's default case folding.
-	SetSnakeCaseIdentifiers(enabled bool)
+	// SetIdentifierCase controls how source identifiers are mapped to PostgreSQL names.
+	// Values: "snake" (current default, applies toSnakeCase), "lower" (lowercase only),
+	// "preserve" (keep source casing unchanged — relies on pgferry always quoting DDL identifiers).
+	SetIdentifierCase(mode string)
 
 	// SetCharset sets the character set for the source connection.
 	// For MySQL, this is injected into the DSN. For SQLite, this is a no-op.
@@ -87,7 +88,7 @@ func newConfiguredSourceDB(cfg *MigrationConfig) (SourceDB, error) {
 	if err != nil {
 		return nil, err
 	}
-	src.SetSnakeCaseIdentifiers(cfg.SnakeCaseIdentifiers)
+	src.SetIdentifierCase(cfg.IdentifierCase)
 	src.SetCharset(cfg.Source.Charset)
 	src.SetSourceSchema(cfg.Source.SourceSchema)
 	return src, nil

--- a/source_mssql.go
+++ b/source_mssql.go
@@ -13,13 +13,13 @@ import (
 )
 
 type mssqlSourceDB struct {
-	snakeCaseIDs bool
+	identCase    string
 	sourceSchema string // MSSQL schema (default "dbo")
 }
 
-func (m *mssqlSourceDB) Name() string                         { return "MSSQL" }
-func (m *mssqlSourceDB) SetSnakeCaseIdentifiers(enabled bool) { m.snakeCaseIDs = enabled }
-func (m *mssqlSourceDB) SetCharset(_ string)                  {}
+func (m *mssqlSourceDB) Name() string                  { return "MSSQL" }
+func (m *mssqlSourceDB) SetIdentifierCase(mode string) { m.identCase = mode }
+func (m *mssqlSourceDB) SetCharset(_ string)           {}
 func (m *mssqlSourceDB) SetSourceSchema(schema string) {
 	schema = strings.TrimSpace(schema)
 	if schema == "" {
@@ -30,12 +30,14 @@ func (m *mssqlSourceDB) SetSourceSchema(schema string) {
 func (m *mssqlSourceDB) SupportsSnapshotMode() bool { return true }
 func (m *mssqlSourceDB) MaxWorkers() int            { return 0 }
 
-// identName converts a source identifier to its PostgreSQL name.
+// identName converts a source identifier to its PostgreSQL name according to identCase.
 func (m *mssqlSourceDB) identName(s string) string {
-	if m.snakeCaseIDs {
+	switch m.identCase {
+	case "snake":
 		return toSnakeCase(s)
+	default: // "lower"
+		return strings.ToLower(s)
 	}
-	return strings.ToLower(s)
 }
 
 func (m *mssqlSourceDB) QuoteIdentifier(name string) string {

--- a/source_mssql.go
+++ b/source_mssql.go
@@ -33,6 +33,8 @@ func (m *mssqlSourceDB) MaxWorkers() int            { return 0 }
 // identName converts a source identifier to its PostgreSQL name according to identCase.
 func (m *mssqlSourceDB) identName(s string) string {
 	switch m.identCase {
+	case "preserve":
+		return s
 	case "snake":
 		return toSnakeCase(s)
 	default: // "lower"

--- a/source_mssql_introspection_test.go
+++ b/source_mssql_introspection_test.go
@@ -230,7 +230,7 @@ func TestMSSQLIntrospectSchemaBatchesSchemaQueries(t *testing.T) {
 	db, stub := openMSSQLIntrospectionStubDB(t)
 	defer db.Close()
 
-	src := &mssqlSourceDB{snakeCaseIDs: true, sourceSchema: "dbo"}
+	src := &mssqlSourceDB{identCase: "snake", sourceSchema: "dbo"}
 	schema, err := src.IntrospectSchema(db, "")
 	if err != nil {
 		t.Fatalf("IntrospectSchema: %v", err)
@@ -320,7 +320,7 @@ func TestMSSQLIntrospectSchemaSemanticWarnings(t *testing.T) {
 	db, _ := openMSSQLIntrospectionStubDB(t)
 	defer db.Close()
 
-	src := &mssqlSourceDB{snakeCaseIDs: true, sourceSchema: "dbo"}
+	src := &mssqlSourceDB{identCase: "snake", sourceSchema: "dbo"}
 	warnings, err := src.IntrospectSchemaSemanticWarnings(db, "")
 	if err != nil {
 		t.Fatalf("IntrospectSchemaSemanticWarnings: %v", err)

--- a/source_mssql_test.go
+++ b/source_mssql_test.go
@@ -483,12 +483,12 @@ func TestMSSQLName(t *testing.T) {
 }
 
 func TestMSSQLIdentName(t *testing.T) {
-	src := &mssqlSourceDB{snakeCaseIDs: true}
+	src := &mssqlSourceDB{identCase: "snake"}
 	if got := src.identName("MyColumn"); got != "my_column" {
 		t.Errorf("identName(MyColumn) = %q, want my_column", got)
 	}
 
-	src.snakeCaseIDs = false
+	src.identCase = "lower"
 	if got := src.identName("MyColumn"); got != "mycolumn" {
 		t.Errorf("identName(MyColumn) = %q, want mycolumn", got)
 	}

--- a/source_mysql.go
+++ b/source_mysql.go
@@ -17,7 +17,7 @@ var uuidRegexp = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{
 var mariaDBJSONValidCheckRegexp = regexp.MustCompile(`(?i)json_valid\s*\(\s*\(*\s*(?:` + "`" + `([^` + "`" + `]+)` + "`" + `|"([^"]+)"|([a-zA-Z_][a-zA-Z0-9_$]*))\s*\)*\s*\)`)
 
 type mysqlSourceDB struct {
-	snakeCaseIDs          bool
+	identCase             string
 	charset               string
 	axisOrderOptionKnown  bool
 	supportsAxisOrderExpr bool
@@ -27,17 +27,18 @@ type mariadbSourceDB struct {
 	mysqlSourceDB
 }
 
-func (m *mysqlSourceDB) SetSnakeCaseIdentifiers(enabled bool) { m.snakeCaseIDs = enabled }
-func (m *mysqlSourceDB) SetCharset(charset string)            { m.charset = charset }
-func (m *mysqlSourceDB) SetSourceSchema(_ string)             {}
+func (m *mysqlSourceDB) SetIdentifierCase(mode string) { m.identCase = mode }
+func (m *mysqlSourceDB) SetCharset(charset string)     { m.charset = charset }
+func (m *mysqlSourceDB) SetSourceSchema(_ string)      {}
 
-// identName converts a source identifier to its PostgreSQL name.
-// When snakeCaseIDs is true, applies toSnakeCase; otherwise lowercases.
+// identName converts a source identifier to its PostgreSQL name according to identCase.
 func (m *mysqlSourceDB) identName(s string) string {
-	if m.snakeCaseIDs {
+	switch m.identCase {
+	case "snake":
 		return toSnakeCase(s)
+	default: // "lower"
+		return strings.ToLower(s)
 	}
-	return strings.ToLower(s)
 }
 
 func (m *mysqlSourceDB) Name() string { return "MySQL" }

--- a/source_mysql.go
+++ b/source_mysql.go
@@ -34,6 +34,8 @@ func (m *mysqlSourceDB) SetSourceSchema(_ string)      {}
 // identName converts a source identifier to its PostgreSQL name according to identCase.
 func (m *mysqlSourceDB) identName(s string) string {
 	switch m.identCase {
+	case "preserve":
+		return s
 	case "snake":
 		return toSnakeCase(s)
 	default: // "lower"

--- a/source_mysql_introspection_test.go
+++ b/source_mysql_introspection_test.go
@@ -341,7 +341,7 @@ func TestMySQLIntrospectSchemaSemanticWarnings(t *testing.T) {
 	db, _ := openMySQLIntrospectionStubDB(t)
 	defer db.Close()
 
-	src := &mysqlSourceDB{snakeCaseIDs: true}
+	src := &mysqlSourceDB{identCase: "snake"}
 	warnings, err := src.IntrospectSchemaSemanticWarnings(db, "appdb")
 	if err != nil {
 		t.Fatalf("IntrospectSchemaSemanticWarnings: %v", err)

--- a/source_sqlite.go
+++ b/source_sqlite.go
@@ -26,6 +26,8 @@ func (s *sqliteSourceDB) SetSourceSchema(_ string)      {}
 // identName converts a source identifier to its PostgreSQL name according to identCase.
 func (s *sqliteSourceDB) identName(name string) string {
 	switch s.identCase {
+	case "preserve":
+		return name
 	case "snake":
 		return toSnakeCase(name)
 	default: // "lower"

--- a/source_sqlite.go
+++ b/source_sqlite.go
@@ -16,20 +16,21 @@ import (
 const sqliteMaxCompoundSelectTerms = 400
 
 type sqliteSourceDB struct {
-	snakeCaseIDs bool
+	identCase string
 }
 
-func (s *sqliteSourceDB) SetSnakeCaseIdentifiers(enabled bool) { s.snakeCaseIDs = enabled }
-func (s *sqliteSourceDB) SetCharset(_ string)                  {}
-func (s *sqliteSourceDB) SetSourceSchema(_ string)             {}
+func (s *sqliteSourceDB) SetIdentifierCase(mode string) { s.identCase = mode }
+func (s *sqliteSourceDB) SetCharset(_ string)           {}
+func (s *sqliteSourceDB) SetSourceSchema(_ string)      {}
 
-// identName converts a source identifier to its PostgreSQL name.
-// When snakeCaseIDs is true, applies toSnakeCase; otherwise lowercases.
+// identName converts a source identifier to its PostgreSQL name according to identCase.
 func (s *sqliteSourceDB) identName(name string) string {
-	if s.snakeCaseIDs {
+	switch s.identCase {
+	case "snake":
 		return toSnakeCase(name)
+	default: // "lower"
+		return strings.ToLower(name)
 	}
-	return strings.ToLower(name)
 }
 
 func (s *sqliteSourceDB) Name() string { return "SQLite" }

--- a/source_test.go
+++ b/source_test.go
@@ -158,3 +158,35 @@ func TestSourceTypeForDB_FallsBackToNameForTestDoubles(t *testing.T) {
 		t.Fatalf("sourceTypeForDB(fake MariaDB) = %q, want mariadb", got)
 	}
 }
+
+func TestMySQLIdentName_PreserveMode(t *testing.T) {
+	src := &mysqlSourceDB{}
+	src.SetIdentifierCase("preserve")
+	cases := []struct{ in, want string }{
+		{"SomeProducts", "SomeProducts"},
+		{"SomeProductId", "SomeProductId"},
+		{"HTMLParser", "HTMLParser"},
+		{"user_id", "user_id"},
+	}
+	for _, tc := range cases {
+		if got := src.identName(tc.in); got != tc.want {
+			t.Errorf("identName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSQLiteIdentName_PreserveMode(t *testing.T) {
+	src := &sqliteSourceDB{}
+	src.SetIdentifierCase("preserve")
+	if got := src.identName("MixedCase"); got != "MixedCase" {
+		t.Errorf("identName(\"MixedCase\") = %q, want %q", got, "MixedCase")
+	}
+}
+
+func TestMSSQLIdentName_PreserveMode(t *testing.T) {
+	src := &mssqlSourceDB{}
+	src.SetIdentifierCase("preserve")
+	if got := src.identName("SomeProducts"); got != "SomeProducts" {
+		t.Errorf("identName(\"SomeProducts\") = %q, want %q", got, "SomeProducts")
+	}
+}

--- a/source_test.go
+++ b/source_test.go
@@ -9,7 +9,7 @@ func TestNewConfiguredSourceDB_MSSQLSourceSchema(t *testing.T) {
 	cfg := defaultMigrationConfig()
 	cfg.Source.Type = "mssql"
 	cfg.Source.SourceSchema = "sales"
-	cfg.SnakeCaseIdentifiers = true
+	cfg.IdentifierCase = "snake"
 
 	src, err := newConfiguredSourceDB(&cfg)
 	if err != nil {
@@ -24,8 +24,8 @@ func TestNewConfiguredSourceDB_MSSQLSourceSchema(t *testing.T) {
 	if mssqlSrc.sourceSchema != "sales" {
 		t.Fatalf("sourceSchema = %q, want sales", mssqlSrc.sourceSchema)
 	}
-	if !mssqlSrc.snakeCaseIDs {
-		t.Fatal("snakeCaseIDs = false, want true")
+	if mssqlSrc.identCase != "snake" {
+		t.Fatalf("identCase = %q, want snake", mssqlSrc.identCase)
 	}
 }
 
@@ -33,7 +33,7 @@ func TestNewConfiguredSourceDB_MySQLAppliesCharsetAndIdentifiers(t *testing.T) {
 	cfg := defaultMigrationConfig()
 	cfg.Source.Type = "mysql"
 	cfg.Source.Charset = "latin1"
-	cfg.SnakeCaseIdentifiers = false
+	cfg.IdentifierCase = "lower"
 
 	src, err := newConfiguredSourceDB(&cfg)
 	if err != nil {
@@ -48,8 +48,8 @@ func TestNewConfiguredSourceDB_MySQLAppliesCharsetAndIdentifiers(t *testing.T) {
 	if mysqlSrc.charset != "latin1" {
 		t.Fatalf("charset = %q, want latin1", mysqlSrc.charset)
 	}
-	if mysqlSrc.snakeCaseIDs {
-		t.Fatal("snakeCaseIDs = true, want false")
+	if mysqlSrc.identCase != "lower" {
+		t.Fatalf("identCase = %q, want lower", mysqlSrc.identCase)
 	}
 }
 
@@ -57,7 +57,7 @@ func TestNewConfiguredSourceDB_MariaDBAppliesCharsetAndIdentifiers(t *testing.T)
 	cfg := defaultMigrationConfig()
 	cfg.Source.Type = "mariadb"
 	cfg.Source.Charset = "latin1"
-	cfg.SnakeCaseIdentifiers = false
+	cfg.IdentifierCase = "lower"
 
 	src, err := newConfiguredSourceDB(&cfg)
 	if err != nil {
@@ -72,8 +72,8 @@ func TestNewConfiguredSourceDB_MariaDBAppliesCharsetAndIdentifiers(t *testing.T)
 	if mariaSrc.charset != "latin1" {
 		t.Fatalf("charset = %q, want latin1", mariaSrc.charset)
 	}
-	if mariaSrc.snakeCaseIDs {
-		t.Fatal("snakeCaseIDs = true, want false")
+	if mariaSrc.identCase != "lower" {
+		t.Fatalf("identCase = %q, want lower", mariaSrc.identCase)
 	}
 	if mariaSrc.Name() != "MariaDB" {
 		t.Fatalf("Name() = %q, want MariaDB", mariaSrc.Name())
@@ -83,7 +83,7 @@ func TestNewConfiguredSourceDB_MariaDBAppliesCharsetAndIdentifiers(t *testing.T)
 func TestNewConfiguredSourceDB_SQLiteAppliesIdentifiers(t *testing.T) {
 	cfg := defaultMigrationConfig()
 	cfg.Source.Type = "sqlite"
-	cfg.SnakeCaseIdentifiers = false
+	cfg.IdentifierCase = "lower"
 
 	src, err := newConfiguredSourceDB(&cfg)
 	if err != nil {
@@ -95,8 +95,8 @@ func TestNewConfiguredSourceDB_SQLiteAppliesIdentifiers(t *testing.T) {
 		t.Fatalf("source type = %T, want *sqliteSourceDB", src)
 	}
 
-	if sqliteSrc.snakeCaseIDs {
-		t.Fatal("snakeCaseIDs = true, want false")
+	if sqliteSrc.identCase != "lower" {
+		t.Fatalf("identCase = %q, want lower", sqliteSrc.identCase)
 	}
 }
 
@@ -149,7 +149,7 @@ func (f fakeNamedSource) SourceTableRef(Table) string                           
 func (f fakeNamedSource) SupportsSnapshotMode() bool                                 { return false }
 func (f fakeNamedSource) MaxWorkers() int                                            { return 0 }
 func (f fakeNamedSource) ValidateTypeMapping(TypeMappingConfig) error                { return nil }
-func (f fakeNamedSource) SetSnakeCaseIdentifiers(bool)                               {}
+func (f fakeNamedSource) SetIdentifierCase(string)                                   {}
 func (f fakeNamedSource) SetCharset(string)                                          {}
 func (f fakeNamedSource) SetSourceSchema(string)                                     {}
 

--- a/wizard.go
+++ b/wizard.go
@@ -255,6 +255,7 @@ func collectGeneratedConfig(w *wizardPrompter, configDir string) (*MigrationConf
 	cfg.IdentifierCase, err = w.promptChoice("Identifier casing", []wizardOption{
 		{key: "snake", help: "OrderItems -> order_items, USER_ID -> user_id. Cleanest PostgreSQL style; recommended default."},
 		{key: "lower", help: "OrderItems -> orderitems. Lowercase only — no boundary insertion."},
+		{key: "preserve", help: "OrderItems -> OrderItems. Keeps source casing; PostgreSQL DDL is always quoted so mixed case is safe."},
 	}, cfg.IdentifierCase)
 	if err != nil {
 		return nil, err

--- a/wizard.go
+++ b/wizard.go
@@ -252,11 +252,10 @@ func collectGeneratedConfig(w *wizardPrompter, configDir string) (*MigrationConf
 		return nil, err
 	}
 
-	cfg.SnakeCaseIdentifiers, err = w.promptBoolGuided(
-		"Convert identifiers to snake_case",
-		cfg.SnakeCaseIdentifiers,
-		"Produces cleaner PostgreSQL names, for example OrderItems -> order_items and USER_ID -> user_id. If turned off, pgferry only lowercases names, so OrderItems becomes orderitems instead. Leave it on unless existing SQL or application code depends on the original source naming.",
-	)
+	cfg.IdentifierCase, err = w.promptChoice("Identifier casing", []wizardOption{
+		{key: "snake", help: "OrderItems -> order_items, USER_ID -> user_id. Cleanest PostgreSQL style; recommended default."},
+		{key: "lower", help: "OrderItems -> orderitems. Lowercase only — no boundary insertion."},
+	}, cfg.IdentifierCase)
 	if err != nil {
 		return nil, err
 	}
@@ -614,8 +613,8 @@ func renderConfigTOML(cfg *MigrationConfig) string {
 	if !cfg.CleanOrphans {
 		writeLine("clean_orphans = false")
 	}
-	if !cfg.SnakeCaseIdentifiers {
-		writeLine("snake_case_identifiers = false")
+	if cfg.IdentifierCase != "" && cfg.IdentifierCase != "snake" {
+		writeLine("identifier_case = %q", cfg.IdentifierCase)
 	}
 	if cfg.ReplicateOnUpdateCurrentTimestamp {
 		writeLine("replicate_on_update_current_timestamp = true")

--- a/wizard_test.go
+++ b/wizard_test.go
@@ -718,3 +718,45 @@ func TestRenderConfigTOMLIncludesNewTypeMappingOptions(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderConfigTOML_EmitsIdentifierCasePreserve(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Source.Type = "mysql"
+	cfg.Source.DSN = "root:root@tcp(127.0.0.1:3306)/sakila"
+	cfg.Target.DSN = "postgres://postgres:postgres@127.0.0.1:5432/target?sslmode=disable"
+	cfg.Schema = "sakila"
+	cfg.IdentifierCase = "preserve"
+
+	rendered := renderConfigTOML(&cfg)
+	if !strings.Contains(rendered, `identifier_case = "preserve"`) {
+		t.Fatalf("expected identifier_case = \"preserve\" in rendered config, got:\n%s", rendered)
+	}
+}
+
+func TestRenderConfigTOML_EmitsIdentifierCaseLower(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Source.Type = "mysql"
+	cfg.Source.DSN = "root:root@tcp(127.0.0.1:3306)/sakila"
+	cfg.Target.DSN = "postgres://postgres:postgres@127.0.0.1:5432/target?sslmode=disable"
+	cfg.Schema = "sakila"
+	cfg.IdentifierCase = "lower"
+
+	rendered := renderConfigTOML(&cfg)
+	if !strings.Contains(rendered, `identifier_case = "lower"`) {
+		t.Fatalf("expected identifier_case = \"lower\" in rendered config, got:\n%s", rendered)
+	}
+}
+
+func TestRenderConfigTOML_OmitsIdentifierCaseWhenDefault(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Source.Type = "mysql"
+	cfg.Source.DSN = "root:root@tcp(127.0.0.1:3306)/sakila"
+	cfg.Target.DSN = "postgres://postgres:postgres@127.0.0.1:5432/target?sslmode=disable"
+	cfg.Schema = "sakila"
+	// IdentifierCase left at the default "snake".
+
+	rendered := renderConfigTOML(&cfg)
+	if strings.Contains(rendered, "identifier_case") {
+		t.Fatalf("expected rendered config to omit identifier_case at default, got:\n%s", rendered)
+	}
+}

--- a/wizard_test.go
+++ b/wizard_test.go
@@ -113,7 +113,7 @@ func TestRunGenerateWizardRunsGeneratedConfig(t *testing.T) {
 		"",    // source_snapshot_mode = none
 		"",    // unlogged_tables = true
 		"",    // preserve_defaults = true
-		"",    // snake_case_identifiers = true
+		"",    // identifier_case = snake
 		"",    // clean_orphans = true
 		"",    // workers = default
 		"",    // json_as_jsonb = true
@@ -420,7 +420,7 @@ func TestRunGenerateWizardConfiguresAdvancedOptions(t *testing.T) {
 		"",             // source_snapshot_mode = none
 		"n",            // unlogged_tables = false so resume can be enabled
 		"",             // preserve_defaults = true
-		"",             // snake_case_identifiers = true
+		"",             // identifier_case = snake
 		"",             // clean_orphans = true
 		"4",            // workers
 		"",             // json_as_jsonb = true
@@ -488,7 +488,7 @@ func TestCollectGeneratedConfigAdvancedResumeInvalidCombinationRePrompts(t *test
 		"",  // source_snapshot_mode = none
 		"",  // unlogged_tables = true
 		"",  // preserve_defaults = true
-		"",  // snake_case_identifiers = true
+		"",  // identifier_case = snake
 		"",  // clean_orphans = true
 		"",  // workers = default
 		"",  // json_as_jsonb = true


### PR DESCRIPTION
Closes #193.

## Summary

- Replaces the `snake_case_identifiers` bool with an `identifier_case` string enum accepting `"snake"` (default), `"lower"`, and `"preserve"`. `"preserve"` keeps source identifier casing unchanged (e.g. MSSQL `PascalCase` stays `PascalCase`), relying on pgferry's existing quoted-DDL emission.
- Clean break: old `snake_case_identifiers` TOML key is rejected by the existing unknown-key check. Pre-1.0 tool; release notes should call out the one-line rename for users.
- End-to-end coverage: config validation, all three source backends (MySQL/MariaDB, SQLite, MSSQL), checkpoint compatibility fingerprint, plan summary, startup log, status printer, wizard prompt, identifier-collision hint, and docs.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — green
- [x] `bun run build` in `site/` — 53 pages, no broken links
- [x] `grep -rE "SnakeCaseIdentifiers|snake_case_identifiers|SetSnakeCaseIdentifiers|snakeCaseIDs|SnakeCaseIDs"` over Go + Markdown + TOML — zero hits
- [ ] `go test -tags integration -run TestIntegration_MSSQL_IdentifierCasePreserve -count=1 -v ./...` against live MSSQL + Postgres (new test compiles locally but wasn't executed — no MSSQL available in the dev env)