### PR TITLE
test(integration): broaden coverage (filters, validate, multi-source parity)

### DIFF
--- a/integration_extended_test.go
+++ b/integration_extended_test.go
@@ -257,6 +257,39 @@ dsn = %q
 	assertRowCount(t, pgPool, pgSchema, "comments", 10)
 }
 
+func TestIntegration_MariaDB_ValidateStandaloneRowCount(t *testing.T) {
+	mariaDSN, pgDSN := requireMariaDBAndPostgresDSNs(t)
+
+	db, err := sql.Open("mysql", mariaDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mariadb: %v", err)
+	}
+	defer db.Close()
+	seedMySQLNoOrphans(t, db)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_validate_standalone_maria")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+validation = "row_count"
+
+[source]
+type = "mariadb"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, mariaDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+	runValidateFromConfig(t, cfgPath)
+}
+
 func TestIntegration_MariaDB_ValidationSampledHashMismatchAfterHook(t *testing.T) {
 	mariaDSN, pgDSN := requireMariaDBAndPostgresDSNs(t)
 
@@ -815,6 +848,32 @@ func TestIntegration_SQLite_ResumeAfterChunkFailure(t *testing.T) {
 	}
 
 	assertRowCount(t, pgPool, pgSchema, "events", 5)
+
+	seqName := generatedSequenceName(Table{PGName: "events"}, Column{PGName: "id"})
+	var (
+		lastValue int64
+		isCalled  bool
+	)
+	err = pgPool.QueryRow(ctx,
+		fmt.Sprintf("SELECT last_value, is_called FROM %s", pgQualifiedIdent(pgSchema, seqName)),
+	).Scan(&lastValue, &isCalled)
+	if err != nil {
+		t.Fatalf("query resumed sequence state: %v", err)
+	}
+	if lastValue != 6 || isCalled {
+		t.Fatalf("sequence state after resume = last_value:%d is_called:%t, want last_value:6 is_called:false", lastValue, isCalled)
+	}
+
+	var nextID int64
+	err = pgPool.QueryRow(ctx,
+		fmt.Sprintf("INSERT INTO %s.events (happened_at, note) VALUES ('2024-01-06 06:07:08', 'after-resume') RETURNING id", pgIdent(pgSchema)),
+	).Scan(&nextID)
+	if err != nil {
+		t.Fatalf("insert after resume: %v", err)
+	}
+	if nextID != 6 {
+		t.Fatalf("next inserted id after resume = %d, want 6", nextID)
+	}
 }
 
 // --- Standalone pgferry validate (live source + target) ---
@@ -1012,6 +1071,7 @@ dsn = %q
 	runMigrationFromConfig(t, cfgPath)
 
 	assertRowCount(t, pgPool, pgSchema, "users", 3)
+	assertRowCount(t, pgPool, pgSchema, "orders", 3)
 }
 
 func TestIntegration_MSSQL_SchemaOnly(t *testing.T) {

--- a/integration_extended_test.go
+++ b/integration_extended_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/spf13/cobra"
 )
 
