### PR TITLE
Add truncate_before_copy option

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type MigrationConfig struct {
 	OnSchemaExists                    string            `toml:"on_schema_exists"`
 	SchemaOnly                        bool              `toml:"schema_only"`
 	DataOnly                          bool              `toml:"data_only"`
+	TruncateBeforeCopy                bool              `toml:"truncate_before_copy"`
 	SourceSnapshotMode                string            `toml:"source_snapshot_mode"` // none|single_tx
 	UnloggedTables                    bool              `toml:"unlogged_tables"`
 	PreserveDefaults                  bool              `toml:"preserve_defaults"`
@@ -338,6 +339,9 @@ func finalizeConfig(cfg *MigrationConfig, configDir string) error {
 	}
 	if cfg.Resume && cfg.SchemaOnly {
 		return fmt.Errorf("resume is incompatible with schema_only (no data to resume)")
+	}
+	if cfg.Resume && cfg.TruncateBeforeCopy {
+		return fmt.Errorf("resume is incompatible with truncate_before_copy=true (a resumed run would truncate rows that the checkpoint may skip)")
 	}
 	if cfg.Resume && cfg.UnloggedTables {
 		return fmt.Errorf("resume is incompatible with unlogged_tables=true (checkpointed progress can outlive crash-truncated UNLOGGED tables)")

--- a/config.go
+++ b/config.go
@@ -331,6 +331,9 @@ func finalizeConfig(cfg *MigrationConfig, configDir string) error {
 	if cfg.SchemaOnly && cfg.DataOnly {
 		return fmt.Errorf("schema_only and data_only are mutually exclusive")
 	}
+	if cfg.SchemaOnly && cfg.TruncateBeforeCopy {
+		return fmt.Errorf("truncate_before_copy is incompatible with schema_only (no data phase runs)")
+	}
 	if cfg.Resume && cfg.OnSchemaExists == "recreate" {
 		return fmt.Errorf("resume is incompatible with on_schema_exists=recreate (would destroy data to resume into)")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -242,6 +242,35 @@ dsn = "postgres://u:p@h:5432/db"
 	}
 }
 
+func TestLoadConfig_SchemaOnlyRejectsTruncateBeforeCopy(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "schema-only-truncate.toml")
+
+	content := `
+schema = "target"
+schema_only = true
+truncate_before_copy = true
+
+[source]
+type = "mysql"
+dsn = "root:root@tcp(127.0.0.1:3306)/db"
+
+[target]
+dsn = "postgres://u:p@h:5432/db"
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadConfig(cfgFile)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "truncate_before_copy is incompatible with schema_only") {
+		t.Fatalf("error = %v, want schema_only/truncate incompatibility", err)
+	}
+}
+
 func TestLoadConfig_DSNEnvOverrides(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/config_test.go
+++ b/config_test.go
@@ -22,6 +22,7 @@ preserve_defaults = true
 add_unsigned_checks = true
 replicate_on_update_current_timestamp = true
 workers = 8
+truncate_before_copy = true
 
 [source]
 type = "mysql"
@@ -78,6 +79,9 @@ after_all = ["post.sql"]
 	if !cfg.ReplicateOnUpdateCurrentTimestamp {
 		t.Errorf("ReplicateOnUpdateCurrentTimestamp = %t, want true", cfg.ReplicateOnUpdateCurrentTimestamp)
 	}
+	if !cfg.TruncateBeforeCopy {
+		t.Errorf("TruncateBeforeCopy = %t, want true", cfg.TruncateBeforeCopy)
+	}
 	if len(cfg.Hooks.BeforeFk) != 1 || cfg.Hooks.BeforeFk[0] != "cleanup.sql" {
 		t.Errorf("Hooks.BeforeFk = %v", cfg.Hooks.BeforeFk)
 	}
@@ -130,6 +134,9 @@ dsn = "postgres://u:p@h:5432/db"
 	}
 	if cfg.ReplicateOnUpdateCurrentTimestamp {
 		t.Errorf("default ReplicateOnUpdateCurrentTimestamp = %t, want false", cfg.ReplicateOnUpdateCurrentTimestamp)
+	}
+	if cfg.TruncateBeforeCopy {
+		t.Errorf("default TruncateBeforeCopy = %t, want false", cfg.TruncateBeforeCopy)
 	}
 	if !cfg.CleanOrphans {
 		t.Errorf("default CleanOrphans = %t, want true", cfg.CleanOrphans)
@@ -203,6 +210,35 @@ dsn = "postgres://u:p@h:5432/db"
 	}
 	if cfg.Source.Charset != "utf8mb4" {
 		t.Errorf("default Source.Charset = %q, want %q", cfg.Source.Charset, "utf8mb4")
+	}
+}
+
+func TestLoadConfig_ResumeRejectsTruncateBeforeCopy(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "resume-truncate.toml")
+
+	content := `
+schema = "target"
+resume = true
+truncate_before_copy = true
+
+[source]
+type = "mysql"
+dsn = "root:root@tcp(127.0.0.1:3306)/db"
+
+[target]
+dsn = "postgres://u:p@h:5432/db"
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadConfig(cfgFile)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "resume is incompatible with truncate_before_copy=true") {
+		t.Fatalf("error = %v, want resume/truncate incompatibility", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -424,7 +424,6 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 				if !cfg.TruncateBeforeCopy {
 					return nil
 				}
-				log.Printf("truncating target tables before COPY...")
 				return truncateTargetTablesBeforeCopy(ctx, pgPool, schema, cfg.Schema)
 			},
 			func() error {

--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 		mode = "data_only"
 	}
 	log.Printf(
-		"config: mode=%s workers=%d index_workers=%d schema=%s on_schema_exists=%s source_snapshot_mode=%s unlogged_tables=%t preserve_defaults=%t add_unsigned_checks=%t clean_orphans=%t clean_orphans_mode=%s clean_orphans_max_rows=%d identifier_case=%s replicate_on_update_current_timestamp=%t chunk_size=%d copy_risk_analysis=%t resume=%t validation=%s",
+		"config: mode=%s workers=%d index_workers=%d schema=%s on_schema_exists=%s source_snapshot_mode=%s unlogged_tables=%t preserve_defaults=%t add_unsigned_checks=%t clean_orphans=%t clean_orphans_mode=%s clean_orphans_max_rows=%d identifier_case=%s replicate_on_update_current_timestamp=%t truncate_before_copy=%t chunk_size=%d copy_risk_analysis=%t resume=%t validation=%s",
 		mode,
 		cfg.Workers,
 		cfg.IndexWorkers,
@@ -207,6 +207,7 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 		cfg.CleanOrphansMaxRows,
 		cfg.IdentifierCase,
 		cfg.ReplicateOnUpdateCurrentTimestamp,
+		cfg.TruncateBeforeCopy,
 		cfg.ChunkSize,
 		cfg.CopyRiskAnalysis,
 		cfg.Resume,
@@ -420,6 +421,13 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 				return loadAndExecSQLFiles(ctx, pgPool, cfg, cfg.Hooks.BeforeData, "before_data")
 			},
 			func() error {
+				if !cfg.TruncateBeforeCopy {
+					return nil
+				}
+				log.Printf("truncating target tables before COPY...")
+				return truncateTargetTablesBeforeCopy(ctx, pgPool, schema, cfg.Schema)
+			},
+			func() error {
 				if cfg.SourceSnapshotMode == "single_tx" {
 					log.Printf("migrating data with source_snapshot_mode=single_tx (sequential)")
 				} else {
@@ -528,12 +536,16 @@ func runDataMigrationPhase(
 	preflightTriggerControl func() error,
 	setTriggers func(enable bool) error,
 	beforeData func() error,
+	truncateBeforeCopy func() error,
 	migrate func() error,
 	afterData func() error,
 ) (err error) {
 	if !dataOnly {
 		if err := beforeData(); err != nil {
 			return fmt.Errorf("before_data hooks: %w", err)
+		}
+		if err := truncateBeforeCopy(); err != nil {
+			return fmt.Errorf("truncate before copy: %w", err)
 		}
 		if err := migrate(); err != nil {
 			return fmt.Errorf("migrate data: %w", err)
@@ -572,6 +584,9 @@ func runDataMigrationPhase(
 
 	if err := beforeData(); err != nil {
 		return fmt.Errorf("before_data hooks: %w", err)
+	}
+	if err := truncateBeforeCopy(); err != nil {
+		return fmt.Errorf("truncate before copy: %w", err)
 	}
 	if err := migrate(); err != nil {
 		return fmt.Errorf("migrate data: %w", err)

--- a/main_data_phase_test.go
+++ b/main_data_phase_test.go
@@ -29,6 +29,10 @@ func TestRunDataMigrationPhase_DataOnlySuccess(t *testing.T) {
 			return nil
 		},
 		func() error {
+			calls = append(calls, "truncate")
+			return nil
+		},
+		func() error {
 			calls = append(calls, "migrate")
 			return nil
 		},
@@ -41,7 +45,56 @@ func TestRunDataMigrationPhase_DataOnlySuccess(t *testing.T) {
 		t.Fatalf("runDataMigrationPhase() error: %v", err)
 	}
 
-	want := []string{"preflight", "disable", "before", "migrate", "after", "enable"}
+	want := []string{"preflight", "disable", "before", "truncate", "migrate", "after", "enable"}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("call order = %v, want %v", calls, want)
+	}
+}
+
+func TestRunDataMigrationPhase_DataOnlyTruncateFailureStillEnables(t *testing.T) {
+	truncateErr := errors.New("truncate failed")
+	var calls []string
+
+	err := runDataMigrationPhase(
+		true,
+		func(string, ...any) {},
+		func() error {
+			calls = append(calls, "preflight")
+			return nil
+		},
+		func(enable bool) error {
+			if enable {
+				calls = append(calls, "enable")
+			} else {
+				calls = append(calls, "disable")
+			}
+			return nil
+		},
+		func() error {
+			calls = append(calls, "before")
+			return nil
+		},
+		func() error {
+			calls = append(calls, "truncate")
+			return truncateErr
+		},
+		func() error {
+			calls = append(calls, "migrate")
+			return nil
+		},
+		func() error {
+			calls = append(calls, "after")
+			return nil
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, truncateErr) {
+		t.Fatalf("expected error to wrap truncateErr, got %v", err)
+	}
+
+	want := []string{"preflight", "disable", "before", "truncate", "enable"}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("call order = %v, want %v", calls, want)
 	}
@@ -70,6 +123,10 @@ func TestRunDataMigrationPhase_DataOnlyBeforeFailureStillEnables(t *testing.T) {
 		func() error {
 			calls = append(calls, "before")
 			return beforeErr
+		},
+		func() error {
+			calls = append(calls, "truncate")
+			return nil
 		},
 		func() error {
 			calls = append(calls, "migrate")
@@ -120,6 +177,10 @@ func TestRunDataMigrationPhase_DataOnlyMigrateFailureStillEnables(t *testing.T) 
 			return nil
 		},
 		func() error {
+			calls = append(calls, "truncate")
+			return nil
+		},
+		func() error {
 			calls = append(calls, "migrate")
 			return migrateErr
 		},
@@ -135,7 +196,7 @@ func TestRunDataMigrationPhase_DataOnlyMigrateFailureStillEnables(t *testing.T) 
 		t.Fatalf("expected error to wrap migrateErr, got %v", err)
 	}
 
-	want := []string{"preflight", "disable", "before", "migrate", "enable"}
+	want := []string{"preflight", "disable", "before", "truncate", "migrate", "enable"}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("call order = %v, want %v", calls, want)
 	}
@@ -165,6 +226,10 @@ func TestRunDataMigrationPhase_DataOnlyAfterFailureStillEnables(t *testing.T) {
 			return nil
 		},
 		func() error {
+			calls = append(calls, "truncate")
+			return nil
+		},
+		func() error {
 			calls = append(calls, "migrate")
 			return nil
 		},
@@ -180,7 +245,7 @@ func TestRunDataMigrationPhase_DataOnlyAfterFailureStillEnables(t *testing.T) {
 		t.Fatalf("expected error to wrap afterErr, got %v", err)
 	}
 
-	want := []string{"preflight", "disable", "before", "migrate", "after", "enable"}
+	want := []string{"preflight", "disable", "before", "truncate", "migrate", "after", "enable"}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("call order = %v, want %v", calls, want)
 	}
@@ -207,6 +272,10 @@ func TestRunDataMigrationPhase_DataOnlyPreflightFailureStopsEarly(t *testing.T) 
 		},
 		func() error {
 			calls = append(calls, "before")
+			return nil
+		},
+		func() error {
+			calls = append(calls, "truncate")
 			return nil
 		},
 		func() error {
@@ -255,6 +324,10 @@ func TestRunDataMigrationPhase_DataOnlyDisableFailureStopsEarly(t *testing.T) {
 			return nil
 		},
 		func() error {
+			calls = append(calls, "truncate")
+			return nil
+		},
+		func() error {
 			calls = append(calls, "migrate")
 			return nil
 		},
@@ -299,6 +372,10 @@ func TestRunDataMigrationPhase_NonDataOnlySkipsTriggerCalls(t *testing.T) {
 			return nil
 		},
 		func() error {
+			calls = append(calls, "truncate")
+			return nil
+		},
+		func() error {
 			calls = append(calls, "migrate")
 			return nil
 		},
@@ -311,7 +388,7 @@ func TestRunDataMigrationPhase_NonDataOnlySkipsTriggerCalls(t *testing.T) {
 		t.Fatalf("runDataMigrationPhase() error: %v", err)
 	}
 
-	want := []string{"before", "migrate", "after"}
+	want := []string{"before", "truncate", "migrate", "after"}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("call order = %v, want %v", calls, want)
 	}
@@ -329,6 +406,7 @@ func TestRunDataMigrationPhase_CleanupLogsOnFailure(t *testing.T) {
 		func() error { return nil },
 		func(bool) error { return nil },
 		func() error { return beforeErr },
+		func() error { return nil },
 		func() error { return nil },
 		func() error { return nil },
 	)

--- a/site/src/content/docs/migration-patterns/schema-only-and-data-only.md
+++ b/site/src/content/docs/migration-patterns/schema-only-and-data-only.md
@@ -17,11 +17,15 @@ Use this when the target schema already exists and you only need to stream data 
 
 If that preflight fails, pgferry aborts before COPY starts so operators are not left guessing whether any data moved or whether trigger state changed permanently.
 
+If your own schema migrator creates the target tables and inserts seed/reference data, use `truncate_before_copy = true` in the data-only config when those rows should be replaced by the source data. pgferry runs `TRUNCATE TABLE ... CASCADE` on the selected target tables after `before_data` hooks and before COPY.
+
 ## Tradeoff
 
 This is slower than the default full pipeline because data loads into a schema that already has more objects in place.
 
 It is also more privilege-sensitive than the full pipeline, especially on managed PostgreSQL services or environments with restricted application roles.
+
+`truncate_before_copy = true` is incompatible with `resume = true`, because a resumed retry would truncate rows that the checkpoint may skip.
 
 ## Start from these examples
 

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -108,6 +108,7 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | `on_schema_exists` | string | `"error"` | `"error"` aborts if the schema exists. `"recreate"` drops and recreates it. `"use"` requires the schema to already exist and be empty, then pgferry creates objects inside it. |
 | `schema_only` | bool | `false` | Create schema objects only. Skip data COPY. |
 | `data_only` | bool | `false` | Load data into an existing schema, then reset sequences. Requires the target role to disable and re-enable triggers on the selected target tables during the load. |
+| `truncate_before_copy` | bool | `false` | Run `TRUNCATE TABLE ... CASCADE` on the selected target tables after `before_data` hooks and before COPY. Useful with `data_only` when an external schema migrator pre-seeds reference rows that should be replaced by source data. |
 | `source_snapshot_mode` | string | `"none"` | `"none"` is fastest. `"single_tx"` gives one consistent source snapshot on MySQL, MariaDB, and MSSQL. |
 | `identifier_case` | string | `"snake"` | How source identifiers map to PostgreSQL names. `"snake"` converts `OrderItems` → `order_items`. `"lower"` lowercases only (`OrderItems` → `orderitems`). `"preserve"` keeps the source casing unchanged (`OrderItems` → `OrderItems`); PostgreSQL DDL is always quoted so mixed-case names are safe. |
 | `unlogged_tables` | bool | `true` | Use `UNLOGGED` tables during full loads, then `SET LOGGED` later. |
@@ -129,6 +130,8 @@ Table filters always match source table names, not the transformed PostgreSQL na
 Column filters also match source names, not transformed PostgreSQL names. When a column is excluded, pgferry omits it from `CREATE TABLE`, source `SELECT`, and target `COPY`. Primary keys, plain-column indexes, and foreign keys that reference excluded columns are skipped. pgferry cannot inspect arbitrary expression index definitions for excluded column references; expression indexes are already reported as unsupported and skipped separately. If a filter entry matches no source column in the migrated schema, pgferry fails early.
 
 Changing `table_filter_mode`, `include_tables`, `exclude_tables`, `column_filter_mode`, or `exclude_columns` can change the selected migration scope. When `resume = true`, that can invalidate the checkpoint fingerprint and force a fresh run.
+
+`truncate_before_copy` follows the selected table scope after filters. Excluded tables are not named in pgferry's generated `TRUNCATE TABLE ... CASCADE` statement, though PostgreSQL can still truncate dependent tables through `CASCADE`.
 
 ### `[source]`
 
@@ -246,6 +249,7 @@ The `database` parameter is required because pgferry extracts the DB name for in
 | `resume = true` + `on_schema_exists = "recreate"` | Invalid because the target schema would be dropped. |
 | `resume = true` + `on_schema_exists = "use"` | Invalid because a resumed run would re-enter a now non-empty schema. |
 | `resume = true` + `schema_only = true` | Invalid because there is no data stage to resume. |
+| `resume = true` + `truncate_before_copy = true` | Invalid because a resumed run would truncate rows that the checkpoint may skip. |
 | `resume = true` + `unlogged_tables = true` | Invalid because checkpointed progress could outlive crash-truncated tables. |
 | `schema_only = true` + `data_only = true` | Invalid. Choose one or neither. |
 | SQLite + `source_snapshot_mode = "single_tx"` | Invalid. SQLite only supports `none`. |
@@ -260,5 +264,6 @@ The `database` parameter is required because pgferry extracts the DB name for in
 - Use `source_snapshot_mode = "single_tx"` when the source stays live during the migration and you need one consistent read view.
 - Keep `on_schema_exists = "error"` for the first production dry runs so you do not destroy previous target state by mistake.
 - Use `on_schema_exists = "use"` only when infrastructure or policy pre-creates the schema shell and you want pgferry to own everything inside it from empty.
+- Use `truncate_before_copy = true` with `data_only` when the target schema was created by another migrator and contains seed rows that should be replaced before COPY.
 - Expect `data_only` to fail early on PostgreSQL roles that cannot run `ALTER TABLE ... DISABLE/ENABLE TRIGGER ALL`; rehearse that path with the real target role before cutover.
 - Prefer hooks for views, routines, cleanup SQL, or post-load validation queries that are specific to your application.

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -108,7 +108,7 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | `on_schema_exists` | string | `"error"` | `"error"` aborts if the schema exists. `"recreate"` drops and recreates it. `"use"` requires the schema to already exist and be empty, then pgferry creates objects inside it. |
 | `schema_only` | bool | `false` | Create schema objects only. Skip data COPY. |
 | `data_only` | bool | `false` | Load data into an existing schema, then reset sequences. Requires the target role to disable and re-enable triggers on the selected target tables during the load. |
-| `truncate_before_copy` | bool | `false` | Run `TRUNCATE TABLE ... CASCADE` on the selected target tables after `before_data` hooks and before COPY. Useful with `data_only` when an external schema migrator pre-seeds reference rows that should be replaced by source data. |
+| `truncate_before_copy` | bool | `false` | Run `TRUNCATE TABLE ... CASCADE` on the selected target tables after `before_data` hooks and before COPY. Useful with `data_only` when an external schema migrator pre-seeds reference rows that should be replaced by source data. In full migrations, target tables are normally freshly created, so this is usually a no-op. |
 | `source_snapshot_mode` | string | `"none"` | `"none"` is fastest. `"single_tx"` gives one consistent source snapshot on MySQL, MariaDB, and MSSQL. |
 | `identifier_case` | string | `"snake"` | How source identifiers map to PostgreSQL names. `"snake"` converts `OrderItems` → `order_items`. `"lower"` lowercases only (`OrderItems` → `orderitems`). `"preserve"` keeps the source casing unchanged (`OrderItems` → `OrderItems`); PostgreSQL DDL is always quoted so mixed-case names are safe. |
 | `unlogged_tables` | bool | `true` | Use `UNLOGGED` tables during full loads, then `SET LOGGED` later. |
@@ -252,6 +252,7 @@ The `database` parameter is required because pgferry extracts the DB name for in
 | `resume = true` + `truncate_before_copy = true` | Invalid because a resumed run would truncate rows that the checkpoint may skip. |
 | `resume = true` + `unlogged_tables = true` | Invalid because checkpointed progress could outlive crash-truncated tables. |
 | `schema_only = true` + `data_only = true` | Invalid. Choose one or neither. |
+| `schema_only = true` + `truncate_before_copy = true` | Invalid because no data phase runs. |
 | SQLite + `source_snapshot_mode = "single_tx"` | Invalid. SQLite only supports `none`. |
 | MariaDB + `[postgis]` | Invalid. Use `type_mapping.spatial_mode` fallback modes instead. |
 

--- a/site/src/content/docs/reference/migration-pipeline.md
+++ b/site/src/content/docs/reference/migration-pipeline.md
@@ -13,19 +13,20 @@ The default pgferry flow is built to load data first and add expensive constrain
 | 2 | Introspect the source schema | Yes | Yes | Yes |
 | 3 | Create target schema and tables | Yes | Yes | No |
 | 4 | Run `before_data` hooks | Yes | No | Yes |
-| 5 | Stream data with `COPY` | Yes | No | Yes |
-| 6 | Run `after_data` hooks | Yes | No | Yes |
-| 7 | Optional validation | Yes | No | Yes |
-| 8 | `SET LOGGED` for full migrations using `UNLOGGED` tables | Yes | No | No |
-| 9 | Add primary keys | Yes | Yes | No |
-| 10 | Add indexes with bounded parallelism | Yes | Yes | No |
-| 11 | Run `before_fk` hooks | Yes | Yes | No |
-| 12 | Optional orphan cleanup | Yes | No | No |
-| 13 | Add foreign keys | Yes | Yes | No |
-| 14 | Reset sequences | Yes | Yes | Yes |
-| 15 | Optional unsigned checks | Yes | Yes | No |
-| 16 | Optional trigger emulation | Yes | Yes | No |
-| 17 | Run `after_all` hooks | Yes | Yes | Yes |
+| 5 | Optional `truncate_before_copy` target-table truncate | Yes | No | Yes |
+| 6 | Stream data with `COPY` | Yes | No | Yes |
+| 7 | Run `after_data` hooks | Yes | No | Yes |
+| 8 | Optional validation | Yes | No | Yes |
+| 9 | `SET LOGGED` for full migrations using `UNLOGGED` tables | Yes | No | No |
+| 10 | Add primary keys | Yes | Yes | No |
+| 11 | Add indexes with bounded parallelism | Yes | Yes | No |
+| 12 | Run `before_fk` hooks | Yes | Yes | No |
+| 13 | Optional orphan cleanup | Yes | No | No |
+| 14 | Add foreign keys | Yes | Yes | No |
+| 15 | Reset sequences | Yes | Yes | Yes |
+| 16 | Optional unsigned checks | Yes | Yes | No |
+| 17 | Optional trigger emulation | Yes | Yes | No |
+| 18 | Run `after_all` hooks | Yes | Yes | Yes |
 
 ## Modes
 
@@ -74,6 +75,8 @@ Use this when the target schema already exists from a prior `schema_only` run or
 Operational note: before COPY starts, pgferry verifies that the target role can run `ALTER TABLE ... DISABLE TRIGGER ALL` and later re-enable those triggers on the selected target tables. If that preflight fails, pgferry aborts before copying any data.
 
 This matters because `data_only` loads into a schema where foreign keys and other triggers may already exist. pgferry temporarily disables those triggers during the load so parallel COPY can proceed without immediate FK enforcement.
+
+When an external schema migrator also inserts seed or reference rows, set `truncate_before_copy = true` in the data-only config. pgferry will run one `TRUNCATE TABLE ... CASCADE` statement for the selected target tables after `before_data` hooks and before COPY, so duplicate source rows do not collide with pre-seeded target rows.
 
 ## Two-phase workflow
 

--- a/site/src/content/docs/reference/migration-pipeline.md
+++ b/site/src/content/docs/reference/migration-pipeline.md
@@ -13,7 +13,7 @@ The default pgferry flow is built to load data first and add expensive constrain
 | 2 | Introspect the source schema | Yes | Yes | Yes |
 | 3 | Create target schema and tables | Yes | Yes | No |
 | 4 | Run `before_data` hooks | Yes | No | Yes |
-| 5 | Optional `truncate_before_copy` target-table truncate | Yes | No | Yes |
+| 5 | Optional target-table truncate (`truncate_before_copy`) | Yes | No | Yes |
 | 6 | Stream data with `COPY` | Yes | No | Yes |
 | 7 | Run `after_data` hooks | Yes | No | Yes |
 | 8 | Optional validation | Yes | No | Yes |

--- a/truncate.go
+++ b/truncate.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -17,5 +18,6 @@ func truncateTargetTablesBeforeCopy(ctx context.Context, exec statementExecutor,
 	}
 
 	q := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", strings.Join(targets, ", "))
+	log.Printf("truncating target tables before COPY (CASCADE may affect dependent tables outside migration scope): %s", strings.Join(targets, ", "))
 	return execSQL(ctx, exec, "truncate target tables before copy", q)
 }

--- a/truncate.go
+++ b/truncate.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+func truncateTargetTablesBeforeCopy(ctx context.Context, exec statementExecutor, schema *Schema, pgSchema string) error {
+	if schema == nil || len(schema.Tables) == 0 {
+		return nil
+	}
+
+	targets := make([]string, len(schema.Tables))
+	for i, t := range schema.Tables {
+		targets[i] = fmt.Sprintf("%s.%s", pgIdent(pgSchema), pgIdent(t.PGName))
+	}
+
+	q := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", strings.Join(targets, ", "))
+	return execSQL(ctx, exec, "truncate target tables before copy", q)
+}

--- a/truncate_test.go
+++ b/truncate_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTruncateTargetTablesBeforeCopy_GeneratesSingleCascadeStatement(t *testing.T) {
+	exec := &recordingStatementExecutor{}
+	schema := &Schema{Tables: []Table{
+		{PGName: "users"},
+		{PGName: `order"items`},
+	}}
+
+	if err := truncateTargetTablesBeforeCopy(context.Background(), exec, schema, "app"); err != nil {
+		t.Fatalf("truncateTargetTablesBeforeCopy() error: %v", err)
+	}
+
+	want := `TRUNCATE TABLE "app"."users", "app"."order""items" CASCADE`
+	if len(exec.calls) != 1 || exec.calls[0] != want {
+		t.Fatalf("exec calls = %v, want [%q]", exec.calls, want)
+	}
+}
+
+func TestTruncateTargetTablesBeforeCopy_SkipsEmptySchema(t *testing.T) {
+	exec := &recordingStatementExecutor{}
+
+	if err := truncateTargetTablesBeforeCopy(context.Background(), exec, &Schema{}, "app"); err != nil {
+		t.Fatalf("truncateTargetTablesBeforeCopy() error: %v", err)
+	}
+	if len(exec.calls) != 0 {
+		t.Fatalf("exec calls = %v, want none", exec.calls)
+	}
+}
+
+func TestTruncateTargetTablesBeforeCopy_WrapsExecError(t *testing.T) {
+	truncateSQL := `TRUNCATE TABLE "app"."users" CASCADE`
+	execErr := errors.New("permission denied")
+	exec := &recordingStatementExecutor{
+		errByQuery: map[string]error{truncateSQL: execErr},
+	}
+
+	err := truncateTargetTablesBeforeCopy(context.Background(), exec, &Schema{Tables: []Table{{PGName: "users"}}}, "app")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, execErr) {
+		t.Fatalf("expected error to wrap execErr, got %v", err)
+	}
+	if !strings.Contains(err.Error(), truncateSQL) {
+		t.Fatalf("error = %v, want SQL detail", err)
+	}
+}

--- a/truncate_test.go
+++ b/truncate_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
 	"strings"
 	"testing"
 )
@@ -21,6 +23,28 @@ func TestTruncateTargetTablesBeforeCopy_GeneratesSingleCascadeStatement(t *testi
 	want := `TRUNCATE TABLE "app"."users", "app"."order""items" CASCADE`
 	if len(exec.calls) != 1 || exec.calls[0] != want {
 		t.Fatalf("exec calls = %v, want [%q]", exec.calls, want)
+	}
+}
+
+func TestTruncateTargetTablesBeforeCopy_LogsCascadeScope(t *testing.T) {
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+
+	exec := &recordingStatementExecutor{}
+	schema := &Schema{Tables: []Table{
+		{PGName: "orders"},
+		{PGName: "order_items"},
+	}}
+
+	if err := truncateTargetTablesBeforeCopy(context.Background(), exec, schema, "app"); err != nil {
+		t.Fatalf("truncateTargetTablesBeforeCopy() error: %v", err)
+	}
+
+	want := `truncating target tables before COPY (CASCADE may affect dependent tables outside migration scope): "app"."orders", "app"."order_items"`
+	if !strings.Contains(buf.String(), want) {
+		t.Fatalf("log output = %q, want %q", buf.String(), want)
 	}
 }
 

--- a/wizard.go
+++ b/wizard.go
@@ -630,6 +630,9 @@ func renderConfigTOML(cfg *MigrationConfig) string {
 	if cfg.ReplicateOnUpdateCurrentTimestamp {
 		writeLine("replicate_on_update_current_timestamp = true")
 	}
+	if cfg.TruncateBeforeCopy {
+		writeLine("truncate_before_copy = true")
+	}
 	if cfg.Workers != effectiveDefaultWorkers(cfg.Source.Type) {
 		writeLine("workers = %d", cfg.Workers)
 	}

--- a/wizard_test.go
+++ b/wizard_test.go
@@ -772,6 +772,22 @@ func TestRenderConfigTOMLIncludesAdvancedOverrides(t *testing.T) {
 	}
 }
 
+func TestRenderConfigTOMLIncludesTruncateBeforeCopy(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Source.Type = "mysql"
+	cfg.Source.DSN = "root:root@tcp(127.0.0.1:3306)/sakila"
+	cfg.Target.DSN = "postgres://postgres:postgres@127.0.0.1:5432/target?sslmode=disable"
+	cfg.Schema = "sakila"
+	cfg.DataOnly = true
+	cfg.TruncateBeforeCopy = true
+
+	rendered := renderConfigTOML(&cfg)
+
+	if !strings.Contains(rendered, "truncate_before_copy = true") {
+		t.Fatalf("expected truncate_before_copy in rendered config, got:\n%s", rendered)
+	}
+}
+
 func TestSuggestSchemaNameFallsBackWhenItMatchesTargetDatabase(t *testing.T) {
 	got := suggestSchemaName(
 		"mysql",


### PR DESCRIPTION
## Summary

Adds a first-class `truncate_before_copy = true` option for migrations that need to clear selected PostgreSQL target tables before COPY.

## Why

`data_only` currently loads into existing tables without clearing seed/reference rows inserted by an external schema migrator. When those rows overlap source rows, PostgreSQL COPY can fail with duplicate key errors. Users could work around this with a `before_data` hook, but the behavior matches a common pgloader `truncate` workflow and belongs in config.

## Changes

- Parses `truncate_before_copy` as a top-level TOML option, defaulting to false.
- Runs one generated `TRUNCATE TABLE ... CASCADE` statement for the selected target tables after `before_data` hooks and before COPY.
- Rejects `resume = true` with `truncate_before_copy = true`, because a resumed retry would truncate rows the checkpoint may skip.
- Adds unit coverage for config parsing/defaults, phase ordering, error handling, SQL generation/quoting, and wizard rendering.
- Updates the site docs for configuration, data-only workflow, and migration pipeline order.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go build -o build/pgferry .`

Fixes #215