### PR TITLE
feat(wizard): offer migrate immediately after plan

### DIFF
--- a/site/src/content/docs/get-started/quick-start.md
+++ b/site/src/content/docs/get-started/quick-start.md
@@ -56,7 +56,7 @@ Use the wizard to generate `migration.toml`.
 
 If you want to stay on the simplest path, skip the optional advanced section and accept the defaults. If you already know you want built-in validation, resume support, or non-default `chunk_size` / `index_workers`, the wizard can now capture those too without sending you straight into manual TOML edits.
 
-When the wizard offers **plan** as the next step (the default) and you take it, the same analysis as `pgferry plan` runs in the terminal. After the report, it asks whether to start **migrate** immediately with that config; the default is **no** so you can still save or edit the TOML first.
+When the wizard offers **plan** as the next step (the default) and you take it, the same analysis as `pgferry plan` runs in the terminal. After the plan report, pgferry asks whether to start **migrate** immediately with that config. The default is **no**. If you saved a TOML in the step above, you can edit that file before migrating; if you skipped saving, **yes** still runs **migrate** using the in-memory config from the wizard.
 
 If you already know your source type and want a fuller starter instead, jump to:
 

--- a/site/src/content/docs/get-started/quick-start.md
+++ b/site/src/content/docs/get-started/quick-start.md
@@ -56,6 +56,8 @@ Use the wizard to generate `migration.toml`.
 
 If you want to stay on the simplest path, skip the optional advanced section and accept the defaults. If you already know you want built-in validation, resume support, or non-default `chunk_size` / `index_workers`, the wizard can now capture those too without sending you straight into manual TOML edits.
 
+When the wizard offers **plan** as the next step (the default) and you take it, the same analysis as `pgferry plan` runs in the terminal. After the report, it asks whether to start **migrate** immediately with that config; the default is **no** so you can still save or edit the TOML first.
+
 If you already know your source type and want a fuller starter instead, jump to:
 
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)

--- a/wizard.go
+++ b/wizard.go
@@ -134,6 +134,16 @@ func runGenerateWizard(cmd *cobra.Command, _ []string) error {
 		if err := generatedConfigPlanner(cfg, w.out, wizardPlanOptions()); err != nil {
 			return fmt.Errorf("run plan: %w", err)
 		}
+		runAfterPlan, err := w.promptBool(
+			"Run the migration now with this config",
+			false,
+		)
+		if err != nil {
+			return err
+		}
+		if runAfterPlan {
+			nextStep = "run"
+		}
 	}
 
 	if nextStep == "run" {

--- a/wizard_test.go
+++ b/wizard_test.go
@@ -329,6 +329,7 @@ func TestRunGenerateWizardRunsPlanFromGeneratedConfig(t *testing.T) {
 		"n",
 		"n",
 		"plan",
+		"",
 	}, "\n") + "\n"
 
 	cmd := &cobra.Command{}
@@ -346,6 +347,77 @@ func TestRunGenerateWizardRunsPlanFromGeneratedConfig(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "plan ok") {
 		t.Fatalf("expected planner output, got:\n%s", out.String())
+	}
+}
+
+func TestRunGenerateWizardRunsMigrationAfterPlanWhenConfirmed(t *testing.T) {
+	dir := t.TempDir()
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(prevWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	prevPlanner := generatedConfigPlanner
+	generatedConfigPlanner = func(cfg *MigrationConfig, out io.Writer, _ PlanOptions) error {
+		_, err := out.Write([]byte("plan ok\n"))
+		return err
+	}
+	t.Cleanup(func() {
+		generatedConfigPlanner = prevPlanner
+	})
+
+	var runnerCalled bool
+	prevRunner := generatedConfigRunner
+	generatedConfigRunner = func(cfg *MigrationConfig, _ MigrateOptions) error {
+		runnerCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		generatedConfigRunner = prevRunner
+	})
+
+	var out bytes.Buffer
+	input := strings.Join([]string{
+		"sqlite",
+		"/tmp/source.db",
+		"n",
+		"postgres://postgres:postgres@127.0.0.1:5432/target?sslmode=disable",
+		"n",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"n",
+		"n",
+		"plan",
+		"y",
+	}, "\n") + "\n"
+
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(&out)
+
+	if err := runGenerateWizard(cmd, nil); err != nil {
+		t.Fatalf("runGenerateWizard() error: %v", err)
+	}
+	if !runnerCalled {
+		t.Fatal("expected generated config runner to be called after confirming post-plan migration")
+	}
+	if !strings.Contains(out.String(), "Starting migration...") {
+		t.Fatalf("expected migration start message, got:\n%s", out.String())
 	}
 }
 

--- a/wizard_test.go
+++ b/wizard_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -310,10 +311,21 @@ func TestRunGenerateWizardRunsPlanFromGeneratedConfig(t *testing.T) {
 		generatedConfigPlanner = prevPlanner
 	})
 