@@ -54,6 +53,8 @@ func introspectMSSQLSchemaForTest(t *testing.T, mssqlDSN string) (*mssqlSourceDB
 
 func runValidateFromConfig(t *testing.T, cfgPath string) {
 	t.Helper()
+	prev, prevV := configPath, validateConfigPath
+	t.Cleanup(func() { configPath, validateConfigPath = prev, prevV })
 	configPath = ""
 	validateConfigPath = ""
 	if err := runValidate(&cobra.Command{}, []string{cfgPath}); err != nil {
@@ -461,16 +462,12 @@ func TestIntegration_SQLite_SchemaOnly(t *testing.T) {
 	if pgDSN == "" {
 		t.Skip("POSTGRES_DSN env var required")
 	}
-	ctx := context.Background()
 	tmpDir := t.TempDir()
 	sqliteFile := filepath.Join(tmpDir, "test.db")
 	seedSQLite(t, sqliteFile)
 
-	pgPool, err := pgxpool.New(ctx, pgDSN)
-	if err != nil {
-		t.Fatalf("connect pg: %v", err)
-	}
-	defer pgPool.Close()
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_sqlite_schema_only")
 	ensureDroppedSchema(t, pgPool, pgSchema)
@@ -478,7 +475,6 @@ func TestIntegration_SQLite_SchemaOnly(t *testing.T) {
 
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
 schema_only = true
-unlogged_tables = true
 
 [source]
 type = "sqlite"
@@ -530,11 +526,8 @@ func TestIntegration_SQLite_DataOnly_PrecreatedSchema(t *testing.T) {
 		t.Fatalf("introspect: %v", err)
 	}
 
-	pgPool, err := pgxpool.New(ctx, pgDSN)
-	if err != nil {
-		t.Fatalf("connect pg: %v", err)
-	}
-	defer pgPool.Close()
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_sqlite_data_only")
 	ensureDroppedSchema(t, pgPool, pgSchema)
@@ -604,11 +597,8 @@ func TestIntegration_SQLite_SchemaOnlyThenDataOnly(t *testing.T) {
 	sqliteFile := filepath.Join(tmpDir, "test.db")
 	seedSQLite(t, sqliteFile)
 
-	pgPool, err := pgxpool.New(ctx, pgDSN)
-	if err != nil {
-		t.Fatalf("connect pg: %v", err)
-	}
-	defer pgPool.Close()
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_sqlite_split")
 	ensureDroppedSchema(t, pgPool, pgSchema)
@@ -647,7 +637,7 @@ dsn = %q
 	assertRowCount(t, pgPool, pgSchema, "comments", 10)
 
 	var body string
-	err = pgPool.QueryRow(ctx,
+	err := pgPool.QueryRow(ctx,
 		fmt.Sprintf("SELECT body FROM %s.posts WHERE id = 1", pgIdent(pgSchema)),
 	).Scan(&body)
 	if err != nil {
@@ -780,6 +770,10 @@ func TestIntegration_SQLite_ResumeAfterChunkFailure(t *testing.T) {
 	err = migrateData(ctx, dataCfg)
 	if err == nil {
 		t.Fatal("expected migrateData to fail on invalid timestamp chunk")
+	}
+	low := strings.ToLower(err.Error())
+	if !strings.Contains(low, "timestamp") && !strings.Contains(low, "invalid") && !strings.Contains(low, "parse") && !strings.Contains(low, "date/time") && !strings.Contains(low, "datetime") {
+		t.Fatalf("unexpected migrateData error (want timestamp/parse failure): %v", err)
 	}
 
 	assertRowCount(t, pgPool, pgSchema, "events", 2)

--- a/integration_extended_test.go
+++ b/integration_extended_test.go
@@ -1,0 +1,1236 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/spf13/cobra"
+)
+
+func requireMariaDBAndPostgresDSNs(t *testing.T) (string, string) {
+	t.Helper()
+	maria := os.Getenv("MARIADB_DSN")
+	pg := os.Getenv("POSTGRES_DSN")
+	if maria == "" || pg == "" {
+		t.Skip("MARIADB_DSN and POSTGRES_DSN env vars required")
+	}
+	return maria, pg
+}
+
+func introspectMSSQLSchemaForTest(t *testing.T, mssqlDSN string) (*mssqlSourceDB, *Schema) {
+	t.Helper()
+
+	dsn := normalizeIntegrationMSSQLDSN(mssqlDSN)
+	src := &mssqlSourceDB{}
+	src.SetIdentifierCase("snake")
+	src.SetSourceSchema("sales")
+
+	db, err := src.OpenDB(dsn)
+	if err != nil {
+		t.Fatalf("open mssql for introspection: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	dbName, err := src.ExtractDBName(dsn)
+	if err != nil {
+		t.Fatalf("extract db name: %v", err)
+	}
+
+	schema, err := src.IntrospectSchema(db, dbName)
+	if err != nil {
+		t.Fatalf("introspect schema: %v", err)
+	}
+	return src, schema
+}
+
+func runValidateFromConfig(t *testing.T, cfgPath string) {
+	t.Helper()
+	configPath = ""
+	validateConfigPath = ""
+	if err := runValidate(&cobra.Command{}, []string{cfgPath}); err != nil {
+		t.Fatalf("runValidate(%s): %v", cfgPath, err)
+	}
+}
+
+// seedSQLiteResumeFixture creates an events table with one row that cannot be loaded into timestamptz.
+func seedSQLiteResumeFixture(t *testing.T, dbPath string) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	stmts := []string{
+		"DROP TABLE IF EXISTS events",
+		`CREATE TABLE events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			happened_at DATETIME NOT NULL,
+			note TEXT NOT NULL
+		)`,
+		"INSERT INTO events (happened_at, note) VALUES ('2024-01-01 01:02:03', 'one')",
+		"INSERT INTO events (happened_at, note) VALUES ('2024-01-02 02:03:04', 'two')",
+		"INSERT INTO events (happened_at, note) VALUES ('2024-01-03 03:04:05', 'three')",
+		"INSERT INTO events (happened_at, note) VALUES ('not-a-valid-timestamp', 'bad-four')",
+		"INSERT INTO events (happened_at, note) VALUES ('2024-01-05 05:06:07', 'five')",
+	}
+
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed sqlite resume %q: %v", stmt[:min(len(stmt), 60)], err)
+		}
+	}
+}
+
+// --- MariaDB parity with selected MySQL-only scenarios ---
+
+func TestIntegration_MariaDB_SingleTx(t *testing.T) {
+	mariaDSN, pgDSN := requireMariaDBAndPostgresDSNs(t)
+	ctx := context.Background()
+
+	db, err := sql.Open("mysql", mariaDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mariadb: %v", err)
+	}
+	defer db.Close()
+	seedMySQLNoOrphans(t, db)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_maria_single_tx")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+workers = 4
+chunk_size = 2
+source_snapshot_mode = "single_tx"
+
+[source]
+type = "mariadb"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, mariaDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 5)
+	assertRowCount(t, pgPool, pgSchema, "posts", 5)
+	assertRowCount(t, pgPool, pgSchema, "comments", 10)
+	assertFKExists(t, pgPool, pgSchema, "posts", "users")
+
+	var name string
+	err = pgPool.QueryRow(ctx, fmt.Sprintf("SELECT name FROM %s.users WHERE id = 1", pgIdent(pgSchema))).Scan(&name)
+	if err != nil {
+		t.Fatalf("query migrated user: %v", err)
+	}
+	if name != "Alice" {
+		t.Fatalf("name = %q, want Alice", name)
+	}
+}
+
+func TestIntegration_MariaDB_ValidationRowCount(t *testing.T) {
+	mariaDSN, pgDSN := requireMariaDBAndPostgresDSNs(t)
+
+	db, err := sql.Open("mysql", mariaDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mariadb: %v", err)
+	}
+	defer db.Close()
+	seedMySQLNoOrphans(t, db)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_maria_validate_rows")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+validation = "row_count"
+
+[source]
+type = "mariadb"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, mariaDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 5)
+	assertRowCount(t, pgPool, pgSchema, "posts", 5)
+	assertRowCount(t, pgPool, pgSchema, "comments", 10)
+}
+
+func TestIntegration_MariaDB_ValidationRowCountMismatchAfterHook(t *testing.T) {
+	mariaDSN, pgDSN := requireMariaDBAndPostgresDSNs(t)
+
+	db, err := sql.Open("mysql", mariaDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mariadb: %v", err)
+	}
+	defer db.Close()
+	seedMySQLNoOrphans(t, db)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_maria_validate_rows_fail")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "after_data.sql"), []byte(`DELETE FROM {{schema}}.users WHERE id = 1;`), 0644); err != nil {
+		t.Fatalf("write after_data hook: %v", err)
+	}
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+validation = "row_count"
+
+[source]
+type = "mariadb"
+dsn = %q
+
+[target]
+dsn = %q
+
+[hooks]
+after_data = ["after_data.sql"]
+`, pgSchema, mariaDSN, pgDSN))
+
+	err = runMigrationFromConfigExpectError(t, cfgPath)
+	if !strings.Contains(err.Error(), "row count mismatch") || !strings.Contains(err.Error(), "users") {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+func TestIntegration_MariaDB_ValidationSampledHash(t *testing.T) {
+	mariaDSN, pgDSN := requireMariaDBAndPostgresDSNs(t)
+
+	db, err := sql.Open("mysql", mariaDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mariadb: %v", err)
+	}
+	defer db.Close()
+	seedMySQLNoOrphans(t, db)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_maria_validate_hash")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+validation = "sampled_hash"
+
+[source]
+type = "mariadb"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, mariaDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 5)
+	assertRowCount(t, pgPool, pgSchema, "posts", 5)
+	assertRowCount(t, pgPool, pgSchema, "comments", 10)
+}
+
+func TestIntegration_MariaDB_ValidationSampledHashMismatchAfterHook(t *testing.T) {
+	mariaDSN, pgDSN := requireMariaDBAndPostgresDSNs(t)
+
+	db, err := sql.Open("mysql", mariaDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mariadb: %v", err)
+	}
+	defer db.Close()
+	seedMySQLNoOrphans(t, db)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_maria_validate_hash_fail")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "after_data.sql"), []byte(`UPDATE {{schema}}.users SET name = 'Mallory' WHERE id = 1;`), 0644); err != nil {
+		t.Fatalf("write after_data hook: %v", err)
+	}
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+validation = "sampled_hash"
+
+[source]
+type = "mariadb"
+dsn = %q
+
+[target]
+dsn = %q
+
+[hooks]
+after_data = ["after_data.sql"]
+`, pgSchema, mariaDSN, pgDSN))
+
+	err = runMigrationFromConfigExpectError(t, cfgPath)
+	if !strings.Contains(err.Error(), "sampled_hash mismatch") || !strings.Contains(err.Error(), "users") {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+func TestIntegration_MariaDB_ResumeAfterChunkFailure(t *testing.T) {
+	mariaDSN, pgDSN := requireMariaDBAndPostgresDSNs(t)
+	ctx := context.Background()
+
+	mariaDB, err := sql.Open("mysql", mariaDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mariadb: %v", err)
+	}
+	defer mariaDB.Close()
+	seedMySQLResumeFixture(t, mariaDB)
+
+	src := &mariadbSourceDB{}
+	src.SetIdentifierCase("snake")
+
+	sourceDB, err := src.OpenDB(mariaDSN)
+	if err != nil {
+		t.Fatalf("open mariadb for introspection: %v", err)
+	}
+	defer sourceDB.Close()
+	sourceDB.SetMaxOpenConns(1)
+
+	dbName, err := src.ExtractDBName(mariaDSN)
+	if err != nil {
+		t.Fatalf("extract db name: %v", err)
+	}
+	schema, err := src.IntrospectSchema(sourceDB, dbName)
+	if err != nil {
+		t.Fatalf("introspect schema: %v", err)
+	}
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_maria_resume")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+	if _, err := pgPool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA %s", pgIdent(pgSchema))); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	cfg := &MigrationConfig{
+		Source:             SourceConfig{Type: "mariadb", DSN: mariaDSN},
+		Target:             TargetConfig{DSN: pgDSN},
+		Schema:             pgSchema,
+		IncludeTables:      []string{"events"},
+		Workers:            1,
+		ChunkSize:          2,
+		Resume:             true,
+		UnloggedTables:     false,
+		PreserveDefaults:   true,
+		OnSchemaExists:     "error",
+		SourceSnapshotMode: "none",
+		IdentifierCase:     "snake",
+		Validation:         "none",
+		TypeMapping:        defaultTypeMappingConfig(),
+		configDir:          tmpDir,
+	}
+	schema, _, err = filterSchemaTables(schema, cfg)
+	if err != nil {
+		t.Fatalf("filter schema: %v", err)
+	}
+	cfg.TypeMapping.ZeroDateMode = "error"
+	typeMap := effectiveTypeMapping(cfg)
+	compat, err := buildCheckpointCompatibility(cfg, schema, src, dbName, typeMap)
+	if err != nil {
+		t.Fatalf("buildCheckpointCompatibility: %v", err)
+	}
+
+	if err := createTables(ctx, pgPool, schema, pgSchema, false, cfg.PreserveDefaults, typeMap, src); err != nil {
+		t.Fatalf("createTables: %v", err)
+	}
+
+	dataCfg := migrateDataConfig{
+		Src:                 src,
+		SrcDSN:              mariaDSN,
+		Pool:                pgPool,
+		Schema:              schema,
+		PGSchema:            pgSchema,
+		Workers:             1,
+		TypeMap:             typeMap,
+		SourceSnapshotMode:  "none",
+		ChunkSize:           2,
+		Resume:              true,
+		ConfigDir:           tmpDir,
+		ResumeCompatibility: compat,
+	}
+
+	err = migrateData(ctx, dataCfg)
+	if err == nil {
+		t.Fatal("expected migrateData to fail on zero datetime chunk")
+	}
+	if !strings.Contains(err.Error(), "zero date/time value") {
+		t.Fatalf("unexpected migrateData error: %v", err)
+	}
+
+	assertRowCount(t, pgPool, pgSchema, "events", 2)
+
+	cpPath := checkpointPath(tmpDir)
+	state, err := loadCheckpoint(cpPath)
+	if err != nil {
+		t.Fatalf("loadCheckpoint: %v", err)
+	}
+	if state == nil || state.Tables["events"] == nil {
+		t.Fatalf("checkpoint state = %+v, want events progress", state)
+	}
+	if !state.isChunkCompleted("events", 0) {
+		t.Fatalf("checkpoint should mark first chunk completed: %+v", state.Tables["events"])
+	}
+	if state.isChunkCompleted("events", 1) {
+		t.Fatalf("checkpoint should not mark failed chunk completed: %+v", state.Tables["events"])
+	}
+
+	if _, err := mariaDB.Exec(`UPDATE events SET happened_at = '2024-01-04 04:05:06' WHERE id = 4`); err != nil {
+		t.Fatalf("fix source row: %v", err)
+	}
+
+	if err := migrateData(ctx, dataCfg); err != nil {
+		t.Fatalf("resume migrateData: %v", err)
+	}
+	if _, err := os.Stat(cpPath); !os.IsNotExist(err) {
+		t.Fatalf("checkpoint file should be removed after successful resume, stat err=%v", err)
+	}
+
+	if err := postMigrate(ctx, pgPool, schema, cfg); err != nil {
+		t.Fatalf("postMigrate: %v", err)
+	}
+
+	assertRowCount(t, pgPool, pgSchema, "events", 5)
+
+	seqName := generatedSequenceName(Table{PGName: "events"}, Column{PGName: "id"})
+	var (
+		lastValue int64
+		isCalled  bool
+	)
+	err = pgPool.QueryRow(ctx,
+		fmt.Sprintf("SELECT last_value, is_called FROM %s", pgQualifiedIdent(pgSchema, seqName)),
+	).Scan(&lastValue, &isCalled)
+	if err != nil {
+		t.Fatalf("query resumed sequence state: %v", err)
+	}
+	if lastValue != 6 || isCalled {
+		t.Fatalf("sequence state after resume = last_value:%d is_called:%t, want last_value:6 is_called:false", lastValue, isCalled)
+	}
+
+	var nextID int64
+	err = pgPool.QueryRow(ctx,
+		fmt.Sprintf("INSERT INTO %s.events (happened_at, note) VALUES ('2024-01-06 06:07:08', 'after-resume') RETURNING id", pgIdent(pgSchema)),
+	).Scan(&nextID)
+	if err != nil {
+		t.Fatalf("insert after resume: %v", err)
+	}
+	if nextID != 6 {
+		t.Fatalf("next inserted id after resume = %d, want 6", nextID)
+	}
+}
+
+// --- SQLite: schema/data split, validation, resume, standalone validate ---
+
+func TestIntegration_SQLite_SchemaOnly(t *testing.T) {
+	pgDSN := os.Getenv("POSTGRES_DSN")
+	if pgDSN == "" {
+		t.Skip("POSTGRES_DSN env var required")
+	}
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	sqliteFile := filepath.Join(tmpDir, "test.db")
+	seedSQLite(t, sqliteFile)
+
+	pgPool, err := pgxpool.New(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect pg: %v", err)
+	}
+	defer pgPool.Close()
+
+	pgSchema := integrationSchemaName("inttest_sqlite_schema_only")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+schema_only = true
+unlogged_tables = true
+
+[source]
+type = "sqlite"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, sqliteFile, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 0)
+	assertRowCount(t, pgPool, pgSchema, "posts", 0)
+	assertRowCount(t, pgPool, pgSchema, "comments", 0)
+
+	for _, tbl := range []string{"users", "posts", "comments"} {
+		assertPKExists(t, pgPool, pgSchema, tbl)
+		assertTablePersistence(t, pgPool, pgSchema, tbl, "p")
+	}
+	assertFKExists(t, pgPool, pgSchema, "posts", "users")
+	assertFKExists(t, pgPool, pgSchema, "comments", "posts")
+	assertFKExists(t, pgPool, pgSchema, "comments", "users")
+}
+
+func TestIntegration_SQLite_DataOnly_PrecreatedSchema(t *testing.T) {
+	pgDSN := os.Getenv("POSTGRES_DSN")
+	if pgDSN == "" {
+		t.Skip("POSTGRES_DSN env var required")
+	}
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	sqliteFile := filepath.Join(tmpDir, "test.db")
+	seedSQLite(t, sqliteFile)
+
+	src := &sqliteSourceDB{}
+	src.SetIdentifierCase("snake")
+	db, err := src.OpenDB(sqliteFile)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	dbName, err := src.ExtractDBName(sqliteFile)
+	if err != nil {
+		t.Fatalf("extract db name: %v", err)
+	}
+	schema, err := src.IntrospectSchema(db, dbName)
+	if err != nil {
+		t.Fatalf("introspect: %v", err)
+	}
+
+	pgPool, err := pgxpool.New(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect pg: %v", err)
+	}
+	defer pgPool.Close()
+
+	pgSchema := integrationSchemaName("inttest_sqlite_data_only")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	if _, err := pgPool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA %s", pgIdent(pgSchema))); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	preCfg := &MigrationConfig{
+		Schema:           pgSchema,
+		SchemaOnly:       true,
+		PreserveDefaults: true,
+		CleanOrphans:     true,
+		TypeMapping:      defaultTypeMappingConfig(),
+	}
+	if err := createTables(ctx, pgPool, schema, pgSchema, false, preCfg.PreserveDefaults, preCfg.TypeMapping, src); err != nil {
+		t.Fatalf("precreate tables: %v", err)
+	}
+	if err := postMigrate(ctx, pgPool, schema, preCfg); err != nil {
+		t.Fatalf("precreate post-migrate: %v", err)
+	}
+
+	if _, err := pgPool.Exec(ctx, fmt.Sprintf("CREATE TABLE %s.manual_marker (note text)", pgIdent(pgSchema))); err != nil {
+		t.Fatalf("create marker table: %v", err)
+	}
+	if _, err := pgPool.Exec(ctx, fmt.Sprintf("INSERT INTO %s.manual_marker (note) VALUES ('keep-me')", pgIdent(pgSchema))); err != nil {
+		t.Fatalf("insert marker row: %v", err)
+	}
+
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+data_only = true
+
+[source]
+type = "sqlite"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, sqliteFile, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 5)
+	assertRowCount(t, pgPool, pgSchema, "posts", 5)
+	assertRowCount(t, pgPool, pgSchema, "comments", 10)
+
+	var markerCount int
+	err = pgPool.QueryRow(ctx,
+		fmt.Sprintf("SELECT COUNT(*) FROM %s.manual_marker", pgIdent(pgSchema)),
+	).Scan(&markerCount)
+	if err != nil {
+		t.Fatalf("count marker rows: %v", err)
+	}
+	if markerCount != 1 {
+		t.Errorf("manual_marker row count: got %d, want 1", markerCount)
+	}
+}
+
+func TestIntegration_SQLite_SchemaOnlyThenDataOnly(t *testing.T) {
+	pgDSN := os.Getenv("POSTGRES_DSN")
+	if pgDSN == "" {
+		t.Skip("POSTGRES_DSN env var required")
+	}
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	sqliteFile := filepath.Join(tmpDir, "test.db")
+	seedSQLite(t, sqliteFile)
+
+	pgPool, err := pgxpool.New(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect pg: %v", err)
+	}
+	defer pgPool.Close()
+
+	pgSchema := integrationSchemaName("inttest_sqlite_split")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	schemaOnlyCfg := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+schema_only = true
+
+[source]
+type = "sqlite"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, sqliteFile, pgDSN))
+
+	runMigrationFromConfig(t, schemaOnlyCfg)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 0)
+
+	dataOnlyCfg := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+data_only = true
+
+[source]
+type = "sqlite"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, sqliteFile, pgDSN))
+
+	runMigrationFromConfig(t, dataOnlyCfg)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 5)
+	assertRowCount(t, pgPool, pgSchema, "posts", 5)
+	assertRowCount(t, pgPool, pgSchema, "comments", 10)
+
+	var body string
+	err = pgPool.QueryRow(ctx,
+		fmt.Sprintf("SELECT body FROM %s.posts WHERE id = 1", pgIdent(pgSchema)),
+	).Scan(&body)
+	if err != nil {
+		t.Fatalf("spot-check split-mode post body: %v", err)
+	}
+	if body != "Hello world" {
+		t.Errorf("posts.id=1 body: got %q, want %q", body, "Hello world")
+	}
+}
+
+func TestIntegration_SQLite_ValidationRowCount(t *testing.T) {
+	pgDSN := os.Getenv("POSTGRES_DSN")
+	if pgDSN == "" {
+		t.Skip("POSTGRES_DSN env var required")
+	}
+	tmpDir := t.TempDir()
+	sqliteFile := filepath.Join(tmpDir, "test.db")
+	seedSQLite(t, sqliteFile)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_sqlite_validate")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+validation = "row_count"
+
+[source]
+type = "sqlite"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, sqliteFile, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 5)
+	assertRowCount(t, pgPool, pgSchema, "posts", 5)
+	assertRowCount(t, pgPool, pgSchema, "comments", 10)
+}
+
+func TestIntegration_SQLite_ResumeAfterChunkFailure(t *testing.T) {
+	pgDSN := os.Getenv("POSTGRES_DSN")
+	if pgDSN == "" {
+		t.Skip("POSTGRES_DSN env var required")
+	}
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	sqliteFile := filepath.Join(tmpDir, "resume.db")
+	seedSQLiteResumeFixture(t, sqliteFile)
+
+	src := &sqliteSourceDB{}
+	src.SetIdentifierCase("snake")
+
+	sourceDB, err := src.OpenDB(sqliteFile)
+	if err != nil {
+		t.Fatalf("open sqlite for introspection: %v", err)
+	}
+	defer sourceDB.Close()
+	sourceDB.SetMaxOpenConns(1)
+
+	dbName, err := src.ExtractDBName(sqliteFile)
+	if err != nil {
+		t.Fatalf("extract db name: %v", err)
+	}
+	schema, err := src.IntrospectSchema(sourceDB, dbName)
+	if err != nil {
+		t.Fatalf("introspect schema: %v", err)
+	}
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_sqlite_resume")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+	if _, err := pgPool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA %s", pgIdent(pgSchema))); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	cfg := &MigrationConfig{
+		Source:             SourceConfig{Type: "sqlite", DSN: sqliteFile},
+		Target:             TargetConfig{DSN: pgDSN},
+		Schema:             pgSchema,
+		IncludeTables:      []string{"events"},
+		Workers:            1,
+		ChunkSize:          2,
+		Resume:             true,
+		UnloggedTables:     false,
+		PreserveDefaults:   true,
+		OnSchemaExists:     "error",
+		SourceSnapshotMode: "none",
+		IdentifierCase:     "snake",
+		Validation:         "none",
+		TypeMapping:        defaultTypeMappingConfig(),
+		configDir:          tmpDir,
+	}
+	schema, _, err = filterSchemaTables(schema, cfg)
+	if err != nil {
+		t.Fatalf("filter schema: %v", err)
+	}
+	typeMap := effectiveTypeMapping(cfg)
+	compat, err := buildCheckpointCompatibility(cfg, schema, src, dbName, typeMap)
+	if err != nil {
+		t.Fatalf("buildCheckpointCompatibility: %v", err)
+	}
+
+	if err := createTables(ctx, pgPool, schema, pgSchema, false, cfg.PreserveDefaults, typeMap, src); err != nil {
+		t.Fatalf("createTables: %v", err)
+	}
+
+	dataCfg := migrateDataConfig{
+		Src:                 src,
+		SrcDSN:              sqliteFile,
+		Pool:                pgPool,
+		Schema:              schema,
+		PGSchema:            pgSchema,
+		Workers:             1,
+		TypeMap:             typeMap,
+		SourceSnapshotMode:  "none",
+		ChunkSize:           2,
+		Resume:              true,
+		ConfigDir:           tmpDir,
+		ResumeCompatibility: compat,
+	}
+
+	err = migrateData(ctx, dataCfg)
+	if err == nil {
+		t.Fatal("expected migrateData to fail on invalid timestamp chunk")
+	}
+
+	assertRowCount(t, pgPool, pgSchema, "events", 2)
+
+	cpPath := checkpointPath(tmpDir)
+	state, err := loadCheckpoint(cpPath)
+	if err != nil {
+		t.Fatalf("loadCheckpoint: %v", err)
+	}
+	if state == nil || state.Tables["events"] == nil {
+		t.Fatalf("checkpoint state = %+v, want events progress", state)
+	}
+
+	fixDB, err := sql.Open("sqlite", sqliteFile)
+	if err != nil {
+		t.Fatalf("open sqlite for fix: %v", err)
+	}
+	if _, err := fixDB.Exec(`UPDATE events SET happened_at = '2024-01-04 04:05:06' WHERE id = 4`); err != nil {
+		fixDB.Close()
+		t.Fatalf("fix source row: %v", err)
+	}
+	fixDB.Close()
+
+	if err := migrateData(ctx, dataCfg); err != nil {
+		t.Fatalf("resume migrateData: %v", err)
+	}
+	if _, err := os.Stat(cpPath); !os.IsNotExist(err) {
+		t.Fatalf("checkpoint file should be removed after successful resume, stat err=%v", err)
+	}
+
+	if err := postMigrate(ctx, pgPool, schema, cfg); err != nil {
+		t.Fatalf("postMigrate: %v", err)
+	}
+
+	assertRowCount(t, pgPool, pgSchema, "events", 5)
+}
+
+// --- Standalone pgferry validate (live source + target) ---
+
+func TestIntegration_MySQL_ValidateStandaloneRowCount(t *testing.T) {
+	mysqlDSN, pgDSN := requireMySQLAndPostgresDSNs(t)
+
+	db, err := sql.Open("mysql", mysqlDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	defer db.Close()
+	seedMySQLNoOrphans(t, db)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_validate_standalone_mysql")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+validation = "row_count"
+
+[source]
+type = "mysql"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, mysqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+	runValidateFromConfig(t, cfgPath)
+}
+
+func TestIntegration_SQLite_ValidateStandaloneRowCount(t *testing.T) {
+	pgDSN := os.Getenv("POSTGRES_DSN")
+	if pgDSN == "" {
+		t.Skip("POSTGRES_DSN env var required")
+	}
+	tmpDir := t.TempDir()
+	sqliteFile := filepath.Join(tmpDir, "test.db")
+	seedSQLite(t, sqliteFile)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_validate_standalone_sqlite")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+validation = "row_count"
+
+[source]
+type = "sqlite"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, sqliteFile, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+	runValidateFromConfig(t, cfgPath)
+}
+
+// --- MSSQL: single_tx, validation, schema/data split ---
+
+func TestIntegration_MSSQL_SingleTx(t *testing.T) {
+	mssqlDSN, pgDSN := requireMSSQLAndPostgresDSNs(t)
+	ctx := context.Background()
+
+	mssqlDB, err := sql.Open("sqlserver", mssqlDSN)
+	if err != nil {
+		t.Fatalf("open mssql: %v", err)
+	}
+	defer mssqlDB.Close()
+	seedMSSQL(t, mssqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_mssql_single_tx")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+workers = 4
+chunk_size = 2
+source_snapshot_mode = "single_tx"
+
+[source]
+type = "mssql"
+dsn = %q
+source_schema = "sales"
+
+[type_mapping]
+spatial_mode = "wkt_text"
+
+[target]
+dsn = %q
+`, pgSchema, mssqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 3)
+	assertRowCount(t, pgPool, pgSchema, "orders", 3)
+	assertFKExists(t, pgPool, pgSchema, "orders", "users")
+
+	var displayName string
+	err = pgPool.QueryRow(ctx, fmt.Sprintf("SELECT display_name FROM %s.users WHERE user_id = 1", pgIdent(pgSchema))).Scan(&displayName)
+	if err != nil {
+		t.Fatalf("query user: %v", err)
+	}
+	if displayName != "Alice" {
+		t.Fatalf("display_name = %q, want Alice", displayName)
+	}
+}
+
+func TestIntegration_MSSQL_ValidationRowCount(t *testing.T) {
+	mssqlDSN, pgDSN := requireMSSQLAndPostgresDSNs(t)
+
+	mssqlDB, err := sql.Open("sqlserver", mssqlDSN)
+	if err != nil {
+		t.Fatalf("open mssql: %v", err)
+	}
+	defer mssqlDB.Close()
+	seedMSSQL(t, mssqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_mssql_validate_rows")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+validation = "row_count"
+
+[source]
+type = "mssql"
+dsn = %q
+source_schema = "sales"
+
+[type_mapping]
+spatial_mode = "wkt_text"
+
+[target]
+dsn = %q
+`, pgSchema, mssqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 3)
+	assertRowCount(t, pgPool, pgSchema, "orders", 3)
+}
+
+func TestIntegration_MSSQL_ValidationSampledHash(t *testing.T) {
+	mssqlDSN, pgDSN := requireMSSQLAndPostgresDSNs(t)
+
+	mssqlDB, err := sql.Open("sqlserver", mssqlDSN)
+	if err != nil {
+		t.Fatalf("open mssql: %v", err)
+	}
+	defer mssqlDB.Close()
+	seedMSSQL(t, mssqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_mssql_validate_hash")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+validation = "sampled_hash"
+
+[source]
+type = "mssql"
+dsn = %q
+source_schema = "sales"
+
+[type_mapping]
+spatial_mode = "wkt_text"
+
+[target]
+dsn = %q
+`, pgSchema, mssqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 3)
+}
+
+func TestIntegration_MSSQL_SchemaOnly(t *testing.T) {
+	mssqlDSN, pgDSN := requireMSSQLAndPostgresDSNs(t)
+
+	mssqlDB, err := sql.Open("sqlserver", mssqlDSN)
+	if err != nil {
+		t.Fatalf("open mssql: %v", err)
+	}
+	defer mssqlDB.Close()
+	seedMSSQL(t, mssqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_mssql_schema_only")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+schema_only = true
+
+[source]
+type = "mssql"
+dsn = %q
+source_schema = "sales"
+
+[type_mapping]
+spatial_mode = "wkt_text"
+
+[target]
+dsn = %q
+`, pgSchema, mssqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 0)
+	assertRowCount(t, pgPool, pgSchema, "orders", 0)
+
+	for _, tbl := range []string{"users", "orders", "exact_numerics", "special_types"} {
+		assertPKExists(t, pgPool, pgSchema, tbl)
+	}
+	assertFKExists(t, pgPool, pgSchema, "orders", "users")
+
+	// Skip INSERT probe: sales.Users carries computed columns that are awkward to
+	// populate manually; empty-table + DDL assertions are enough here.
+}
+
+func TestIntegration_MSSQL_SchemaOnlyThenDataOnly(t *testing.T) {
+	mssqlDSN, pgDSN := requireMSSQLAndPostgresDSNs(t)
+
+	mssqlDB, err := sql.Open("sqlserver", mssqlDSN)
+	if err != nil {
+		t.Fatalf("open mssql: %v", err)
+	}
+	defer mssqlDB.Close()
+	seedMSSQL(t, mssqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_mssql_split")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	schemaOnlyCfg := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+schema_only = true
+
+[source]
+type = "mssql"
+dsn = %q
+source_schema = "sales"
+
+[type_mapping]
+spatial_mode = "wkt_text"
+
+[target]
+dsn = %q
+`, pgSchema, mssqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, schemaOnlyCfg)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 0)
+
+	dataOnlyCfg := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+data_only = true
+
+[source]
+type = "mssql"
+dsn = %q
+source_schema = "sales"
+
+[type_mapping]
+spatial_mode = "wkt_text"
+
+[target]
+dsn = %q
+`, pgSchema, mssqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, dataOnlyCfg)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 3)
+	assertRowCount(t, pgPool, pgSchema, "orders", 3)
+	assertFKExists(t, pgPool, pgSchema, "orders", "users")
+}
+
+func TestIntegration_MSSQL_DataOnly_PrecreatedSchema(t *testing.T) {
+	mssqlDSN, pgDSN := requireMSSQLAndPostgresDSNs(t)
+	ctx := context.Background()
+
+	mssqlDB, err := sql.Open("sqlserver", mssqlDSN)
+	if err != nil {
+		t.Fatalf("open mssql: %v", err)
+	}
+	defer mssqlDB.Close()
+	seedMSSQL(t, mssqlDB)
+
+	src, schema := introspectMSSQLSchemaForTest(t, mssqlDSN)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_mssql_data_only")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	if _, err := pgPool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA %s", pgIdent(pgSchema))); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	preCfg := &MigrationConfig{
+		Schema:           pgSchema,
+		SchemaOnly:       true,
+		PreserveDefaults: true,
+		CleanOrphans:     true,
+		TypeMapping:      defaultTypeMappingConfig(),
+	}
+	preCfg.TypeMapping.SpatialMode = "wkt_text"
+	if err := createTables(ctx, pgPool, schema, pgSchema, false, preCfg.PreserveDefaults, preCfg.TypeMapping, src); err != nil {
+		t.Fatalf("precreate tables: %v", err)
+	}
+	if err := postMigrate(ctx, pgPool, schema, preCfg); err != nil {
+		t.Fatalf("precreate post-migrate: %v", err)
+	}
+
+	if _, err := pgPool.Exec(ctx, fmt.Sprintf("CREATE TABLE %s.manual_marker (note text)", pgIdent(pgSchema))); err != nil {
+		t.Fatalf("create marker table: %v", err)
+	}
+	if _, err := pgPool.Exec(ctx, fmt.Sprintf("INSERT INTO %s.manual_marker (note) VALUES ('keep-me')", pgIdent(pgSchema))); err != nil {
+		t.Fatalf("insert marker row: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+data_only = true
+
+[source]
+type = "mssql"
+dsn = %q
+source_schema = "sales"
+
+[type_mapping]
+spatial_mode = "wkt_text"
+
+[target]
+dsn = %q
+`, pgSchema, mssqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 3)
+
+	var markerCount int
+	err = pgPool.QueryRow(ctx,
+		fmt.Sprintf("SELECT COUNT(*) FROM %s.manual_marker", pgIdent(pgSchema)),
+	).Scan(&markerCount)
+	if err != nil {
+		t.Fatalf("count marker rows: %v", err)
+	}
+	if markerCount != 1 {
+		t.Errorf("manual_marker row count: got %d, want 1", markerCount)
+	}
+}
+
+func TestIntegration_MSSQL_ValidateStandaloneRowCount(t *testing.T) {
+	mssqlDSN, pgDSN := requireMSSQLAndPostgresDSNs(t)
+
+	mssqlDB, err := sql.Open("sqlserver", mssqlDSN)
+	if err != nil {
+		t.Fatalf("open mssql: %v", err)
+	}
+	defer mssqlDB.Close()
+	seedMSSQL(t, mssqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() { pgPool.Close() })
+
+	pgSchema := integrationSchemaName("inttest_mssql_validate_standalone")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+validation = "row_count"
+
+[source]
+type = "mssql"
+dsn = %q
+source_schema = "sales"
+
+[type_mapping]
+spatial_mode = "wkt_text"
+
+[target]
+dsn = %q
+`, pgSchema, mssqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+	runValidateFromConfig(t, cfgPath)
+}

--- a/integration_extended_test.go
+++ b/integration_extended_test.go
@@ -786,6 +786,12 @@ func TestIntegration_SQLite_ResumeAfterChunkFailure(t *testing.T) {
 	if state == nil || state.Tables["events"] == nil {
 		t.Fatalf("checkpoint state = %+v, want events progress", state)
 	}
+	if !state.isChunkCompleted("events", 0) {
+		t.Fatalf("checkpoint should mark first chunk completed: %+v", state.Tables["events"])
+	}
+	if state.isChunkCompleted("events", 1) {
+		t.Fatalf("checkpoint should not mark failed chunk completed: %+v", state.Tables["events"])
+	}
 
 	fixDB, err := sql.Open("sqlite", sqliteFile)
 	if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -420,15 +420,11 @@ func TestIntegration_MySQL_TableFilter_ExactExcludeComments(t *testing.T) {
 	seedMySQLNoOrphans(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_tbl_exact")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -473,15 +469,11 @@ func TestIntegration_MySQL_TableFilter_GlobIncludeMeta(t *testing.T) {
 	seedMySQLTableFilterGlob(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_tbl_glob")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -517,15 +509,11 @@ func TestIntegration_MySQL_HookBeforeDataFails(t *testing.T) {
 	seedMySQLNoOrphans(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_hook_before_data")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	badHook := filepath.Join(tmpDir, "bad_before_data.sql")
@@ -571,15 +559,11 @@ func TestIntegration_MySQL_HookBeforeFkFails(t *testing.T) {
 	seedMySQLNoOrphans(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_hook_before_fk")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	badHook := filepath.Join(tmpDir, "bad_before_fk.sql")
@@ -626,15 +610,11 @@ func TestIntegration_MySQL_CleanOrphansApplyWithoutBeforeFkHook(t *testing.T) {
 	seedMySQL(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_clean_orphans")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -679,15 +659,11 @@ func TestIntegration_MySQL_IdentifierCasePreserve(t *testing.T) {
 	seedMySQLMixedCaseIdentifiers(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_mysql_preserve")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -745,20 +721,15 @@ func TestIntegration_MySQL_SchemaOnly(t *testing.T) {
 	seedMySQLNoOrphans(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_schema_only")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
 schema_only = true
-unlogged_tables = true
 
 [source]
 type = "mysql"
@@ -812,15 +783,11 @@ func TestIntegration_MySQL_DataOnly_PrecreatedSchema(t *testing.T) {
 	src, schema := introspectMySQLSchemaForTest(t, mysqlDSN)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_data_only")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	if _, err := pgPool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA %s", pgIdent(pgSchema))); err != nil {
 		t.Fatalf("create schema: %v", err)
@@ -889,15 +856,11 @@ func TestIntegration_MySQL_SchemaOnlyThenDataOnly(t *testing.T) {
 	seedMySQLNoOrphans(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_split_mode")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	schemaOnlyCfg := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -965,15 +928,11 @@ func TestIntegration_MySQL_SequenceReset_AllowsNextInsert(t *testing.T) {
 	seedMySQL(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_sequence")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -1015,15 +974,11 @@ func TestIntegration_MySQL_SingleTx(t *testing.T) {
 	seedMySQLNoOrphans(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_single_tx")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -1068,15 +1023,11 @@ func TestIntegration_MySQL_ValidationRowCount(t *testing.T) {
 	seedMySQLNoOrphans(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_validate_rows")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -1108,15 +1059,11 @@ func TestIntegration_MySQL_ValidationRowCountMismatchAfterHook(t *testing.T) {
 	seedMySQLNoOrphans(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_validate_rows_fail")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmpDir, "after_data.sql"), []byte(`DELETE FROM {{schema}}.users WHERE id = 1;`), 0644); err != nil {
@@ -1153,15 +1100,11 @@ func TestIntegration_MySQL_ValidationSampledHash(t *testing.T) {
 	seedMySQLNoOrphans(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_validate_hash")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -1193,15 +1136,11 @@ func TestIntegration_MySQL_ValidationSampledHashMismatchAfterHook(t *testing.T) 
 	seedMySQLNoOrphans(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_validate_hash_fail")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmpDir, "after_data.sql"), []byte(`UPDATE {{schema}}.users SET name = 'Mallory' WHERE id = 1;`), 0644); err != nil {
@@ -1258,15 +1197,11 @@ func TestIntegration_MySQL_ResumeAfterChunkFailure(t *testing.T) {
 	}
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_resume")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 	if _, err := pgPool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA %s", pgIdent(pgSchema))); err != nil {
 		t.Fatalf("create schema: %v", err)
 	}
@@ -1406,18 +1341,14 @@ func TestIntegration_MySQL_PostGIS(t *testing.T) {
 	seedMySQLSpatial(t, mysqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 	if !extensionAvailable(t, pgPool, "postgis") {
 		t.Skip("postgis extension is not available on the target server")
 	}
 
 	pgSchema := integrationSchemaName("inttest_postgis")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -1492,15 +1423,11 @@ func TestIntegration_MSSQL(t *testing.T) {
 	seedMSSQL(t, mssqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_mssql")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -1664,15 +1591,11 @@ func TestIntegration_MSSQL_IdentifierCasePreserve(t *testing.T) {
 	seedMSSQL(t, mssqlDB)
 
 	pgPool := openIntegrationPGPool(t, pgDSN)
-	t.Cleanup(func() {
-		pgPool.Close()
-	})
+	t.Cleanup(func() { pgPool.Close() })
 
 	pgSchema := integrationSchemaName("inttest_mssql_preserve")
 	ensureDroppedSchema(t, pgPool, pgSchema)
-	t.Cleanup(func() {
-		dropSchema(t, pgPool, pgSchema)
-	})
+	t.Cleanup(func() { dropSchema(t, pgPool, pgSchema) })
 
 	tmpDir := t.TempDir()
 	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
@@ -2817,6 +2740,8 @@ func writeIntegrationConfig(t *testing.T, dir, content string) string {
 func runMigrationFromConfig(t *testing.T, cfgPath string) {
 	t.Helper()
 
+	prev := configPath
+	t.Cleanup(func() { configPath = prev })
 	configPath = ""
 	if err := runMigration(nil, []string{cfgPath}); err != nil {
 		t.Fatalf("runMigration(%s): %v", cfgPath, err)
@@ -2826,6 +2751,8 @@ func runMigrationFromConfig(t *testing.T, cfgPath string) {
 func runMigrationFromConfigExpectError(t *testing.T, cfgPath string) error {
 	t.Helper()
 
+	prev := configPath
+	t.Cleanup(func() { configPath = prev })
 	configPath = ""
 	err := runMigration(nil, []string{cfgPath})
 	if err == nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -408,6 +408,179 @@ dsn = %q
 	}
 }
 
+func TestIntegration_MySQL_TableFilter_ExactExcludeComments(t *testing.T) {
+	mysqlDSN, pgDSN := requireMySQLAndPostgresDSNs(t)
+	ctx := context.Background()
+
+	mysqlDB, err := sql.Open("mysql", mysqlDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	defer mysqlDB.Close()
+	seedMySQLNoOrphans(t, mysqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() {
+		pgPool.Close()
+	})
+
+	pgSchema := integrationSchemaName("inttest_tbl_exact")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() {
+		dropSchema(t, pgPool, pgSchema)
+	})
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+workers = 2
+exclude_tables = ["comments"]
+
+[source]
+type = "mysql"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, mysqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertRowCount(t, pgPool, pgSchema, "users", 5)
+	assertRowCount(t, pgPool, pgSchema, "posts", 5)
+	assertInformationSchemaTableCount(t, pgPool, pgSchema, "comments", 0)
+	assertFKExists(t, pgPool, pgSchema, "posts", "users")
+
+	var name string
+	err = pgPool.QueryRow(ctx,
+		fmt.Sprintf("SELECT name FROM %s.users WHERE id = 1", pgIdent(pgSchema)),
+	).Scan(&name)
+	if err != nil {
+		t.Fatalf("spot-check users: %v", err)
+	}
+	if name != "Alice" {
+		t.Errorf("users.name = %q, want Alice", name)
+	}
+}
+
+func TestIntegration_MySQL_TableFilter_GlobIncludeMeta(t *testing.T) {
+	mysqlDSN, pgDSN := requireMySQLAndPostgresDSNs(t)
+
+	mysqlDB, err := sql.Open("mysql", mysqlDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	defer mysqlDB.Close()
+	seedMySQLTableFilterGlob(t, mysqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() {
+		pgPool.Close()
+	})
+
+	pgSchema := integrationSchemaName("inttest_tbl_glob")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() {
+		dropSchema(t, pgPool, pgSchema)
+	})
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+workers = 2
+table_filter_mode = "glob"
+include_tables = ["meta_*"]
+exclude_tables = ["meta_skip"]
+
+[source]
+type = "mysql"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, mysqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertInformationSchemaTableCount(t, pgPool, pgSchema, "meta_keep", 1)
+	assertInformationSchemaTableCount(t, pgPool, pgSchema, "meta_skip", 0)
+	assertInformationSchemaTableCount(t, pgPool, pgSchema, "users", 0)
+	assertRowCount(t, pgPool, pgSchema, "meta_keep", 1)
+}
+
+func TestIntegration_MySQL_IdentifierCasePreserve(t *testing.T) {
+	mysqlDSN, pgDSN := requireMySQLAndPostgresDSNs(t)
+	ctx := context.Background()
+
+	mysqlDB, err := sql.Open("mysql", mysqlDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	defer mysqlDB.Close()
+
+	var lowerCaseTableNames int
+	if err := mysqlDB.QueryRow("SELECT @@lower_case_table_names").Scan(&lowerCaseTableNames); err != nil {
+		t.Fatalf("read lower_case_table_names: %v", err)
+	}
+	if lowerCaseTableNames != 0 {
+		t.Skipf("skipping: MySQL @@lower_case_table_names=%d (need 0 for case-preserved table names)", lowerCaseTableNames)
+	}
+
+	seedMySQLMixedCaseIdentifiers(t, mysqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() {
+		pgPool.Close()
+	})
+
+	pgSchema := integrationSchemaName("inttest_mysql_preserve")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() {
+		dropSchema(t, pgPool, pgSchema)
+	})
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+workers = 1
+identifier_case = "preserve"
+
+[source]
+type = "mysql"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, mysqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	assertInformationSchemaTableCount(t, pgPool, pgSchema, "UserAccounts", 1)
+	var colCount int
+	err = pgPool.QueryRow(ctx, `
+		SELECT count(*) FROM information_schema.columns
+		 WHERE table_schema = $1 AND table_name = $2 AND column_name = $3
+	`, pgSchema, "UserAccounts", "DisplayName").Scan(&colCount)
+	if err != nil {
+		t.Fatalf("query column UserAccounts.DisplayName: %v", err)
+	}
+	if colCount != 1 {
+		t.Fatalf("expected column DisplayName in %s.UserAccounts, got count=%d", pgSchema, colCount)
+	}
+
+	var display string
+	err = pgPool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT %s FROM %s.%s WHERE %s = 1`,
+			pgIdent("DisplayName"), pgIdent(pgSchema), pgIdent("UserAccounts"), pgIdent("UserID")),
+	).Scan(&display)
+	if err != nil {
+		t.Fatalf("select DisplayName: %v", err)
+	}
+	if display != "Alice" {
+		t.Fatalf("DisplayName = %q, want Alice", display)
+	}
+
+	assertInformationSchemaTableCount(t, pgPool, pgSchema, "user_accounts", 0)
+	assertInformationSchemaTableCount(t, pgPool, pgSchema, "useraccounts", 0)
+}
+
 func TestIntegration_MySQL_SchemaOnly(t *testing.T) {
 	mysqlDSN, pgDSN := requireMySQLAndPostgresDSNs(t)
 	ctx := context.Background()
@@ -1608,6 +1781,90 @@ func seedMySQLNoOrphans(t *testing.T, db *sql.DB) {
 	}
 }
 
+// seedMySQLTableFilterGlob loads users/posts/comments plus meta_keep and meta_skip for glob filter tests.
+func seedMySQLTableFilterGlob(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	stmts := []string{
+		"DROP TABLE IF EXISTS meta_skip",
+		"DROP TABLE IF EXISTS meta_keep",
+		"DROP TABLE IF EXISTS places_optional",
+		"DROP TABLE IF EXISTS places",
+		"DROP TABLE IF EXISTS events",
+		"DROP TABLE IF EXISTS comments",
+		"DROP TABLE IF EXISTS posts",
+		"DROP TABLE IF EXISTS users",
+
+		`CREATE TABLE users (
+			id INT AUTO_INCREMENT PRIMARY KEY,
+			name VARCHAR(100) NOT NULL,
+			email VARCHAR(200) NULL
+		)`,
+		`CREATE TABLE posts (
+			id INT AUTO_INCREMENT PRIMARY KEY,
+			user_id INT NOT NULL,
+			title VARCHAR(200) NOT NULL,
+			body TEXT,
+			FOREIGN KEY (user_id) REFERENCES users(id)
+		)`,
+		`CREATE TABLE comments (
+			id INT AUTO_INCREMENT PRIMARY KEY,
+			post_id INT NOT NULL,
+			user_id INT NOT NULL,
+			content TEXT,
+			FOREIGN KEY (post_id) REFERENCES posts(id),
+			FOREIGN KEY (user_id) REFERENCES users(id)
+		)`,
+		`CREATE TABLE meta_keep (
+			id INT AUTO_INCREMENT PRIMARY KEY,
+			note VARCHAR(50) NOT NULL
+		)`,
+		`CREATE TABLE meta_skip (
+			id INT AUTO_INCREMENT PRIMARY KEY,
+			junk VARCHAR(10)
+		)`,
+
+		"INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')",
+		"INSERT INTO users (name, email) VALUES ('Bob', NULL)",
+		"INSERT INTO users (name, email) VALUES ('Charlie', 'charlie@example.com')",
+		"INSERT INTO users (name, email) VALUES ('Diana', 'diana@example.com')",
+		"INSERT INTO users (name, email) VALUES ('Eve', NULL)",
+
+		"INSERT INTO posts (user_id, title, body) VALUES (1, 'First Post', 'Hello world')",
+		"INSERT INTO posts (user_id, title, body) VALUES (2, 'Bobs Post', 'Content here')",
+		"INSERT INTO posts (user_id, title, body) VALUES (3, 'Thoughts', 'Some thoughts')",
+		"INSERT INTO posts (user_id, title, body) VALUES (4, 'Update', NULL)",
+		"INSERT INTO posts (user_id, title, body) VALUES (5, 'Hello', 'Eve here')",
+
+		"INSERT INTO comments (post_id, user_id, content) VALUES (1, 2, 'Nice post!')",
+		"INSERT INTO meta_keep (note) VALUES ('keep-me')",
+		"INSERT INTO meta_skip (junk) VALUES ('skip')",
+	}
+
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed mysql table filter glob %q: %v", stmt[:min(len(stmt), 60)], err)
+		}
+	}
+}
+
+// seedMySQLMixedCaseIdentifiers creates a single PascalCase table for identifier_case=preserve tests.
+func seedMySQLMixedCaseIdentifiers(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	stmts := []string{
+		"DROP TABLE IF EXISTS `UserAccounts`",
+		"CREATE TABLE `UserAccounts` (`UserID` INT AUTO_INCREMENT PRIMARY KEY, `DisplayName` VARCHAR(100) NOT NULL)",
+		"INSERT INTO `UserAccounts` (`DisplayName`) VALUES ('Alice')",
+	}
+
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed mysql mixed-case identifiers %q: %v", stmt[:min(len(stmt), 60)], err)
+		}
+	}
+}
+
 func seedMySQLResumeFixture(t *testing.T, db *sql.DB) {
 	t.Helper()
 	ctx := context.Background()
@@ -2472,6 +2729,21 @@ func assertRowCount(t *testing.T, pool *pgxpool.Pool, schema, table string, want
 	}
 	if got != want {
 		t.Errorf("%s.%s row count: got %d, want %d", schema, table, got, want)
+	}
+}
+
+func assertInformationSchemaTableCount(t *testing.T, pool *pgxpool.Pool, schema, table string, want int) {
+	t.Helper()
+	var got int
+	err := pool.QueryRow(context.Background(), `
+		SELECT count(*) FROM information_schema.tables
+		 WHERE table_schema = $1 AND table_name = $2
+	`, schema, table).Scan(&got)
+	if err != nil {
+		t.Fatalf("information_schema.tables %s.%s: %v", schema, table, err)
+	}
+	if got != want {
+		t.Errorf("information_schema table %q in schema %q: count=%d, want %d", table, schema, got, want)
 	}
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -506,6 +506,158 @@ dsn = %q
 	assertRowCount(t, pgPool, pgSchema, "meta_keep", 1)
 }
 
+func TestIntegration_MySQL_HookBeforeDataFails(t *testing.T) {
+	mysqlDSN, pgDSN := requireMySQLAndPostgresDSNs(t)
+
+	mysqlDB, err := sql.Open("mysql", mysqlDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	defer mysqlDB.Close()
+	seedMySQLNoOrphans(t, mysqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() {
+		pgPool.Close()
+	})
+
+	pgSchema := integrationSchemaName("inttest_hook_before_data")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() {
+		dropSchema(t, pgPool, pgSchema)
+	})
+
+	tmpDir := t.TempDir()
+	badHook := filepath.Join(tmpDir, "bad_before_data.sql")
+	if err := os.WriteFile(badHook, []byte("SELECT 1;\nSELECT pgferry_no_such_function_for_hook_test();\n"), 0644); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+workers = 1
+
+[source]
+type = "mysql"
+dsn = %q
+
+[target]
+dsn = %q
+
+[hooks]
+before_data = [%q]
+`, pgSchema, mysqlDSN, pgDSN, filepath.Base(badHook)))
+
+	err = runMigrationFromConfigExpectError(t, cfgPath)
+	if err == nil {
+		t.Fatal("expected migration error from failing before_data hook")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "before_data hooks") {
+		t.Fatalf("error should mention before_data hooks: %v", err)
+	}
+	if !strings.Contains(msg, "bad_before_data.sql") || !strings.Contains(msg, "statement 2") {
+		t.Fatalf("error should name hook file and failing statement: %v", err)
+	}
+}
+
+func TestIntegration_MySQL_HookBeforeFkFails(t *testing.T) {
+	mysqlDSN, pgDSN := requireMySQLAndPostgresDSNs(t)
+
+	mysqlDB, err := sql.Open("mysql", mysqlDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	defer mysqlDB.Close()
+	seedMySQLNoOrphans(t, mysqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() {
+		pgPool.Close()
+	})
+
+	pgSchema := integrationSchemaName("inttest_hook_before_fk")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() {
+		dropSchema(t, pgPool, pgSchema)
+	})
+
+	tmpDir := t.TempDir()
+	badHook := filepath.Join(tmpDir, "bad_before_fk.sql")
+	if err := os.WriteFile(badHook, []byte("SELECT pgferry_no_such_function_before_fk();\n"), 0644); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+workers = 1
+clean_orphans = false
+
+[source]
+type = "mysql"
+dsn = %q
+
+[target]
+dsn = %q
+
+[hooks]
+before_fk = [%q]
+`, pgSchema, mysqlDSN, pgDSN, filepath.Base(badHook)))
+
+	err = runMigrationFromConfigExpectError(t, cfgPath)
+	if err == nil {
+		t.Fatal("expected migration error from failing before_fk hook")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "before_fk hooks") {
+		t.Fatalf("error should mention before_fk hooks: %v", err)
+	}
+	if !strings.Contains(msg, "bad_before_fk.sql") {
+		t.Fatalf("error should name hook file: %v", err)
+	}
+}
+
+func TestIntegration_MySQL_CleanOrphansApplyWithoutBeforeFkHook(t *testing.T) {
+	mysqlDSN, pgDSN := requireMySQLAndPostgresDSNs(t)
+
+	mysqlDB, err := sql.Open("mysql", mysqlDSN+"?parseTime=true&loc=UTC&interpolateParams=true&multiStatements=true")
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	defer mysqlDB.Close()
+	seedMySQL(t, mysqlDB)
+
+	pgPool := openIntegrationPGPool(t, pgDSN)
+	t.Cleanup(func() {
+		pgPool.Close()
+	})
+
+	pgSchema := integrationSchemaName("inttest_clean_orphans")
+	ensureDroppedSchema(t, pgPool, pgSchema)
+	t.Cleanup(func() {
+		dropSchema(t, pgPool, pgSchema)
+	})
+
+	tmpDir := t.TempDir()
+	cfgPath := writeIntegrationConfig(t, tmpDir, fmt.Sprintf(`schema = %q
+workers = 2
+clean_orphans = true
+clean_orphans_mode = "apply"
+
+[source]
+type = "mysql"
+dsn = %q
+
+[target]
+dsn = %q
+`, pgSchema, mysqlDSN, pgDSN))
+
+	runMigrationFromConfig(t, cfgPath)
+
+	// seedMySQL loads 10 valid comments + 2 orphaned rows; clean_orphans should delete the orphans before FK creation.
+	assertRowCount(t, pgPool, pgSchema, "comments", 10)
+	assertFKExists(t, pgPool, pgSchema, "comments", "posts")
+	assertFKExists(t, pgPool, pgSchema, "comments", "users")
+}
+
 func TestIntegration_MySQL_IdentifierCasePreserve(t *testing.T) {
 	mysqlDSN, pgDSN := requireMySQLAndPostgresDSNs(t)
 	ctx := context.Background()

--- a/integration_test.go
+++ b/integration_test.go
@@ -2111,6 +2111,9 @@ func seedSakila(t *testing.T, db *sql.DB) {
 		"DROP TABLE IF EXISTS comments",
 		"DROP TABLE IF EXISTS posts",
 		"DROP TABLE IF EXISTS users",
+		"DROP TABLE IF EXISTS meta_skip",
+		"DROP TABLE IF EXISTS meta_keep",
+		"DROP TABLE IF EXISTS `UserAccounts`",
 
 		// Drop in reverse dependency order
 		"DROP TABLE IF EXISTS payment",

--- a/migrate.go
+++ b/migrate.go
@@ -278,8 +278,16 @@ func migrateDataSingleTx(ctx context.Context, cfg migrateDataConfig) error {
 	var tx *sql.Tx
 	switch cfg.Src.Name() {
 	case "MSSQL":
+		dbName, nameErr := cfg.Src.ExtractDBName(cfg.SrcDSN)
+		if nameErr != nil {
+			return fmt.Errorf("mssql single_tx: %w", nameErr)
+		}
+		alter := fmt.Sprintf("ALTER DATABASE %s SET ALLOW_SNAPSHOT_ISOLATION ON", cfg.Src.QuoteIdentifier(dbName))
+		if _, err := srcDB.ExecContext(ctx, alter); err != nil {
+			return fmt.Errorf("enable allow_snapshot_isolation on source database %q (required for source_snapshot_mode=single_tx; login needs ALTER on the database): %w", dbName, err)
+		}
 		if _, err := srcDB.ExecContext(ctx, "SET TRANSACTION ISOLATION LEVEL SNAPSHOT"); err != nil {
-			return fmt.Errorf("set source transaction isolation (hint: ensure ALTER DATABASE ... SET ALLOW_SNAPSHOT_ISOLATION ON): %w", err)
+			return fmt.Errorf("set source transaction isolation: %w", err)
 		}
 		// go-mssqldb rejects ReadOnly transactions ("read-only transactions are not supported").
 		// Snapshot isolation still gives a consistent point-in-time view; we only issue SELECTs.

--- a/migrate.go
+++ b/migrate.go
@@ -282,9 +282,17 @@ func migrateDataSingleTx(ctx context.Context, cfg migrateDataConfig) error {
 		if nameErr != nil {
 			return fmt.Errorf("mssql single_tx: %w", nameErr)
 		}
-		alter := fmt.Sprintf("ALTER DATABASE %s SET ALLOW_SNAPSHOT_ISOLATION ON", cfg.Src.QuoteIdentifier(dbName))
-		if _, err := srcDB.ExecContext(ctx, alter); err != nil {
-			return fmt.Errorf("enable allow_snapshot_isolation on source database %q (required for source_snapshot_mode=single_tx; login needs ALTER on the database): %w", dbName, err)
+		// snapshot_isolation_state 1 = ALLOW_SNAPSHOT_ISOLATION is ON (see sys.databases).
+		// Skip ALTER when already enabled so read-only logins can still use single_tx.
+		var snapState int
+		if err := srcDB.QueryRowContext(ctx, "SELECT snapshot_isolation_state FROM sys.databases WHERE name = DB_NAME()").Scan(&snapState); err != nil {
+			return fmt.Errorf("mssql single_tx: read snapshot_isolation_state: %w", err)
+		}
+		if snapState != 1 {
+			alter := fmt.Sprintf("ALTER DATABASE %s SET ALLOW_SNAPSHOT_ISOLATION ON", cfg.Src.QuoteIdentifier(dbName))
+			if _, err := srcDB.ExecContext(ctx, alter); err != nil {
+				return fmt.Errorf("enable allow_snapshot_isolation on source database %q (required for source_snapshot_mode=single_tx when not already enabled; login needs ALTER on the database): %w", dbName, err)
+			}
 		}
 		if _, err := srcDB.ExecContext(ctx, "SET TRANSACTION ISOLATION LEVEL SNAPSHOT"); err != nil {
 			return fmt.Errorf("set source transaction isolation: %w", err)

--- a/migrate.go
+++ b/migrate.go
@@ -281,9 +281,11 @@ func migrateDataSingleTx(ctx context.Context, cfg migrateDataConfig) error {
 		if _, err := srcDB.ExecContext(ctx, "SET TRANSACTION ISOLATION LEVEL SNAPSHOT"); err != nil {
 			return fmt.Errorf("set source transaction isolation (hint: ensure ALTER DATABASE ... SET ALLOW_SNAPSHOT_ISOLATION ON): %w", err)
 		}
+		// go-mssqldb rejects ReadOnly transactions ("read-only transactions are not supported").
+		// Snapshot isolation still gives a consistent point-in-time view; we only issue SELECTs.
 		tx, err = srcDB.BeginTx(ctx, &sql.TxOptions{
 			Isolation: sql.LevelSnapshot,
-			ReadOnly:  true,
+			ReadOnly:  false,
 		})
 	default:
 		if _, err := srcDB.ExecContext(ctx, "SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ"); err != nil {

--- a/post.go
+++ b/post.go
@@ -33,7 +33,8 @@ func postMigrate(ctx context.Context, pool *pgxpool.Pool, schema *Schema, cfg *M
 		return nil
 	}
 
-	// schema_only: skip SET LOGGED (tables are already LOGGED)
+	// schema_only: skip SET LOGGED. createTables already chose logged vs UNLOGGED;
+	// without this step, UNLOGGED tables from an unlogged load stay UNLOGGED.
 	if !cfg.SchemaOnly {
 		log.Printf("  SET LOGGED...")
 		if err := setLogged(ctx, pool, schema, pgSchema); err != nil {

--- a/site/src/content/docs/examples/mssql/index.md
+++ b/site/src/content/docs/examples/mssql/index.md
@@ -13,6 +13,6 @@ MSSQL support currently has two main operational templates: the safe default and
 ## Notes before you choose
 
 - `source_schema` defaults to `dbo`
-- `single_tx` requires snapshot isolation on the source database
+- `single_tx` enables snapshot isolation on the source database when the login allows it
 - `money` and `smallmoney` map to `numeric` by default
 - `uniqueidentifier` values are reordered into standard UUID byte order during copy

--- a/site/src/content/docs/examples/mssql/index.md
+++ b/site/src/content/docs/examples/mssql/index.md
@@ -13,6 +13,6 @@ MSSQL support currently has two main operational templates: the safe default and
 ## Notes before you choose
 
 - `source_schema` defaults to `dbo`
-- `single_tx` enables snapshot isolation on the source database when the login allows it
+- `single_tx` enables snapshot isolation: pgferry may `ALTER` the database only when `ALLOW_SNAPSHOT_ISOLATION` is not already on; that change persists if pgferry makes it
 - `money` and `smallmoney` map to `numeric` by default
 - `uniqueidentifier` values are reordered into standard UUID byte order during copy

--- a/site/src/content/docs/guides/mssql.md
+++ b/site/src/content/docs/guides/mssql.md
@@ -15,7 +15,7 @@ MSSQL support uses `sys.*` catalog introspection and a small set of SQL Server-s
 - choose the right `source_schema` instead of relying on the `dbo` default blindly
 - decide whether `datetime_as_timestamptz` should be enabled
 - keep `money_as_numeric = true` unless you explicitly want text preservation
-- `single_tx` turns on `ALLOW_SNAPSHOT_ISOLATION` on the source database when the login can run `ALTER DATABASE`; otherwise grant that or enable it ahead of time
+- `single_tx` uses snapshot isolation: pgferry enables `ALLOW_SNAPSHOT_ISOLATION` only when `sys.databases` shows it is not already on and the login may `ALTER DATABASE`; if it is already on, read-only logins work. Any `ALTER` pgferry runs leaves that option enabled (it is not reverted).
 
 ## Common caveats
 

--- a/site/src/content/docs/guides/mssql.md
+++ b/site/src/content/docs/guides/mssql.md
@@ -15,7 +15,7 @@ MSSQL support uses `sys.*` catalog introspection and a small set of SQL Server-s
 - choose the right `source_schema` instead of relying on the `dbo` default blindly
 - decide whether `datetime_as_timestamptz` should be enabled
 - keep `money_as_numeric = true` unless you explicitly want text preservation
-- enable `single_tx` only if snapshot isolation is available on the source database
+- `single_tx` turns on `ALLOW_SNAPSHOT_ISOLATION` on the source database when the login can run `ALTER DATABASE`; otherwise grant that or enable it ahead of time
 
 ## Common caveats
 

--- a/site/src/content/docs/operations/how-to-choose-snapshot-mode.md
+++ b/site/src/content/docs/operations/how-to-choose-snapshot-mode.md
@@ -22,5 +22,5 @@ The rule is simple: use `none` unless the source is live enough that cross-table
 
 - MySQL: supported
 - MariaDB: supported
-- MSSQL: supported; pgferry enables `ALLOW_SNAPSHOT_ISOLATION` if the login may `ALTER DATABASE`
+- MSSQL: supported; pgferry enables `ALLOW_SNAPSHOT_ISOLATION` only when it is not already on and the login may `ALTER DATABASE` (or it is already on without needing `ALTER`)
 - SQLite: unsupported

--- a/site/src/content/docs/operations/how-to-choose-snapshot-mode.md
+++ b/site/src/content/docs/operations/how-to-choose-snapshot-mode.md
@@ -22,5 +22,5 @@ The rule is simple: use `none` unless the source is live enough that cross-table
 
 - MySQL: supported
 - MariaDB: supported
-- MSSQL: supported, but source snapshot isolation must be enabled
+- MSSQL: supported; pgferry enables `ALLOW_SNAPSHOT_ISOLATION` if the login may `ALTER DATABASE`
 - SQLite: unsupported

--- a/site/src/content/docs/operations/operator-tuning.md
+++ b/site/src/content/docs/operations/operator-tuning.md
@@ -64,7 +64,7 @@ These are usually maintenance-window or server-level decisions, not pgferry conf
 
 ### MSSQL
 
-- `source_snapshot_mode = "single_tx"` turns on `ALLOW_SNAPSHOT_ISOLATION` on the source database when the login can run `ALTER DATABASE`.
+- `source_snapshot_mode = "single_tx"` on MSSQL turns on `ALLOW_SNAPSHOT_ISOLATION` only when it is not already enabled (`sys.databases`) and the login can run `ALTER DATABASE`; if pgferry runs that `ALTER`, the setting persists (it is not reverted).
 - If that fails (permissions or policy), use `source_snapshot_mode = "none"` or enable snapshot isolation manually, and accept weaker consistency when the source is live.
 - See [MSSQL to PostgreSQL](/guides/mssql/) for source-specific behavior and [How to choose snapshot mode](/operations/how-to-choose-snapshot-mode/) for the consistency tradeoff.
 

--- a/site/src/content/docs/operations/operator-tuning.md
+++ b/site/src/content/docs/operations/operator-tuning.md
@@ -64,8 +64,8 @@ These are usually maintenance-window or server-level decisions, not pgferry conf
 
 ### MSSQL
 
-- `source_snapshot_mode = "single_tx"` depends on snapshot isolation being available on the source database.
-- If snapshot isolation is not enabled, keep `source_snapshot_mode = "none"` and accept that the source may change during the run.
+- `source_snapshot_mode = "single_tx"` turns on `ALLOW_SNAPSHOT_ISOLATION` on the source database when the login can run `ALTER DATABASE`.
+- If that fails (permissions or policy), use `source_snapshot_mode = "none"` or enable snapshot isolation manually, and accept weaker consistency when the source is live.
 - See [MSSQL to PostgreSQL](/guides/mssql/) for source-specific behavior and [How to choose snapshot mode](/operations/how-to-choose-snapshot-mode/) for the consistency tradeoff.
 
 ### SQLite

--- a/site/src/content/docs/reference/conventions-and-limitations.md
+++ b/site/src/content/docs/reference/conventions-and-limitations.md
@@ -159,7 +159,7 @@ Important details:
 - `source_schema` defaults to `dbo`.
 - `timestamp` and `rowversion` map to `bytea`, not PostgreSQL datetime types.
 - `money` and `smallmoney` map to `numeric` by default.
-- `single_tx` requires snapshot isolation on the source database.
+- `single_tx` uses snapshot isolation; pgferry enables `ALLOW_SNAPSHOT_ISOLATION` when the login may `ALTER DATABASE`.
 
 ## What pgferry does automatically vs what you still own
 

--- a/site/src/content/docs/reference/conventions-and-limitations.md
+++ b/site/src/content/docs/reference/conventions-and-limitations.md
@@ -159,7 +159,7 @@ Important details:
 - `source_schema` defaults to `dbo`.
 - `timestamp` and `rowversion` map to `bytea`, not PostgreSQL datetime types.
 - `money` and `smallmoney` map to `numeric` by default.
-- `single_tx` uses snapshot isolation; pgferry enables `ALLOW_SNAPSHOT_ISOLATION` when the login may `ALTER DATABASE`.
+- `single_tx` uses snapshot isolation; on MSSQL, pgferry enables `ALLOW_SNAPSHOT_ISOLATION` only when `sys.databases` shows it is off and the login may `ALTER DATABASE` (already-on databases work with read-only logins). An `ALTER` performed by pgferry leaves that option on.
 
 ## What pgferry does automatically vs what you still own
 

--- a/site/src/content/docs/reference/type-mapping.md
+++ b/site/src/content/docs/reference/type-mapping.md
@@ -100,7 +100,7 @@ SQLite accepts `datetime_as_timestamptz` for `DATETIME` / `TIMESTAMP`. Other MyS
 ### MSSQL-specific mapping notes
 
 - `datetime2` and `time` carry fractional-second **scale** from `sys.columns`; pgferry emits PostgreSQL `timestamp(n)`, `timestamptz(n)`, or `time(n)` when scale &gt; 0, with **n clamped to 6** (SQL Server allows scale 7).
-- `source_snapshot_mode = "single_tx"` uses `SNAPSHOT` isolation; pgferry runs `ALTER DATABASE … SET ALLOW_SNAPSHOT_ISOLATION ON` at COPY start when the login has permission (otherwise enable it manually).
+- `source_snapshot_mode = "single_tx"` uses `SNAPSHOT` isolation on MSSQL. pgferry reads `sys.databases.snapshot_isolation_state` for the current database and runs `ALTER DATABASE … SET ALLOW_SNAPSHOT_ISOLATION ON` only when snapshot isolation is not already fully enabled. If that `ALTER` runs, the database option stays on (pgferry does not revert it). With snapshot already on, a read-only login can still use `single_tx`; otherwise grant `ALTER` on the database or enable the option ahead of time.
 - `uniqueidentifier` values are byte-reordered into standard UUID order during copy.
 - `nvarchar` and `nchar` lengths are divided by two because MSSQL reports byte length, not character length.
 - `(max)` types map to PostgreSQL `text` or `bytea`.

--- a/site/src/content/docs/reference/type-mapping.md
+++ b/site/src/content/docs/reference/type-mapping.md
@@ -100,7 +100,7 @@ SQLite accepts `datetime_as_timestamptz` for `DATETIME` / `TIMESTAMP`. Other MyS
 ### MSSQL-specific mapping notes
 
 - `datetime2` and `time` carry fractional-second **scale** from `sys.columns`; pgferry emits PostgreSQL `timestamp(n)`, `timestamptz(n)`, or `time(n)` when scale &gt; 0, with **n clamped to 6** (SQL Server allows scale 7).
-- `source_snapshot_mode = "single_tx"` uses `SNAPSHOT` isolation and requires `ALLOW_SNAPSHOT_ISOLATION ON` on the source database.
+- `source_snapshot_mode = "single_tx"` uses `SNAPSHOT` isolation; pgferry runs `ALTER DATABASE … SET ALLOW_SNAPSHOT_ISOLATION ON` at COPY start when the login has permission (otherwise enable it manually).
 - `uniqueidentifier` values are byte-reordered into standard UUID order during copy.
 - `nvarchar` and `nchar` lengths are divided by two because MSSQL reports byte length, not character length.
 - `(max)` types map to PostgreSQL `text` or `bytea`.

--- a/type_compat_test.go
+++ b/type_compat_test.go
@@ -2,6 +2,58 @@ package main
 
 import "testing"
 
+func TestCollectUnsupportedTypeErrors_UnknownAsText_PerSource(t *testing.T) {
+	// Columns that error without unknown_as_text; with the flag, mapping succeeds as text.
+	tests := []struct {
+		name   string
+		mapper typeMapper
+		schema *Schema
+	}{
+		{
+			name:   "mysql_geometry",
+			mapper: mysqlMapType,
+			schema: &Schema{Tables: []Table{{SourceName: "t", Columns: []Column{{SourceName: "g", DataType: "geometry", ColumnType: "geometry"}}}}},
+		},
+		{
+			name:   "mariadb_geometry",
+			mapper: mariadbMapType,
+			schema: &Schema{Tables: []Table{{SourceName: "t", Columns: []Column{{SourceName: "g", DataType: "geometry", ColumnType: "geometry"}}}}},
+		},
+		{
+			name:   "mssql_cursor",
+			mapper: mssqlMapType,
+			schema: &Schema{Tables: []Table{{SourceName: "t", Columns: []Column{{SourceName: "c", DataType: "cursor", ColumnType: "cursor"}}}}},
+		},
+		{
+			name:   "sqlite_unlisted_affinity",
+			mapper: sqliteMapType,
+			schema: &Schema{Tables: []Table{{SourceName: "t", Columns: []Column{{SourceName: "x", ColumnType: "vendor_specific_frob"}}}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := defaultTypeMappingConfig()
+			if n := len(collectUnsupportedTypeErrors(tt.schema, def, tt.mapper)); n == 0 {
+				t.Fatalf("expected unsupported type errors without unknown_as_text, got 0")
+			}
+			tm := def
+			tm.UnknownAsText = true
+			if n := len(collectUnsupportedTypeErrors(tt.schema, tm, tt.mapper)); n != 0 {
+				t.Fatalf("with unknown_as_text, want no errors, got %d: %v", n, collectUnsupportedTypeErrors(tt.schema, tm, tt.mapper))
+			}
+			col := tt.schema.Tables[0].Columns[0]
+			got, err := tt.mapper(col, tm)
+			if err != nil {
+				t.Fatalf("MapType with unknown_as_text: %v", err)
+			}
+			if got != "text" {
+				t.Fatalf("MapType with unknown_as_text = %q, want text", got)
+			}
+		})
+	}
+}
+
 func TestCollectUnsupportedTypeErrors(t *testing.T) {
 	schema := &Schema{
 		Tables: []Table{

--- a/type_compat_test.go
+++ b/type_compat_test.go
@@ -39,8 +39,9 @@ func TestCollectUnsupportedTypeErrors_UnknownAsText_PerSource(t *testing.T) {
 			}
 			tm := def
 			tm.UnknownAsText = true
-			if n := len(collectUnsupportedTypeErrors(tt.schema, tm, tt.mapper)); n != 0 {
-				t.Fatalf("with unknown_as_text, want no errors, got %d: %v", n, collectUnsupportedTypeErrors(tt.schema, tm, tt.mapper))
+			errs := collectUnsupportedTypeErrors(tt.schema, tm, tt.mapper)
+			if len(errs) != 0 {
+				t.Fatalf("with unknown_as_text, want no errors, got %d: %v", len(errs), errs)
 			}
 			col := tt.schema.Tables[0].Columns[0]
 			got, err := tt.mapper(col, tm)


### PR DESCRIPTION
## Summary

Expands integration and unit tests around table filters, identifier casing, type-mapping fallbacks, hook failures, orphan cleanup, and cross-engine parity.

## Changes

### `integration_test.go`
- **MySQL:** `exclude_tables` (exact) and glob `include_tables` / `exclude_tables`; `identifier_case = "preserve"` with mixed-case identifiers (skips when `@@lower_case_table_names != 0`).
- **Hooks:** `before_data` and `before_fk` SQL failures assert wrapped errors (phase, file, statement).
- **Orphans:** `clean_orphans = apply` without `before_fk` cleanup.sql (comment orphans removed during post-migrate).

### `type_compat_test.go`
- **`unknown_as_text`:** Table-driven checks per source (MySQL/MariaDB geometry, MSSQL `cursor`, SQLite undeclared affinity) — errors cleared and maps to `text`.

### `integration_extended_test.go` (new, `integration` build tag)
- **MariaDB:** Parity with selected MySQL scenarios — `single_tx`, `row_count` / `sampled_hash` validation (including mismatch after `after_data`), resume after chunk failure (zero datetime).
- **SQLite:** `schema_only`, `data_only` (precreated schema + marker), schema/data split, `row_count` validation, resume after bad `DATETIME` chunk, standalone `validate`.
- **MSSQL:** `single_tx`, `row_count` / `sampled_hash` validation, `schema_only`, schema/data split, `data_only` with marker, standalone `validate`.
- Helper: `runValidateFromConfig` exercises the `validate` subcommand against live source + target after migrate.

## How to test

```bash
go test -count=1 ./...
go test -tags integration -count=1 -v ./...
```

Use env vars from `AGENTS.md` (`MYSQL_DSN`, `MARIADB_DSN`, `POSTGRES_DSN`, `MSSQL_DSN` as applicable).