### PR TITLE
Add column exclusion filters

### DIFF
--- a/config.go
+++ b/config.go
@@ -24,9 +24,11 @@ type MigrationConfig struct {
 	Target                            TargetConfig      `toml:"target"`
 	PostGIS                           PostGISConfig     `toml:"postgis"`
 	Schema                            string            `toml:"schema"`
-	TableFilterMode                   string            `toml:"table_filter_mode"` // exact|glob
+	TableFilterMode                   string            `toml:"table_filter_mode"`  // exact|glob
+	ColumnFilterMode                  string            `toml:"column_filter_mode"` // exact|glob
 	IncludeTables                     []string          `toml:"include_tables"`
 	ExcludeTables                     []string          `toml:"exclude_tables"`
+	ExcludeColumns                    []string          `toml:"exclude_columns"`
 	OnSchemaExists                    string            `toml:"on_schema_exists"`
 	SchemaOnly                        bool              `toml:"schema_only"`
 	DataOnly                          bool              `toml:"data_only"`
@@ -152,6 +154,7 @@ func defaultMigrationConfig() MigrationConfig {
 	return MigrationConfig{
 		OnSchemaExists:     "error",
 		TableFilterMode:    "exact",
+		ColumnFilterMode:   "exact",
 		SourceSnapshotMode: "none",
 		UnloggedTables:     true,
 		PreserveDefaults:   true,
@@ -204,6 +207,15 @@ func finalizeConfig(cfg *MigrationConfig, configDir string) error {
 	default:
 		return fmt.Errorf("table_filter_mode must be one of: exact, glob")
 	}
+	if cfg.ColumnFilterMode == "" {
+		cfg.ColumnFilterMode = "exact"
+	}
+	cfg.ColumnFilterMode = strings.ToLower(strings.TrimSpace(cfg.ColumnFilterMode))
+	switch cfg.ColumnFilterMode {
+	case "exact", "glob":
+	default:
+		return fmt.Errorf("column_filter_mode must be one of: exact, glob")
+	}
 	cfg.IdentifierCase = strings.ToLower(strings.TrimSpace(cfg.IdentifierCase))
 	if cfg.IdentifierCase == "" {
 		cfg.IdentifierCase = "snake"
@@ -223,6 +235,11 @@ func finalizeConfig(cfg *MigrationConfig, configDir string) error {
 		return err
 	}
 	cfg.ExcludeTables = excludeTables
+	excludeColumns, err := normalizeColumnFilterEntries("exclude_columns", cfg.ColumnFilterMode, cfg.ExcludeColumns)
+	if err != nil {
+		return err
+	}
+	cfg.ExcludeColumns = excludeColumns
 
 	if cfg.OnSchemaExists == "" {
 		cfg.OnSchemaExists = "error"
@@ -491,4 +508,39 @@ func normalizeTableFilterEntries(field, mode string, entries []string) ([]string
 
 func normalizeTableFilterKey(name string) string {
 	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func normalizeColumnFilterEntries(field, mode string, entries []string) ([]string, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	out := make([]string, 0, len(entries))
+	seen := make(map[string]string, len(entries))
+	for _, raw := range entries {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			return nil, fmt.Errorf("%s entries must be non-empty", field)
+		}
+		if strings.HasPrefix(name, ".") || strings.HasSuffix(name, ".") {
+			return nil, fmt.Errorf("%s entry %q is invalid: use ColumnName or TableName.ColumnName", field, raw)
+		}
+		if mode == "exact" && strings.ContainsAny(name, "*?[]") {
+			return nil, fmt.Errorf("%s entry %q is invalid: glob patterns are not supported; use exact source column names", field, raw)
+		}
+		if mode == "glob" {
+			if strings.ContainsAny(name, "[]\\") {
+				return nil, fmt.Errorf("%s entry %q is invalid glob pattern: only literal characters plus '*' and '?' are supported", field, raw)
+			}
+		}
+
+		key := normalizeTableFilterKey(name)
+		if prev, ok := seen[key]; ok {
+			return nil, fmt.Errorf("%s contains duplicate column filter %q (conflicts with %q after normalization)", field, name, prev)
+		}
+		seen[key] = name
+		out = append(out, name)
+	}
+
+	return out, nil
 }

--- a/config.go
+++ b/config.go
@@ -525,6 +525,9 @@ func normalizeColumnFilterEntries(field, mode string, entries []string) ([]strin
 		if strings.HasPrefix(name, ".") || strings.HasSuffix(name, ".") {
 			return nil, fmt.Errorf("%s entry %q is invalid: use ColumnName or TableName.ColumnName", field, raw)
 		}
+		if strings.Count(name, ".") > 1 {
+			return nil, fmt.Errorf("%s entry %q is invalid: only ColumnName or TableName.ColumnName are supported", field, raw)
+		}
 		if mode == "exact" && strings.ContainsAny(name, "*?[]") {
 			return nil, fmt.Errorf("%s entry %q is invalid: glob patterns are not supported; use exact source column names", field, raw)
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -425,6 +425,67 @@ dsn = "postgres://u:p@h:5432/db"
 	}
 }
 
+func TestLoadConfig_ColumnFilters(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "filters.toml")
+
+	content := `
+schema = "target"
+column_filter_mode = "glob"
+exclude_columns = [" RowVersion ", "orders.sys_*"]
+
+[source]
+type = "mssql"
+dsn = "sqlserver://sa:pass@127.0.0.1:1433?database=db"
+
+[target]
+dsn = "postgres://u:p@h:5432/db"
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadConfig(cfgFile)
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+
+	if got := cfg.ColumnFilterMode; got != "glob" {
+		t.Fatalf("ColumnFilterMode = %q, want glob", got)
+	}
+	if got := strings.Join(cfg.ExcludeColumns, ","); got != "RowVersion,orders.sys_*" {
+		t.Fatalf("ExcludeColumns = %q, want RowVersion,orders.sys_*", got)
+	}
+}
+
+func TestLoadConfig_ColumnFiltersRejectGlobPatternsInExactMode(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "filters.toml")
+
+	content := `
+schema = "target"
+exclude_columns = ["rv_*"]
+
+[source]
+type = "mysql"
+dsn = "root:root@tcp(127.0.0.1:3306)/db"
+
+[target]
+dsn = "postgres://u:p@h:5432/db"
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadConfig(cfgFile)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "glob patterns are not supported") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadConfig_TableFiltersRejectDuplicateAfterNormalization(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := filepath.Join(dir, "filters.toml")

--- a/config_test.go
+++ b/config_test.go
@@ -514,6 +514,34 @@ dsn = "postgres://u:p@h:5432/db"
 	}
 }
 
+func TestLoadConfig_ColumnFiltersRejectMultiDotEntries(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "filters.toml")
+
+	content := `
+schema = "target"
+exclude_columns = ["dbo.Orders.RowVersion"]
+
+[source]
+type = "mssql"
+dsn = "sqlserver://sa:pass@127.0.0.1:1433?database=db"
+
+[target]
+dsn = "postgres://u:p@h:5432/db"
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadConfig(cfgFile)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "only ColumnName or TableName.ColumnName are supported") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadConfig_TableFiltersRejectDuplicateAfterNormalization(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := filepath.Join(dir, "filters.toml")

--- a/config_test.go
+++ b/config_test.go
@@ -486,6 +486,34 @@ dsn = "postgres://u:p@h:5432/db"
 	}
 }
 
+func TestLoadConfig_ColumnFiltersRejectDuplicateAfterNormalization(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "filters.toml")
+
+	content := `
+schema = "target"
+exclude_columns = ["Orders.RowVersion", " orders.rowversion "]
+
+[source]
+type = "mssql"
+dsn = "sqlserver://sa:pass@127.0.0.1:1433?database=db"
+
+[target]
+dsn = "postgres://u:p@h:5432/db"
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadConfig(cfgFile)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "duplicate column filter") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadConfig_TableFiltersRejectDuplicateAfterNormalization(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := filepath.Join(dir, "filters.toml")

--- a/main.go
+++ b/main.go
@@ -268,6 +268,17 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 			log.Printf("table filter: resume enabled; changing table_filter_mode/include_tables/exclude_tables between runs can invalidate the checkpoint")
 		}
 	}
+	filteredSchema, columnFilterReport, err := filterSchemaColumns(schema, cfg)
+	if err != nil {
+		return fmt.Errorf("filter schema columns: %w", err)
+	}
+	schema = filteredSchema
+	if hasColumnFilters(cfg) {
+		logColumnFilterReport(columnFilterReport)
+		if cfg.Resume {
+			log.Printf("column filter: resume enabled; changing column_filter_mode/exclude_columns between runs can invalidate the checkpoint")
+		}
+	}
 	log.Printf("found %d tables", len(schema.Tables))
 	for _, t := range schema.Tables {
 		log.Printf("  %s → %s (%d cols, %d indexes, %d fks)",

--- a/plan.go
+++ b/plan.go
@@ -498,6 +498,14 @@ func runPlanWithConfig(cfg *MigrationConfig, out io.Writer, opts PlanOptions) er
 	if hasTableFilters(cfg) {
 		logTableFilterReport(filterReport)
 	}
+	filteredSchema, columnFilterReport, err := filterSchemaColumns(schema, cfg)
+	if err != nil {
+		return fmt.Errorf("filter schema columns: %w", err)
+	}
+	schema = filteredSchema
+	if hasColumnFilters(cfg) {
+		logColumnFilterReport(columnFilterReport)
+	}
 
 	sourceObjects, err := src.IntrospectSourceObjects(sourceDB, dbName)
 	if err != nil {

--- a/site/src/content/docs/get-started/advanced-options.md
+++ b/site/src/content/docs/get-started/advanced-options.md
@@ -85,6 +85,21 @@ exclude_tables = ["app_tmp_*"]
 
 In glob mode, matching is case-insensitive and supports only `*` and `?`. `exclude_tables` is applied after `include_tables`, so excludes still win.
 
+To skip source columns that PostgreSQL should not receive, use `exclude_columns`:
+
+```toml
+exclude_columns = ["RowVersion"]
+```
+
+Column filtering uses source column names. A bare name applies to every table. Scope a rule to one source table with `TableName.ColumnName`; use `column_filter_mode = "glob"` for `*` and `?` patterns:
+
+```toml
+column_filter_mode = "glob"
+exclude_columns = ["*.RowVersion", "audit_*.sys_*"]
+```
+
+When a column is excluded, pgferry omits it from schema creation and data COPY. Keys, indexes, and foreign keys that reference excluded columns are skipped.
+
 - [How to read plan output](/operations/how-to-read-plan-output/)
 
 ## Hooks

--- a/site/src/content/docs/get-started/advanced-options.md
+++ b/site/src/content/docs/get-started/advanced-options.md
@@ -91,14 +91,14 @@ To skip source columns that PostgreSQL should not receive, use `exclude_columns`
 exclude_columns = ["RowVersion"]
 ```
 
-Column filtering uses source column names. A bare name applies to every table. Scope a rule to one source table with `TableName.ColumnName`; use `column_filter_mode = "glob"` for `*` and `?` patterns:
+Column filtering uses source column names. A bare name applies to every table. Scope a rule to one source table with `TableName.ColumnName`; use `column_filter_mode = "glob"` for `*` and `?` patterns in either the table or column part:
 
 ```toml
 column_filter_mode = "glob"
 exclude_columns = ["RowVersion", "audit_*.sys_*"]
 ```
 
-When a column is excluded, pgferry omits it from schema creation and data COPY. Keys, indexes, and foreign keys that reference excluded columns are skipped.
+When a column is excluded, pgferry omits it from schema creation and data COPY. Primary keys, plain-column indexes, and foreign keys that reference excluded columns are skipped. pgferry cannot inspect arbitrary expression index definitions for excluded column references; expression indexes are already reported as unsupported and skipped separately.
 
 - [How to read plan output](/operations/how-to-read-plan-output/)
 

--- a/site/src/content/docs/get-started/advanced-options.md
+++ b/site/src/content/docs/get-started/advanced-options.md
@@ -95,7 +95,7 @@ Column filtering uses source column names. A bare name applies to every table. S
 
 ```toml
 column_filter_mode = "glob"
-exclude_columns = ["*.RowVersion", "audit_*.sys_*"]
+exclude_columns = ["RowVersion", "audit_*.sys_*"]
 ```
 
 When a column is excluded, pgferry omits it from schema creation and data COPY. Keys, indexes, and foreign keys that reference excluded columns are skipped.

--- a/site/src/content/docs/operations/when-resume-is-worth-it.md
+++ b/site/src/content/docs/operations/when-resume-is-worth-it.md
@@ -27,7 +27,7 @@ unlogged_tables = false
 
 Why: checkpoints only make sense when the target data survives a crash.
 
-If you use table filters, treat `table_filter_mode`, `include_tables`, and `exclude_tables` as part of the checkpoint contract. Changing them between runs can change the selected table set, and pgferry will reject the old checkpoint when the resolved migration scope no longer matches.
+If you use table or column filters, treat `table_filter_mode`, `include_tables`, `exclude_tables`, `column_filter_mode`, and `exclude_columns` as part of the checkpoint contract. Changing them between runs can change the selected migration scope, and pgferry will reject the old checkpoint when the resolved migration scope no longer matches.
 
 ## Practical tradeoff
 

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -101,8 +101,10 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | --- | --- | --- | --- |
 | `schema` | string | required | Target PostgreSQL schema name. |
 | `table_filter_mode` | string | `"exact"` | Table-filter matching mode. `"exact"` preserves current exact-name behavior. `"glob"` enables case-insensitive `*` and `?` patterns in `include_tables` and `exclude_tables`. Character classes like `[]` are intentionally not supported. |
+| `column_filter_mode` | string | `"exact"` | Column-filter matching mode. `"exact"` matches source column names exactly, case-insensitively. `"glob"` enables case-insensitive `*` and `?` patterns in `exclude_columns`. |
 | `include_tables` | array of strings | `[]` | If non-empty, only migrate these source tables. Entries are exact names by default, or glob patterns when `table_filter_mode = "glob"`. |
 | `exclude_tables` | array of strings | `[]` | Source tables to skip. Applied after `include_tables`, so excludes win when both match the same table. |
+| `exclude_columns` | array of strings | `[]` | Source columns to skip. Use `ColumnName` to skip matching columns in any table, or `TableName.ColumnName` to scope a rule to one source table. Entries are exact by default, or glob patterns when `column_filter_mode = "glob"`. |
 | `on_schema_exists` | string | `"error"` | `"error"` aborts if the schema exists. `"recreate"` drops and recreates it. `"use"` requires the schema to already exist and be empty, then pgferry creates objects inside it. |
 | `schema_only` | bool | `false` | Create schema objects only. Skip data COPY. |
 | `data_only` | bool | `false` | Load data into an existing schema, then reset sequences. Requires the target role to disable and re-enable triggers on the selected target tables during the load. |
@@ -124,7 +126,9 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 
 Table filters always match source table names, not the transformed PostgreSQL names. In `glob` mode the matching is case-insensitive, mirroring exact-mode normalization. If a filter entry matches no source table, pgferry fails early instead of silently migrating the wrong scope.
 
-Changing `table_filter_mode`, `include_tables`, or `exclude_tables` can change the selected table set. When `resume = true`, that can invalidate the checkpoint fingerprint and force a fresh run.
+Column filters also match source names, not transformed PostgreSQL names. When a column is excluded, pgferry omits it from `CREATE TABLE`, source `SELECT`, and target `COPY`. Primary keys, indexes, and foreign keys that reference excluded columns are skipped. If a filter entry matches no source column, pgferry fails early.
+
+Changing `table_filter_mode`, `include_tables`, `exclude_tables`, `column_filter_mode`, or `exclude_columns` can change the selected migration scope. When `resume = true`, that can invalidate the checkpoint fingerprint and force a fresh run.
 
 ### `[source]`
 

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -104,7 +104,7 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | `column_filter_mode` | string | `"exact"` | Column-filter matching mode. `"exact"` matches source column names exactly, case-insensitively. `"glob"` enables case-insensitive `*` and `?` patterns in `exclude_columns`. |
 | `include_tables` | array of strings | `[]` | If non-empty, only migrate these source tables. Entries are exact names by default, or glob patterns when `table_filter_mode = "glob"`. |
 | `exclude_tables` | array of strings | `[]` | Source tables to skip. Applied after `include_tables`, so excludes win when both match the same table. |
-| `exclude_columns` | array of strings | `[]` | Source columns to skip. Use `ColumnName` to skip matching columns in any table, or `TableName.ColumnName` to scope a rule to one source table. Entries are exact by default, or glob patterns when `column_filter_mode = "glob"`. |
+| `exclude_columns` | array of strings | `[]` | Source columns to skip. Use `ColumnName` to skip matching columns in any table, or `TableName.ColumnName` to scope a rule to one source table. Entries are exact by default, or glob patterns in either the table or column part when `column_filter_mode = "glob"`. |
 | `on_schema_exists` | string | `"error"` | `"error"` aborts if the schema exists. `"recreate"` drops and recreates it. `"use"` requires the schema to already exist and be empty, then pgferry creates objects inside it. |
 | `schema_only` | bool | `false` | Create schema objects only. Skip data COPY. |
 | `data_only` | bool | `false` | Load data into an existing schema, then reset sequences. Requires the target role to disable and re-enable triggers on the selected target tables during the load. |
@@ -126,7 +126,7 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 
 Table filters always match source table names, not the transformed PostgreSQL names. In `glob` mode the matching is case-insensitive, mirroring exact-mode normalization. If a filter entry matches no source table, pgferry fails early instead of silently migrating the wrong scope.
 
-Column filters also match source names, not transformed PostgreSQL names. When a column is excluded, pgferry omits it from `CREATE TABLE`, source `SELECT`, and target `COPY`. Primary keys, indexes, and foreign keys that reference excluded columns are skipped. If a filter entry matches no source column, pgferry fails early.
+Column filters also match source names, not transformed PostgreSQL names. When a column is excluded, pgferry omits it from `CREATE TABLE`, source `SELECT`, and target `COPY`. Primary keys, plain-column indexes, and foreign keys that reference excluded columns are skipped. pgferry cannot inspect arbitrary expression index definitions for excluded column references; expression indexes are already reported as unsupported and skipped separately. If a filter entry matches no source column in the migrated schema, pgferry fails early.
 
 Changing `table_filter_mode`, `include_tables`, `exclude_tables`, `column_filter_mode`, or `exclude_columns` can change the selected migration scope. When `resume = true`, that can invalidate the checkpoint fingerprint and force a fresh run.
 

--- a/table_filter.go
+++ b/table_filter.go
@@ -584,8 +584,8 @@ func logTableFilterReport(report schemaFilterReport) {
 
 func logColumnFilterReport(report columnFilterReport) {
 	log.Printf("column filter: excluded %d of %d column(s)", len(report.ExcludedColumns), report.TotalColumns)
-	if len(report.ExcludedColumns) > 0 {
-		log.Printf("column filter: excluded columns: %s", strings.Join(report.ExcludedColumns, ", "))
+	for _, col := range report.ExcludedColumns {
+		log.Printf("  excluded column %s", col)
 	}
 	for _, pk := range report.SkippedPrimaryKeys {
 		log.Printf("  WARN: skipping primary key %s on %s because %s", pk.Name, pk.Table, pk.Reason)

--- a/table_filter.go
+++ b/table_filter.go
@@ -283,6 +283,8 @@ func filterSchemaColumns(schema *Schema, cfg *MigrationConfig) (*Schema, columnF
 		filtered.Tables = append(filtered.Tables, cloned)
 	}
 
+	// filtered.Tables remains parallel to schema.Tables because the first pass
+	// errors instead of omitting a table when all of its columns are excluded.
 	for i, table := range schema.Tables {
 		keptPGColumns := make(map[string]bool, len(filtered.Tables[i].Columns))
 		for _, col := range filtered.Tables[i].Columns {
@@ -400,7 +402,7 @@ func indexColumnsExist(idx Index, keptPGColumns map[string]bool) bool {
 func shouldKeepColumnFilteredForeignKey(fk ForeignKey, schema *Schema, keptLocalPGColumns map[string]bool) (bool, string) {
 	for _, col := range fk.Columns {
 		if !keptLocalPGColumns[normalizeTableFilterKey(col)] {
-			return false, "local column is excluded"
+			return false, fmt.Sprintf("local column %s is excluded", col)
 		}
 	}
 	refTable := findSchemaTableBySourceName(schema, fk.RefTable)

--- a/table_filter.go
+++ b/table_filter.go
@@ -230,12 +230,15 @@ func filterSchemaColumns(schema *Schema, cfg *MigrationConfig) (*Schema, columnF
 	if missing, err := missingColumnFilterEntries(mode, cfg.ExcludeColumns, schema.Tables); err != nil {
 		return nil, report, err
 	} else if len(missing) > 0 {
-		return nil, report, fmt.Errorf("exclude_columns entries did not match any source column: %s", strings.Join(missing, ", "))
+		return nil, report, fmt.Errorf("exclude_columns entries did not match any source column in the migrated schema (table may have been excluded by table filters): %s", strings.Join(missing, ", "))
 	}
 
 	filtered := &Schema{Tables: make([]Table, 0, len(schema.Tables))}
 	for _, table := range schema.Tables {
-		cloned := cloneTable(table)
+		cloned := Table{
+			SourceName: table.SourceName,
+			PGName:     table.PGName,
+		}
 		keptColumns := make([]Column, 0, len(table.Columns))
 		keptPGColumns := make(map[string]bool, len(table.Columns))
 
@@ -256,6 +259,10 @@ func filterSchemaColumns(schema *Schema, cfg *MigrationConfig) (*Schema, columnF
 		}
 		cloned.Columns = keptColumns
 
+		if table.PrimaryKey != nil {
+			pk := cloneIndex(*table.PrimaryKey)
+			cloned.PrimaryKey = &pk
+		}
 		if cloned.PrimaryKey != nil && !indexColumnsExist(*cloned.PrimaryKey, keptPGColumns) {
 			report.SkippedPrimaryKeys = append(report.SkippedPrimaryKeys, skippedSchemaIndex{
 				Table:  table.SourceName,

--- a/table_filter.go
+++ b/table_filter.go
@@ -234,6 +234,7 @@ func filterSchemaColumns(schema *Schema, cfg *MigrationConfig) (*Schema, columnF
 	}
 
 	filtered := &Schema{Tables: make([]Table, 0, len(schema.Tables))}
+	keptPGColumnsByTable := make([]map[string]bool, 0, len(schema.Tables))
 	for _, table := range schema.Tables {
 		cloned := Table{
 			SourceName: table.SourceName,
@@ -288,15 +289,13 @@ func filterSchemaColumns(schema *Schema, cfg *MigrationConfig) (*Schema, columnF
 		cloned.ForeignKeys = nil
 
 		filtered.Tables = append(filtered.Tables, cloned)
+		keptPGColumnsByTable = append(keptPGColumnsByTable, keptPGColumns)
 	}
 
 	// filtered.Tables remains parallel to schema.Tables because the first pass
 	// errors instead of omitting a table when all of its columns are excluded.
 	for i, table := range schema.Tables {
-		keptPGColumns := make(map[string]bool, len(filtered.Tables[i].Columns))
-		for _, col := range filtered.Tables[i].Columns {
-			keptPGColumns[normalizeTableFilterKey(col.PGName)] = true
-		}
+		keptPGColumns := keptPGColumnsByTable[i]
 		for _, fk := range table.ForeignKeys {
 			keep, reason := shouldKeepColumnFilteredForeignKey(fk, filtered, keptPGColumns)
 			if keep {

--- a/table_filter.go
+++ b/table_filter.go
@@ -22,8 +22,26 @@ type skippedForeignKey struct {
 	Reason   string
 }
 
+type columnFilterReport struct {
+	TotalColumns       int
+	ExcludedColumns    []string
+	SkippedPrimaryKeys []skippedSchemaIndex
+	SkippedIndexes     []skippedSchemaIndex
+	SkippedForeignKeys []skippedForeignKey
+}
+
+type skippedSchemaIndex struct {
+	Table  string
+	Name   string
+	Reason string
+}
+
 func hasTableFilters(cfg *MigrationConfig) bool {
 	return cfg != nil && (len(cfg.IncludeTables) > 0 || len(cfg.ExcludeTables) > 0)
+}
+
+func hasColumnFilters(cfg *MigrationConfig) bool {
+	return cfg != nil && len(cfg.ExcludeColumns) > 0
 }
 
 // Some unit tests and internal callers build MigrationConfig values directly
@@ -33,6 +51,17 @@ func effectiveTableFilterMode(cfg *MigrationConfig) string {
 		return "exact"
 	}
 	mode := strings.ToLower(strings.TrimSpace(cfg.TableFilterMode))
+	if mode == "" {
+		return "exact"
+	}
+	return mode
+}
+
+func effectiveColumnFilterMode(cfg *MigrationConfig) string {
+	if cfg == nil {
+		return "exact"
+	}
+	mode := strings.ToLower(strings.TrimSpace(cfg.ColumnFilterMode))
 	if mode == "" {
 		return "exact"
 	}
@@ -184,6 +213,229 @@ func filterSchemaTables(schema *Schema, cfg *MigrationConfig) (*Schema, schemaFi
 	return filtered, report, nil
 }
 
+func filterSchemaColumns(schema *Schema, cfg *MigrationConfig) (*Schema, columnFilterReport, error) {
+	report := columnFilterReport{}
+	if schema == nil {
+		return &Schema{}, report, nil
+	}
+
+	for _, table := range schema.Tables {
+		report.TotalColumns += len(table.Columns)
+	}
+	if !hasColumnFilters(cfg) {
+		return schema, report, nil
+	}
+	mode := effectiveColumnFilterMode(cfg)
+
+	if missing, err := missingColumnFilterEntries(mode, cfg.ExcludeColumns, schema.Tables); err != nil {
+		return nil, report, err
+	} else if len(missing) > 0 {
+		return nil, report, fmt.Errorf("exclude_columns entries did not match any source column: %s", strings.Join(missing, ", "))
+	}
+
+	filtered := &Schema{Tables: make([]Table, 0, len(schema.Tables))}
+	for _, table := range schema.Tables {
+		cloned := cloneTable(table)
+		keptColumns := make([]Column, 0, len(table.Columns))
+		keptPGColumns := make(map[string]bool, len(table.Columns))
+
+		for _, col := range table.Columns {
+			exclude, err := columnMatchesAnyFilterEntry(mode, table.SourceName, col.SourceName, cfg.ExcludeColumns)
+			if err != nil {
+				return nil, report, err
+			}
+			if exclude {
+				report.ExcludedColumns = append(report.ExcludedColumns, fmt.Sprintf("%s.%s", table.SourceName, col.SourceName))
+				continue
+			}
+			keptColumns = append(keptColumns, col)
+			keptPGColumns[normalizeTableFilterKey(col.PGName)] = true
+		}
+		if len(keptColumns) == 0 {
+			return nil, report, fmt.Errorf("exclude_columns removed every column from table %s; adjust exclude_columns", table.SourceName)
+		}
+		cloned.Columns = keptColumns
+
+		if cloned.PrimaryKey != nil && !indexColumnsExist(*cloned.PrimaryKey, keptPGColumns) {
+			report.SkippedPrimaryKeys = append(report.SkippedPrimaryKeys, skippedSchemaIndex{
+				Table:  table.SourceName,
+				Name:   cloned.PrimaryKey.Name,
+				Reason: "references an excluded column",
+			})
+			cloned.PrimaryKey = nil
+		}
+
+		cloned.Indexes = nil
+		for _, idx := range table.Indexes {
+			if !indexColumnsExist(idx, keptPGColumns) {
+				report.SkippedIndexes = append(report.SkippedIndexes, skippedSchemaIndex{
+					Table:  table.SourceName,
+					Name:   idx.Name,
+					Reason: "references an excluded column",
+				})
+				continue
+			}
+			cloned.Indexes = append(cloned.Indexes, cloneIndex(idx))
+		}
+
+		cloned.ForeignKeys = nil
+
+		filtered.Tables = append(filtered.Tables, cloned)
+	}
+
+	for i, table := range schema.Tables {
+		keptPGColumns := make(map[string]bool, len(filtered.Tables[i].Columns))
+		for _, col := range filtered.Tables[i].Columns {
+			keptPGColumns[normalizeTableFilterKey(col.PGName)] = true
+		}
+		for _, fk := range table.ForeignKeys {
+			keep, reason := shouldKeepColumnFilteredForeignKey(fk, filtered, keptPGColumns)
+			if keep {
+				filtered.Tables[i].ForeignKeys = append(filtered.Tables[i].ForeignKeys, cloneForeignKey(fk))
+				continue
+			}
+			report.SkippedForeignKeys = append(report.SkippedForeignKeys, skippedForeignKey{
+				Table:    table.SourceName,
+				Name:     fk.Name,
+				RefTable: fk.RefTable,
+				Reason:   reason,
+			})
+		}
+	}
+
+	return filtered, report, nil
+}
+
+func missingColumnFilterEntries(mode string, entries []string, tables []Table) ([]string, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	var missing []string
+	for _, entry := range entries {
+		matched, err := columnFilterEntryMatchesAnyColumn(mode, entry, tables)
+		if err != nil {
+			return nil, err
+		}
+		if !matched {
+			missing = append(missing, entry)
+		}
+	}
+	return missing, nil
+}
+
+func columnFilterEntryMatchesAnyColumn(mode, entry string, tables []Table) (bool, error) {
+	for _, table := range tables {
+		for _, col := range table.Columns {
+			matched, err := columnFilterEntryMatches(mode, entry, table.SourceName, col.SourceName)
+			if err != nil {
+				return false, err
+			}
+			if matched {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func columnMatchesAnyFilterEntry(mode, tableName, columnName string, entries []string) (bool, error) {
+	for _, entry := range entries {
+		matched, err := columnFilterEntryMatches(mode, entry, tableName, columnName)
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func columnFilterEntryMatches(mode, entry, tableName, columnName string) (bool, error) {
+	tablePattern, columnPattern, qualified := splitColumnFilterEntry(entry)
+	if mode == "glob" {
+		if qualified {
+			tableMatched, err := path.Match(normalizeTableFilterKey(tablePattern), normalizeTableFilterKey(tableName))
+			if err != nil {
+				return false, fmt.Errorf("match column filter %q against %s.%s: %w", entry, tableName, columnName, err)
+			}
+			if !tableMatched {
+				return false, nil
+			}
+		}
+		columnMatched, err := path.Match(normalizeTableFilterKey(columnPattern), normalizeTableFilterKey(columnName))
+		if err != nil {
+			return false, fmt.Errorf("match column filter %q against %s.%s: %w", entry, tableName, columnName, err)
+		}
+		return columnMatched, nil
+	}
+
+	if qualified && normalizeTableFilterKey(tablePattern) != normalizeTableFilterKey(tableName) {
+		return false, nil
+	}
+	return normalizeTableFilterKey(columnPattern) == normalizeTableFilterKey(columnName), nil
+}
+
+func splitColumnFilterEntry(entry string) (string, string, bool) {
+	tableName, columnName, qualified := strings.Cut(strings.TrimSpace(entry), ".")
+	if !qualified {
+		return "", tableName, false
+	}
+	return tableName, columnName, true
+}
+
+func indexColumnsExist(idx Index, keptPGColumns map[string]bool) bool {
+	if idx.HasExpression {
+		return true
+	}
+	for _, col := range idx.Columns {
+		if !keptPGColumns[normalizeTableFilterKey(col)] {
+			return false
+		}
+	}
+	return true
+}
+
+func shouldKeepColumnFilteredForeignKey(fk ForeignKey, schema *Schema, keptLocalPGColumns map[string]bool) (bool, string) {
+	for _, col := range fk.Columns {
+		if !keptLocalPGColumns[normalizeTableFilterKey(col)] {
+			return false, "local column is excluded"
+		}
+	}
+	refTable := findSchemaTableBySourceName(schema, fk.RefTable)
+	if refTable == nil {
+		return true, ""
+	}
+	for _, col := range fk.RefColumns {
+		if !tableHasPGColumn(*refTable, col) {
+			return false, fmt.Sprintf("referenced column %s is excluded", col)
+		}
+	}
+	return true, ""
+}
+
+func findSchemaTableBySourceName(schema *Schema, sourceName string) *Table {
+	if schema == nil {
+		return nil
+	}
+	for i := range schema.Tables {
+		if strings.EqualFold(schema.Tables[i].SourceName, sourceName) {
+			return &schema.Tables[i]
+		}
+	}
+	return nil
+}
+
+func tableHasPGColumn(table Table, pgName string) bool {
+	for _, col := range table.Columns {
+		if strings.EqualFold(col.PGName, pgName) {
+			return true
+		}
+	}
+	return false
+}
+
 func shouldKeepFilteredForeignKey(fk ForeignKey, cfg *MigrationConfig, selected map[string]bool) (bool, string) {
 	if fk.RefSchema != "" && !strings.EqualFold(strings.TrimSpace(fk.RefSchema), strings.TrimSpace(cfg.Source.SourceSchema)) {
 		return false, fmt.Sprintf("referenced table %s is in schema %q, outside the migrated schema %q", fk.RefTable, fk.RefSchema, cfg.Source.SourceSchema)
@@ -317,6 +569,22 @@ func logTableFilterReport(report schemaFilterReport) {
 	}
 
 	log.Printf("table filter: skipped %d foreign key(s) during table filtering", len(report.SkippedForeignKeys))
+	for _, fk := range report.SkippedForeignKeys {
+		log.Printf("  WARN: skipping foreign key %s on %s because %s", fk.Name, fk.Table, fk.Reason)
+	}
+}
+
+func logColumnFilterReport(report columnFilterReport) {
+	log.Printf("column filter: excluded %d of %d column(s)", len(report.ExcludedColumns), report.TotalColumns)
+	if len(report.ExcludedColumns) > 0 {
+		log.Printf("column filter: excluded columns: %s", strings.Join(report.ExcludedColumns, ", "))
+	}
+	for _, pk := range report.SkippedPrimaryKeys {
+		log.Printf("  WARN: skipping primary key %s on %s because %s", pk.Name, pk.Table, pk.Reason)
+	}
+	for _, idx := range report.SkippedIndexes {
+		log.Printf("  WARN: skipping index %s on %s because %s", idx.Name, idx.Table, idx.Reason)
+	}
 	for _, fk := range report.SkippedForeignKeys {
 		log.Printf("  WARN: skipping foreign key %s on %s because %s", fk.Name, fk.Table, fk.Reason)
 	}

--- a/table_filter_test.go
+++ b/table_filter_test.go
@@ -505,6 +505,75 @@ func TestFilterSchemaColumns_PrunesForeignKeysReferencingExcludedColumns(t *test
 	}
 }
 
+func TestFilterSchemaColumns_PrunesForeignKeysUsingExcludedLocalColumns(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Parents",
+				PGName:     "parents",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+				},
+			},
+			{
+				SourceName: "Children",
+				PGName:     "children",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+					{SourceName: "ParentID", PGName: "parent_id"},
+				},
+				ForeignKeys: []ForeignKey{
+					{Name: "fk_child_parent", Columns: []string{"parent_id"}, RefTable: "Parents", RefPGTable: "parents", RefColumns: []string{"id"}},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ExcludeColumns: []string{"Children.ParentID"},
+	}
+
+	filtered, report, err := filterSchemaColumns(schema, cfg)
+	if err != nil {
+		t.Fatalf("filterSchemaColumns() error: %v", err)
+	}
+
+	children := filtered.Tables[1]
+	if got := len(children.ForeignKeys); got != 0 {
+		t.Fatalf("children foreign keys = %d, want 0", got)
+	}
+	if got := len(report.SkippedForeignKeys); got != 1 {
+		t.Fatalf("skipped foreign keys = %d, want 1", got)
+	}
+	if got := report.SkippedForeignKeys[0].Reason; got != "local column parent_id is excluded" {
+		t.Fatalf("skipped foreign key reason = %q, want local column detail", got)
+	}
+}
+
+func TestFilterSchemaColumns_RejectsAllColumnsExcludedFromTable(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "AuditLog",
+				PGName:     "audit_log",
+				Columns: []Column{
+					{SourceName: "RowVersion", PGName: "row_version"},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ExcludeColumns: []string{"RowVersion"},
+	}
+
+	_, _, err := filterSchemaColumns(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "exclude_columns removed every column from table AuditLog") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestFilterSchemaColumns_RejectsUnknownExcludeColumn(t *testing.T) {
 	schema := &Schema{
 		Tables: []Table{

--- a/table_filter_test.go
+++ b/table_filter_test.go
@@ -346,6 +346,35 @@ func TestFilterSchemaTables_NilSchemaReturnsEmptySchema(t *testing.T) {
 	}
 }
 
+func TestFilterSchemaColumns_NilConfigReturnsSchemaUnchanged(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+					{SourceName: "RowVersion", PGName: "row_version"},
+				},
+			},
+		},
+	}
+
+	filtered, report, err := filterSchemaColumns(schema, nil)
+	if err != nil {
+		t.Fatalf("filterSchemaColumns() error: %v", err)
+	}
+	if filtered != schema {
+		t.Fatal("filtered schema pointer changed, want original schema when no column filters are configured")
+	}
+	if report.TotalColumns != 2 {
+		t.Fatalf("report.TotalColumns = %d, want 2", report.TotalColumns)
+	}
+	if len(report.ExcludedColumns) != 0 {
+		t.Fatalf("report.ExcludedColumns = %v, want none", report.ExcludedColumns)
+	}
+}
+
 func TestFilterSchemaColumns_ExcludesColumnsBySourceNameAndPrunesDependentObjects(t *testing.T) {
 	schema := &Schema{
 		Tables: []Table{

--- a/table_filter_test.go
+++ b/table_filter_test.go
@@ -346,6 +346,196 @@ func TestFilterSchemaTables_NilSchemaReturnsEmptySchema(t *testing.T) {
 	}
 }
 
+func TestFilterSchemaColumns_ExcludesColumnsBySourceNameAndPrunesDependentObjects(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+					{SourceName: "RowVersion", PGName: "row_version"},
+					{SourceName: "CustomerID", PGName: "customer_id"},
+				},
+				PrimaryKey: &Index{Name: "pk_orders", Columns: []string{"id"}},
+				Indexes: []Index{
+					{Name: "idx_customer", Columns: []string{"customer_id"}},
+					{Name: "idx_row_version", Columns: []string{"row_version"}},
+				},
+				ForeignKeys: []ForeignKey{
+					{Name: "fk_orders_customer", Columns: []string{"customer_id"}, RefTable: "Customers", RefPGTable: "customers", RefColumns: []string{"id"}},
+				},
+			},
+			{
+				SourceName: "Customers",
+				PGName:     "customers",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+					{SourceName: "RowVersion", PGName: "row_version"},
+				},
+				PrimaryKey: &Index{Name: "pk_customers", Columns: []string{"id"}},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ExcludeColumns: []string{"rowversion"},
+	}
+
+	filtered, report, err := filterSchemaColumns(schema, cfg)
+	if err != nil {
+		t.Fatalf("filterSchemaColumns() error: %v", err)
+	}
+
+	orders := filtered.Tables[0]
+	if got := sourceColumnNames(orders.Columns); strings.Join(got, ",") != "ID,CustomerID" {
+		t.Fatalf("orders columns = %v, want [ID CustomerID]", got)
+	}
+	if got := len(orders.Indexes); got != 1 {
+		t.Fatalf("orders indexes = %d, want 1", got)
+	}
+	if got := orders.Indexes[0].Name; got != "idx_customer" {
+		t.Fatalf("kept index = %q, want idx_customer", got)
+	}
+	if got := len(orders.ForeignKeys); got != 1 {
+		t.Fatalf("orders foreign keys = %d, want 1", got)
+	}
+	if got := sourceColumnNames(filtered.Tables[1].Columns); strings.Join(got, ",") != "ID" {
+		t.Fatalf("customers columns = %v, want [ID]", got)
+	}
+	if got := strings.Join(report.ExcludedColumns, ","); got != "Orders.RowVersion,Customers.RowVersion" {
+		t.Fatalf("excluded columns = %q, want Orders.RowVersion,Customers.RowVersion", got)
+	}
+	if got := len(report.SkippedIndexes); got != 1 || report.SkippedIndexes[0].Name != "idx_row_version" {
+		t.Fatalf("skipped indexes = %#v, want idx_row_version", report.SkippedIndexes)
+	}
+}
+
+func TestFilterSchemaColumns_QualifiedGlobPattern(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "App_Orders",
+				PGName:     "app_orders",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+					{SourceName: "Sys_RowVersion", PGName: "sys_row_version"},
+				},
+			},
+			{
+				SourceName: "AuditLog",
+				PGName:     "audit_log",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+					{SourceName: "Sys_RowVersion", PGName: "sys_row_version"},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnFilterMode: "glob",
+		ExcludeColumns:   []string{"app_*.sys_*"},
+	}
+
+	filtered, report, err := filterSchemaColumns(schema, cfg)
+	if err != nil {
+		t.Fatalf("filterSchemaColumns() error: %v", err)
+	}
+
+	if got := sourceColumnNames(filtered.Tables[0].Columns); strings.Join(got, ",") != "ID" {
+		t.Fatalf("app orders columns = %v, want [ID]", got)
+	}
+	if got := sourceColumnNames(filtered.Tables[1].Columns); strings.Join(got, ",") != "ID,Sys_RowVersion" {
+		t.Fatalf("audit columns = %v, want [ID Sys_RowVersion]", got)
+	}
+	if got := strings.Join(report.ExcludedColumns, ","); got != "App_Orders.Sys_RowVersion" {
+		t.Fatalf("excluded columns = %q, want App_Orders.Sys_RowVersion", got)
+	}
+}
+
+func TestFilterSchemaColumns_PrunesForeignKeysReferencingExcludedColumns(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Parents",
+				PGName:     "parents",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+					{SourceName: "RowVersion", PGName: "row_version"},
+				},
+			},
+			{
+				SourceName: "Children",
+				PGName:     "children",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+					{SourceName: "ParentID", PGName: "parent_id"},
+					{SourceName: "ParentRowVersion", PGName: "parent_row_version"},
+				},
+				ForeignKeys: []ForeignKey{
+					{Name: "fk_child_parent_id", Columns: []string{"parent_id"}, RefTable: "Parents", RefPGTable: "parents", RefColumns: []string{"id"}},
+					{Name: "fk_child_parent_version", Columns: []string{"parent_row_version"}, RefTable: "Parents", RefPGTable: "parents", RefColumns: []string{"row_version"}},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ExcludeColumns: []string{"RowVersion"},
+	}
+
+	filtered, report, err := filterSchemaColumns(schema, cfg)
+	if err != nil {
+		t.Fatalf("filterSchemaColumns() error: %v", err)
+	}
+
+	children := filtered.Tables[1]
+	if got := len(children.ForeignKeys); got != 1 {
+		t.Fatalf("children foreign keys = %d, want 1", got)
+	}
+	if got := children.ForeignKeys[0].Name; got != "fk_child_parent_id" {
+		t.Fatalf("kept foreign key = %q, want fk_child_parent_id", got)
+	}
+	if got := len(report.SkippedForeignKeys); got != 1 {
+		t.Fatalf("skipped foreign keys = %d, want 1", got)
+	}
+	if got := report.SkippedForeignKeys[0].Name; got != "fk_child_parent_version" {
+		t.Fatalf("skipped foreign key = %q, want fk_child_parent_version", got)
+	}
+	if got := report.SkippedForeignKeys[0].Reason; !strings.Contains(got, "referenced column row_version is excluded") {
+		t.Fatalf("skipped foreign key reason = %q, want referenced column detail", got)
+	}
+}
+
+func TestFilterSchemaColumns_RejectsUnknownExcludeColumn(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ExcludeColumns: []string{"RowVersion"},
+	}
+
+	_, _, err := filterSchemaColumns(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "exclude_columns entries did not match any source column") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func sourceColumnNames(cols []Column) []string {
+	names := make([]string, 0, len(cols))
+	for _, col := range cols {
+		names = append(names, col.SourceName)
+	}
+	return names
+}
+
 func TestFilterTriggersBySelectedTables(t *testing.T) {
 	schema := &Schema{
 		Tables: []Table{

--- a/table_filter_test.go
+++ b/table_filter_test.go
@@ -452,6 +452,89 @@ func TestFilterSchemaColumns_QualifiedGlobPattern(t *testing.T) {
 	}
 }
 
+func TestFilterSchemaColumns_UnqualifiedGlobPattern(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+					{SourceName: "RV_Orders", PGName: "rv_orders"},
+				},
+			},
+			{
+				SourceName: "Customers",
+				PGName:     "customers",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+					{SourceName: "rv_customers", PGName: "rv_customers"},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnFilterMode: "glob",
+		ExcludeColumns:   []string{"rv_*"},
+	}
+
+	filtered, report, err := filterSchemaColumns(schema, cfg)
+	if err != nil {
+		t.Fatalf("filterSchemaColumns() error: %v", err)
+	}
+
+	if got := sourceColumnNames(filtered.Tables[0].Columns); strings.Join(got, ",") != "ID" {
+		t.Fatalf("orders columns = %v, want [ID]", got)
+	}
+	if got := sourceColumnNames(filtered.Tables[1].Columns); strings.Join(got, ",") != "ID" {
+		t.Fatalf("customers columns = %v, want [ID]", got)
+	}
+	if got := strings.Join(report.ExcludedColumns, ","); got != "Orders.RV_Orders,Customers.rv_customers" {
+		t.Fatalf("excluded columns = %q, want Orders.RV_Orders,Customers.rv_customers", got)
+	}
+}
+
+func TestFilterSchemaColumns_ExcludedTableColumnFilterReportsMigratedSchemaScope(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Customers",
+				PGName:     "customers",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+				},
+			},
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns: []Column{
+					{SourceName: "ID", PGName: "id"},
+					{SourceName: "RowVersion", PGName: "row_version"},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ExcludeTables:  []string{"Orders"},
+		ExcludeColumns: []string{"Orders.RowVersion"},
+	}
+
+	filtered, _, err := filterSchemaTables(schema, cfg)
+	if err != nil {
+		t.Fatalf("filterSchemaTables() error: %v", err)
+	}
+	_, _, err = filterSchemaColumns(filtered, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "exclude_columns entries did not match any source column in the migrated schema") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "table may have been excluded by table filters") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestFilterSchemaColumns_PrunesForeignKeysReferencingExcludedColumns(t *testing.T) {
 	schema := &Schema{
 		Tables: []Table{

--- a/validate_cmd.go
+++ b/validate_cmd.go
@@ -133,6 +133,14 @@ func loadValidateSchema(ctx context.Context, src SourceDB, pgPool *pgxpool.Pool,
 	if hasTableFilters(cfg) {
 		logTableFilterReport(filterReport)
 	}
+	schema = filteredSchema
+	filteredSchema, columnFilterReport, err := filterSchemaColumns(schema, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("filter schema columns: %w", err)
+	}
+	if hasColumnFilters(cfg) {
+		logColumnFilterReport(columnFilterReport)
+	}
 	return filteredSchema, nil
 }
 

--- a/validate_cmd.go
+++ b/validate_cmd.go
@@ -133,8 +133,7 @@ func loadValidateSchema(ctx context.Context, src SourceDB, pgPool *pgxpool.Pool,
 	if hasTableFilters(cfg) {
 		logTableFilterReport(filterReport)
 	}
-	schema = filteredSchema
-	filteredSchema, columnFilterReport, err := filterSchemaColumns(schema, cfg)
+	filteredSchema, columnFilterReport, err := filterSchemaColumns(filteredSchema, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("filter schema columns: %w", err)
 	}


### PR DESCRIPTION
Closes #201 

## Summary

Adds column-level exclusion support for migrations.

- adds top-level `exclude_columns` and `column_filter_mode = "exact"|"glob"`
- supports unqualified `ColumnName` entries across all tables and qualified `TableName.ColumnName` entries for table-scoped exclusion
- applies filtering after table filtering for migrate, plan, and standalone validate paths
- prunes primary keys, indexes, and foreign keys that reference excluded columns
- updates configuration and operational docs for the new migration-scope settings

## Impact

Users can skip source columns such as MSSQL `RowVersion`/`timestamp` columns while keeping schema creation and data COPY aligned with the filtered column set. Filters match source names, not transformed PostgreSQL names, and unmatched filters fail early.

## Validation

- `go fmt ./...`
- `go test ./... -count=1`
- `go vet ./...`
- `go build -o build/pgferry .`