+	var runnerInvoked bool
+	prevRunner := generatedConfigRunner
+	generatedConfigRunner = func(_ *MigrationConfig, _ MigrateOptions) error {
+		runnerInvoked = true
+		return errors.New("unexpected migrate")
+	}
+	t.Cleanup(func() {
+		generatedConfigRunner = prevRunner
+	})
+
+	sqlitePath := filepath.Join(dir, "source.db")
 	var out bytes.Buffer
 	input := strings.Join([]string{
 		"sqlite",
-		"/tmp/source.db",
+		sqlitePath,
 		"n",
 		"postgres://postgres:postgres@127.0.0.1:5432/target?sslmode=disable",
 		"n",
@@ -342,6 +354,9 @@ func TestRunGenerateWizardRunsPlanFromGeneratedConfig(t *testing.T) {
 	if gotCfg == nil {
 		t.Fatal("expected generated config planner to be called")
 	}
+	if runnerInvoked {
+		t.Fatal("migration runner must not run when post-plan migrate is declined")
+	}
 	if !strings.Contains(out.String(), "Generating migration plan...") {
 		t.Fatalf("expected plan start message, got:\n%s", out.String())
 	}
@@ -365,8 +380,10 @@ func TestRunGenerateWizardRunsMigrationAfterPlanWhenConfirmed(t *testing.T) {
 		}
 	})
 
+	var planCfg *MigrationConfig
 	prevPlanner := generatedConfigPlanner
 	generatedConfigPlanner = func(cfg *MigrationConfig, out io.Writer, _ PlanOptions) error {
+		planCfg = cfg
 		_, err := out.Write([]byte("plan ok\n"))
 		return err
 	}
@@ -374,9 +391,11 @@ func TestRunGenerateWizardRunsMigrationAfterPlanWhenConfirmed(t *testing.T) {
 		generatedConfigPlanner = prevPlanner
 	})
 
+	var runCfg *MigrationConfig
 	var runnerCalled bool
 	prevRunner := generatedConfigRunner
 	generatedConfigRunner = func(cfg *MigrationConfig, _ MigrateOptions) error {
+		runCfg = cfg
 		runnerCalled = true
 		return nil
 	}
@@ -384,10 +403,11 @@ func TestRunGenerateWizardRunsMigrationAfterPlanWhenConfirmed(t *testing.T) {
 		generatedConfigRunner = prevRunner
 	})
 
+	sqlitePath := filepath.Join(dir, "source.db")
 	var out bytes.Buffer
 	input := strings.Join([]string{
 		"sqlite",
-		"/tmp/source.db",
+		sqlitePath,
 		"n",
 		"postgres://postgres:postgres@127.0.0.1:5432/target?sslmode=disable",
 		"n",
@@ -416,8 +436,86 @@ func TestRunGenerateWizardRunsMigrationAfterPlanWhenConfirmed(t *testing.T) {
 	if !runnerCalled {
 		t.Fatal("expected generated config runner to be called after confirming post-plan migration")
 	}
+	if planCfg == nil || runCfg == nil || planCfg != runCfg {
+		t.Fatalf("expected same config pointer from planner and runner, planCfg=%p runCfg=%p", planCfg, runCfg)
+	}
 	if !strings.Contains(out.String(), "Starting migration...") {
 		t.Fatalf("expected migration start message, got:\n%s", out.String())
+	}
+}
+
+func TestRunGenerateWizardPlanFailureSkipsPostPlanMigratePrompt(t *testing.T) {
+	dir := t.TempDir()
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(prevWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	plannerErr := errors.New("planner failed")
+	prevPlanner := generatedConfigPlanner
+	generatedConfigPlanner = func(_ *MigrationConfig, _ io.Writer, _ PlanOptions) error {
+		return plannerErr
+	}
+	t.Cleanup(func() {
+		generatedConfigPlanner = prevPlanner
+	})
+
+	var runnerInvoked bool
+	prevRunner := generatedConfigRunner
+	generatedConfigRunner = func(_ *MigrationConfig, _ MigrateOptions) error {
+		runnerInvoked = true
+		return nil
+	}
+	t.Cleanup(func() {
+		generatedConfigRunner = prevRunner
+	})
+
+	sqlitePath := filepath.Join(dir, "source.db")
+	input := strings.Join([]string{
+		"sqlite",
+		sqlitePath,
+		"n",
+		"postgres://postgres:postgres@127.0.0.1:5432/target?sslmode=disable",
+		"n",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"n",
+		"n",
+		"plan",
+	}, "\n") + "\n"
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(&out)
+
+	wizErr := runGenerateWizard(cmd, nil)
+	if wizErr == nil {
+		t.Fatal("expected error from failed plan")
+	}
+	if !errors.Is(wizErr, plannerErr) {
+		t.Fatalf("expected wrapped planner error, got: %v", wizErr)
+	}
+	if runnerInvoked {
+		t.Fatal("migration runner must not run when plan fails")
+	}
+	if strings.Contains(out.String(), "Run the migration now with this config") {
+		t.Fatal("post-plan migrate prompt must not appear when plan fails")
 	}
 }
 


### PR DESCRIPTION
## Summary

When the config wizard runs **plan** as the next step (including the default), it now asks whether to start **migrate** right away with the in-memory config. The default is **no**, so users can still save or edit the TOML first.

## Changes

- `wizard.go`: after a successful `generatedConfigPlanner` call, prompt with `promptBool` and reuse the existing `run` path when confirmed.
- `wizard_test.go`: extend plan-flow test input for the new prompt; add `TestRunGenerateWizardRunsMigrationAfterPlanWhenConfirmed`.
- `site/src/content/docs/get-started/quick-start.md`: document the new prompt.

## Testing

- `go test ./... -count=1`
- `go vet ./...`