### PR TITLE
docs: Site SEO wave 1 — destination-specific MySQL/MSSQL → managed Postgres guides (#171)

### DIFF
--- a/site/src/content/docs/examples/mssql/index.md
+++ b/site/src/content/docs/examples/mssql/index.md
@@ -16,3 +16,11 @@ MSSQL support currently has two main operational templates: the safe default and
 - `single_tx` enables snapshot isolation: pgferry may `ALTER` the database only when `ALLOW_SNAPSHOT_ISOLATION` is not already on; that change persists if pgferry makes it
 - `money` and `smallmoney` map to `numeric` by default
 - `uniqueidentifier` values are reordered into standard UUID byte order during copy
+
+## Migrating to a specific provider?
+
+Provider-specific playbooks with connection, TLS, pooling, and firewall setup:
+
+- [MSSQL to Supabase](/guides/mssql-to-supabase/)
+- [MSSQL to Neon](/guides/mssql-to-neon/)
+- [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/)

--- a/site/src/content/docs/examples/mysql/index.md
+++ b/site/src/content/docs/examples/mysql/index.md
@@ -21,3 +21,13 @@ MySQL has the broadest example surface because it exercises the most pgferry fea
 - [schema-only](/examples/mysql/schema-only/)
 - [data-only](/examples/mysql/data-only/)
 - [sakila](/examples/mysql/sakila/)
+
+## Migrating to a specific provider?
+
+Provider-specific playbooks with connection, TLS, pooling, and firewall setup:
+
+- [MySQL to Supabase](/guides/mysql-to-supabase/)
+- [MySQL to Neon](/guides/mysql-to-neon/)
+- [MySQL to Railway Postgres](/guides/mysql-to-railway-postgres/)
+- [MySQL to Render Postgres](/guides/mysql-to-render-postgres/)
+- [MySQL to PlanetScale Postgres](/guides/mysql-to-planetscale-postgres/)

--- a/site/src/content/docs/guides/index.md
+++ b/site/src/content/docs/guides/index.md
@@ -14,13 +14,10 @@ Guides for specific sources, destinations, and combinations — covering caveats
 
 ## By managed Postgres destination
 
-Destination-specific playbooks with provider connection, TLS, pooling, and firewall setup — not just generic source advice.
+Destination-specific playbooks with provider connection, TLS, pooling, and firewall setup — not just generic source advice. Grouped by destination:
 
-- [MySQL to Supabase](/guides/mysql-to-supabase/)
-- [MySQL to Neon](/guides/mysql-to-neon/)
-- [MySQL to Railway Postgres](/guides/mysql-to-railway-postgres/)
-- [MySQL to Render Postgres](/guides/mysql-to-render-postgres/)
-- [MySQL to PlanetScale Postgres](/guides/mysql-to-planetscale-postgres/)
-- [MSSQL to Supabase](/guides/mssql-to-supabase/)
-- [MSSQL to Neon](/guides/mssql-to-neon/)
-- [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/)
+- **Supabase**: [from MySQL](/guides/mysql-to-supabase/) · [from MSSQL](/guides/mssql-to-supabase/)
+- **Neon**: [from MySQL](/guides/mysql-to-neon/) · [from MSSQL](/guides/mssql-to-neon/)
+- **PlanetScale Postgres**: [from MySQL](/guides/mysql-to-planetscale-postgres/) · [from MSSQL](/guides/mssql-to-planetscale-postgres/)
+- **Railway Postgres**: [from MySQL](/guides/mysql-to-railway-postgres/)
+- **Render Postgres**: [from MySQL](/guides/mysql-to-render-postgres/)

--- a/site/src/content/docs/guides/index.md
+++ b/site/src/content/docs/guides/index.md
@@ -5,7 +5,22 @@ description: Source-specific and destination-specific guides for MySQL, MariaDB,
 
 Guides for specific sources, destinations, and combinations — covering caveats, defaults, and practical starting points.
 
+## By source database
+
 - [MySQL to PostgreSQL](/guides/mysql/)
 - [MariaDB to PostgreSQL](/guides/mariadb/)
 - [SQLite to PostgreSQL](/guides/sqlite/)
 - [MSSQL to PostgreSQL](/guides/mssql/)
+
+## By managed Postgres destination
+
+Destination-specific playbooks with provider connection, TLS, pooling, and firewall setup — not just generic source advice.
+
+- [MySQL to Supabase](/guides/mysql-to-supabase/)
+- [MySQL to Neon](/guides/mysql-to-neon/)
+- [MySQL to Railway Postgres](/guides/mysql-to-railway-postgres/)
+- [MySQL to Render Postgres](/guides/mysql-to-render-postgres/)
+- [MySQL to PlanetScale Postgres](/guides/mysql-to-planetscale-postgres/)
+- [MSSQL to Supabase](/guides/mssql-to-supabase/)
+- [MSSQL to Neon](/guides/mssql-to-neon/)
+- [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/)

--- a/site/src/content/docs/guides/mssql-to-neon.md
+++ b/site/src/content/docs/guides/mssql-to-neon.md
@@ -126,4 +126,4 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [Type mapping](/reference/type-mapping/)
 - [MSSQL minimal-safe example](/examples/mssql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
-- Other destinations: [MSSQL to Supabase](/guides/mssql-to-supabase/) · [MySQL to Neon](/guides/mysql-to-neon/)
+- Other destinations: [MSSQL to Supabase](/guides/mssql-to-supabase/) · [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/) · [MySQL to Neon](/guides/mysql-to-neon/)

--- a/site/src/content/docs/guides/mssql-to-neon.md
+++ b/site/src/content/docs/guides/mssql-to-neon.md
@@ -34,6 +34,7 @@ on_schema_exists = "error"
 unlogged_tables = false
 resume = true
 validation = "row_count"
+chunk_size = 100000
 source_snapshot_mode = "single_tx"
 
 [source]

--- a/site/src/content/docs/guides/mssql-to-neon.md
+++ b/site/src/content/docs/guides/mssql-to-neon.md
@@ -1,0 +1,128 @@
+---
+title: MSSQL to Neon
+description: An MSSQL to Neon migration playbook — migrate SQL Server to Neon serverless Postgres with pgferry, covering the direct endpoint, scale-to-zero, TLS, and SQL Server type caveats.
+---
+
+This is an operator's playbook for an **MSSQL to Neon** migration. It covers the Neon-specific endpoint, scale-to-zero, and TLS details plus the SQL Server type caveats you need to move Microsoft SQL Server into [Neon](https://neon.com/)'s serverless PostgreSQL.
+
+If you searched for how to **migrate SQL Server to Neon** or move **MSSQL to Neon Postgres**, the short version is: point `pgferry` at Neon's **unpooled (direct)** endpoint, disable scale-to-zero for the load, and let pgferry's `sys.*` catalog introspection handle the SQL Server types that generic tools botch.
+
+## What this guide is for
+
+Use this guide when you have a Microsoft SQL Server database (on-prem, Azure SQL, AWS RDS for SQL Server, etc.) and want it on Neon Postgres. It assumes you have a Neon project and branch. For source-side behavior that is not Neon-specific, read the generic [MSSQL to PostgreSQL guide](/guides/mssql/) alongside this page.
+
+## Why use pgferry instead of generic pgloader advice
+
+For SQL Server, generic advice is thin: `pgloader`'s MSSQL path is largely unmaintained and most tutorials assume MySQL. `pgferry` is built for this pair:
+
+- It introspects SQL Server through `sys.*` catalog views and applies SQL Server-specific conversions (UUID byte reordering, `datetime2`/`time` scale clamping, `money` → `numeric`).
+- It streams with chunked, parallel `COPY` and **resumes** from a checkpoint — important over a Neon connection that can auto-suspend.
+- `pgferry plan` reports computed columns, skipped non-B-tree/filtered indexes, temporal tables, and `NEXT VALUE FOR` defaults before PostgreSQL is touched.
+- It creates objects as the connecting role, avoiding the ownership/`SET ROLE` errors a `pg_dump`-style restore hits against Neon's non-superuser role.
+
+## Destination prerequisites
+
+- A Neon project and branch. Note the default database (`neondb`) and owner role (`neondb_owner`), or create your own.
+- The connection string from the Neon console (**Connect**), which gives both pooled and direct host forms.
+- Neon's owner role is a member of `neon_superuser` — not a true superuser, but it can create schemas, tables, indexes, FKs, sequences, and allow-listed extensions. That covers pgferry's needs.
+
+## Recommended pgferry config
+
+```toml
+schema = "app"
+on_schema_exists = "error"
+unlogged_tables = false
+resume = true
+validation = "row_count"
+source_snapshot_mode = "single_tx"
+
+[source]
+type = "mssql"
+source_schema = "dbo"
+# dsn supplied via PGFERRY_SOURCE_DSN
+
+[target]
+# dsn supplied via PGFERRY_TARGET_DSN
+
+[type_mapping]
+datetime_as_timestamptz = false
+money_as_numeric = true
+```
+
+`resume = true` requires `unlogged_tables = false`. On MSSQL, `source_snapshot_mode = "single_tx"` uses `SNAPSHOT` isolation — see the [MSSQL guide](/guides/mssql/) for the `ALLOW_SNAPSHOT_ISOLATION` details.
+
+## Neon DSN, TLS, pooling, and firewall notes
+
+Neon endpoints differ only by a `-pooler` suffix:
+
+| Endpoint | Host shape | Use for |
+| --- | --- | --- |
+| Direct (unpooled) | `ep-<id>.<region>.aws.neon.tech` | **Migrations, DDL, bulk load** |
+| Pooled | `ep-<id>-pooler.<region>.aws.neon.tech` | App runtime |
+
+- **Use the direct (unpooled) endpoint.** The pooled endpoint is PgBouncer in transaction mode and breaks session-scoped DDL and the session features pgferry relies on.
+- **TLS is mandatory.** Neon rejects non-TLS connections. Use `?sslmode=require` at minimum; `verify-full` works against the system trust store. Neon's console strings also include `channel_binding=require`, supported by the `pgx` driver pgferry uses.
+- **IP Allow** is a paid-plan feature, default open. If enabled, add your migration host's egress IP/CIDR first.
+
+Example direct-endpoint target DSN:
+
+```bash
+export PGFERRY_TARGET_DSN='postgresql://neondb_owner:<password>@ep-<id>.<region>.aws.neon.tech/neondb?sslmode=require'
+export PGFERRY_SOURCE_DSN='sqlserver://user:pass@mssql-host:1433?database=source_db'
+```
+
+### Scale-to-zero — the Neon-specific gotcha
+
+Neon computes auto-suspend after inactivity (5 minutes by default; fixed on Free). **Disable scale-to-zero (or raise the timeout) for the migration window** in **Branches → compute → Edit**, then re-enable it after. For large datasets, raise the compute size for more `max_connections` and index-build headroom. Keep transactions moving so the 5-minute `idle_in_transaction_session_timeout` does not terminate one mid-load.
+
+## Source-specific caveats (SQL Server)
+
+These come from the MSSQL side (full detail in the [MSSQL guide](/guides/mssql/)):
+
+- Choose the right `source_schema` instead of defaulting to `dbo` blindly.
+- Decide `datetime_as_timestamptz`; keep `money_as_numeric = true` unless you want text.
+- `datetime2`/`time` fractional precision is clamped to PostgreSQL's max scale of **6** (SQL Server allows 7).
+- `uniqueidentifier` values are byte-reordered into standard UUID order.
+- Computed columns are materialized as values and reported for manual recreation.
+- Non-B-tree indexes (columnstore, hash, XML, spatial) and filtered indexes are skipped with warnings.
+- `NEXT VALUE FOR` defaults, system-versioned temporal tables, and `sql_variant` columns produce semantic warnings — handle via [hooks](/reference/hooks/) or manual DDL.
+- External tables are excluded by default.
+
+## Step-by-step MSSQL to Neon migration flow
+
+1. Create the Neon project/branch and copy the **direct** connection string (no `-pooler`).
+2. Disable scale-to-zero and, for large data, raise the compute size.
+3. Generate a config with `pgferry wizard` or start from the snippet above.
+4. Export `PGFERRY_SOURCE_DSN` and `PGFERRY_TARGET_DSN`.
+5. Run `pgferry plan migration.toml` and resolve every warning.
+6. Run `pgferry migrate migration.toml`; rerun on interruption (`resume = true`).
+7. Recreate views, routines, triggers, and `NEXT VALUE FOR` defaults via [hooks](/reference/hooks/).
+
+## Validation and cutover checklist
+
+- `pgferry validate migration.toml` re-runs validation without redoing DDL or `COPY`.
+- Verify computed columns and sequence-backed columns on the target.
+- Confirm required extensions exist.
+- Re-enable scale-to-zero and restore the compute size if you changed it.
+- Walk the [cutover checklist](/operations/cutover-checklist/) and [first production migration checklist](/operations/first-production-migration-checklist/).
+
+## Common failures for this provider pair
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Session/DDL errors, temp-table failures | Connected via the `-pooler` endpoint | Use the direct (unpooled) endpoint |
+| Connection refused / SSL required | Missing TLS | Append `?sslmode=require` |
+| Compute suspended mid-load | Scale-to-zero fired during a quiet gap | Disable scale-to-zero for the load |
+| `single_tx` fails on a read-only login | Snapshot isolation not enabled | Enable `ALLOW_SNAPSHOT_ISOLATION` or grant `ALTER` (see [MSSQL guide](/guides/mssql/)) |
+| Missing column defaults | `NEXT VALUE FOR` not translated | Recreate sequences/defaults via hooks |
+
+See [common failures and recovery](/operations/common-failures-and-recovery/).
+
+## Related
+
+- [MSSQL to PostgreSQL](/guides/mssql/) — generic source guide
+- [Configuration reference](/reference/configuration/)
+- [Type mapping](/reference/type-mapping/)
+- [MSSQL minimal-safe example](/examples/mssql/minimal-safe/)
+- [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
+- Other destinations: [MSSQL to Supabase](/guides/mssql-to-supabase/) · [MySQL to Neon](/guides/mysql-to-neon/)

--- a/site/src/content/docs/guides/mssql-to-planetscale-postgres.md
+++ b/site/src/content/docs/guides/mssql-to-planetscale-postgres.md
@@ -33,6 +33,7 @@ on_schema_exists = "error"
 unlogged_tables = false
 resume = true
 validation = "row_count"
+chunk_size = 100000
 source_snapshot_mode = "single_tx"
 
 [source]
@@ -107,7 +108,7 @@ These come from the MSSQL side (full detail in the [MSSQL guide](/guides/mssql/)
 | Prepared-statement / session errors | Connected via PSBouncer (6432) | Use the direct port (5432) |
 | TLS handshake / cert error | Missing verify-full params | Use `sslmode=verify-full&sslrootcert=system` |
 | Connection refused after enabling IP restrictions | Migration host not allow-listed | Add your egress IP to the branch allowlist |
-| `single_tx` fails on a read-only login | Snapshot isolation not enabled | Enable `ALLOW_SNAPSHOT_ISOLATION` or grant `ALTER` |
+| `single_tx` fails on a read-only login | Snapshot isolation not enabled | Enable `ALLOW_SNAPSHOT_ISOLATION` or grant `ALTER` (see [MSSQL guide](/guides/mssql/)) |
 | Missing column defaults | `NEXT VALUE FOR` not translated | Recreate sequences/defaults via hooks |
 
 See [common failures and recovery](/operations/common-failures-and-recovery/).

--- a/site/src/content/docs/guides/mssql-to-planetscale-postgres.md
+++ b/site/src/content/docs/guides/mssql-to-planetscale-postgres.md
@@ -120,4 +120,4 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [Type mapping](/reference/type-mapping/)
 - [MSSQL minimal-safe example](/examples/mssql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
-- Other destinations: [MySQL to PlanetScale Postgres](/guides/mysql-to-planetscale-postgres/) · [MSSQL to Neon](/guides/mssql-to-neon/)
+- Other destinations: [MSSQL to Supabase](/guides/mssql-to-supabase/) · [MSSQL to Neon](/guides/mssql-to-neon/) · [MySQL to PlanetScale Postgres](/guides/mysql-to-planetscale-postgres/)

--- a/site/src/content/docs/guides/mssql-to-planetscale-postgres.md
+++ b/site/src/content/docs/guides/mssql-to-planetscale-postgres.md
@@ -1,0 +1,122 @@
+---
+title: MSSQL to PlanetScale Postgres
+description: An MSSQL to PlanetScale Postgres migration playbook — migrate SQL Server into PlanetScale for Postgres with pgferry, covering the direct port, verify-full TLS, and SQL Server type caveats.
+---
+
+This is an operator's playbook for an **MSSQL to PlanetScale Postgres** migration — moving a Microsoft SQL Server database into **PlanetScale for Postgres**, PlanetScale's PostgreSQL product (GA since September 2025), **not** PlanetScale's legacy MySQL/Vitess platform.
+
+If you searched for how to **migrate SQL Server to PlanetScale Postgres** or move **MSSQL to PlanetScale for Postgres**, the short version is: point `pgferry` at PlanetScale's **direct port (5432)** with `sslmode=verify-full sslrootcert=system`, not the PSBouncer pooler, and let pgferry's `sys.*` catalog introspection handle the SQL Server types that generic tools botch.
+
+## What this guide is for
+
+Use this guide when your source is **Microsoft SQL Server** and your destination is **PlanetScale for Postgres**. Note that this is a real cross-engine MSSQL-to-PostgreSQL migration: PlanetScale for Postgres is genuine PostgreSQL on PlanetScale Metal, unrelated to PlanetScale's MySQL/Vitess product. For source-side behavior that is not PlanetScale-specific, read the generic [MSSQL to PostgreSQL guide](/guides/mssql/) alongside this page.
+
+## Why use pgferry instead of generic pgloader advice
+
+PlanetScale's documented import path (`pg_dump`/`pg_restore`) is Postgres-to-Postgres only — it cannot read a SQL Server source. The generic cross-engine option, `pgloader`, has weak and largely unmaintained MSSQL support. `pgferry` is purpose-built:
+
+- It introspects SQL Server via `sys.*` catalog views and applies SQL Server-specific conversions (UUID byte reordering, `datetime2`/`time` scale clamping, `money` → `numeric`).
+- It streams with chunked, parallel `COPY`, checkpoints for `resume`, and runs a [`plan`](/operations/how-to-read-plan-output/) preflight.
+- It creates objects as the connecting role, so PlanetScale's `--no-owner --no-privileges` ownership caveats (a `pg_dump` concern) simply do not arise.
+
+## Destination prerequisites
+
+- A PlanetScale for Postgres database and branch.
+- A role's connection string from **Settings → Roles → View connection strings** (passwords are prefixed `pscale_pw_`). PlanetScale recommends a dedicated role over the default `postgres` role for ongoing app traffic.
+- The `postgres` role is `NOSUPERUSER` but has `CREATEDB`/`CREATEROLE` and can create schemas, tables, indexes, FKs, sequences, and allow-listed extensions — everything pgferry needs.
+
+## Recommended pgferry config
+
+```toml
+schema = "app"
+on_schema_exists = "error"
+unlogged_tables = false
+resume = true
+validation = "row_count"
+source_snapshot_mode = "single_tx"
+
+[source]
+type = "mssql"
+source_schema = "dbo"
+# dsn supplied via PGFERRY_SOURCE_DSN
+
+[target]
+# dsn supplied via PGFERRY_TARGET_DSN
+
+[type_mapping]
+datetime_as_timestamptz = false
+money_as_numeric = true
+```
+
+`resume = true` requires `unlogged_tables = false`. On MSSQL, `source_snapshot_mode = "single_tx"` uses `SNAPSHOT` isolation — see the [MSSQL guide](/guides/mssql/).
+
+## PlanetScale Postgres DSN, TLS, pooling, and firewall notes
+
+| Endpoint | Port | Use for |
+| --- | --- | --- |
+| Direct Postgres | `5432` | **Migrations, DDL, bulk load** |
+| PSBouncer (pooler) | `6432` | App runtime |
+
+- **Use the direct port (5432).** PSBouncer runs transaction mode and lacks persistent prepared statements; PlanetScale's docs require the direct connection for schema changes, ETL/data streaming, and long or multi-statement transactions — what pgferry does.
+- **TLS is required.** PlanetScale documents `sslmode=verify-full` with `sslrootcert=system` (certs chain to a public CA, so the OS trust store works) and `sslnegotiation=direct`.
+- **Host shape:** `{identifier}-{region}-{instance}.horizon.psdb.cloud`. Read the exact host/port/user/dbname from the generated connection string.
+- **IP restrictions** are opt-in per branch (default open); add your migration host's egress IP if enabled. Private connectivity via AWS PrivateLink / GCP Private Service Connect is available.
+- **Capacity:** provision around **150% of the source size** on the target.
+
+Example direct target DSN:
+
+```bash
+export PGFERRY_TARGET_DSN='postgres://postgres.<branch_id>:pscale_pw_<...>@<identifier>-<region>-1.horizon.psdb.cloud:5432/<dbname>?sslmode=verify-full&sslrootcert=system&sslnegotiation=direct'
+export PGFERRY_SOURCE_DSN='sqlserver://user:pass@mssql-host:1433?database=source_db'
+```
+
+## Source-specific caveats (SQL Server)
+
+These come from the MSSQL side (full detail in the [MSSQL guide](/guides/mssql/)):
+
+- Choose the right `source_schema` instead of defaulting to `dbo` blindly.
+- Decide `datetime_as_timestamptz`; keep `money_as_numeric = true` unless you want text.
+- `datetime2`/`time` precision is clamped to PostgreSQL's max scale of **6** (SQL Server allows 7).
+- `uniqueidentifier` values are byte-reordered into standard UUID order.
+- Computed columns are materialized as values and reported for manual recreation.
+- Non-B-tree indexes (columnstore, hash, XML, spatial) and filtered indexes are skipped with warnings.
+- `NEXT VALUE FOR` defaults, system-versioned temporal tables, and `sql_variant` columns produce semantic warnings — handle via [hooks](/reference/hooks/) or manual DDL.
+- External tables are excluded by default.
+
+## Step-by-step MSSQL to PlanetScale Postgres migration flow
+
+1. Create the PlanetScale Postgres database/branch and copy a role's **direct** (5432) connection string.
+2. Pre-create any required extensions on the target (within PlanetScale's supported set).
+3. Generate a config with `pgferry wizard` or start from the snippet above.
+4. Export `PGFERRY_SOURCE_DSN` and `PGFERRY_TARGET_DSN`.
+5. Run `pgferry plan migration.toml` and resolve every warning.
+6. Run `pgferry migrate migration.toml`; rerun on interruption (`resume = true`).
+7. Recreate views, routines, triggers, and `NEXT VALUE FOR` defaults via [hooks](/reference/hooks/).
+
+## Validation and cutover checklist
+
+- `pgferry validate migration.toml` re-runs validation without redoing DDL or `COPY`.
+- Verify computed columns and sequence-backed columns on the target.
+- Confirm you connected on 5432, not 6432, throughout, and that required extensions installed.
+- Walk the [cutover checklist](/operations/cutover-checklist/) and [first production migration checklist](/operations/first-production-migration-checklist/).
+
+## Common failures for this provider pair
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Prepared-statement / session errors | Connected via PSBouncer (6432) | Use the direct port (5432) |
+| TLS handshake / cert error | Missing verify-full params | Use `sslmode=verify-full&sslrootcert=system` |
+| Connection refused after enabling IP restrictions | Migration host not allow-listed | Add your egress IP to the branch allowlist |
+| `single_tx` fails on a read-only login | Snapshot isolation not enabled | Enable `ALLOW_SNAPSHOT_ISOLATION` or grant `ALTER` |
+| Missing column defaults | `NEXT VALUE FOR` not translated | Recreate sequences/defaults via hooks |
+
+See [common failures and recovery](/operations/common-failures-and-recovery/).
+
+## Related
+
+- [MSSQL to PostgreSQL](/guides/mssql/) — generic source guide
+- [Configuration reference](/reference/configuration/)
+- [Type mapping](/reference/type-mapping/)
+- [MSSQL minimal-safe example](/examples/mssql/minimal-safe/)
+- [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
+- Other destinations: [MySQL to PlanetScale Postgres](/guides/mysql-to-planetscale-postgres/) · [MSSQL to Neon](/guides/mssql-to-neon/)

--- a/site/src/content/docs/guides/mssql-to-supabase.md
+++ b/site/src/content/docs/guides/mssql-to-supabase.md
@@ -135,4 +135,4 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [Type mapping](/reference/type-mapping/)
 - [MSSQL minimal-safe example](/examples/mssql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
-- Other destinations: [MSSQL to Neon](/guides/mssql-to-neon/) · [MySQL to Supabase](/guides/mysql-to-supabase/)
+- Other destinations: [MSSQL to Neon](/guides/mssql-to-neon/) · [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/) · [MySQL to Supabase](/guides/mysql-to-supabase/)

--- a/site/src/content/docs/guides/mssql-to-supabase.md
+++ b/site/src/content/docs/guides/mssql-to-supabase.md
@@ -34,6 +34,7 @@ on_schema_exists = "error"
 unlogged_tables = false
 resume = true
 validation = "row_count"
+chunk_size = 100000
 source_snapshot_mode = "single_tx"
 
 [source]

--- a/site/src/content/docs/guides/mssql-to-supabase.md
+++ b/site/src/content/docs/guides/mssql-to-supabase.md
@@ -1,0 +1,137 @@
+---
+title: MSSQL to Supabase
+description: An MSSQL to Supabase migration playbook — migrate SQL Server to Supabase Postgres with pgferry, covering the session pooler, TLS, statement timeouts, and SQL Server type caveats.
+---
+
+This is an operator's playbook for an **MSSQL to Supabase** migration. It covers the Supabase-specific connection and timeout setup plus the SQL Server type caveats you need to move Microsoft SQL Server into [Supabase](https://supabase.com/)'s hosted PostgreSQL.
+
+If you searched for how to **migrate SQL Server to Supabase** or move **MSSQL to Supabase Postgres**, the short version is: point `pgferry` at a session-mode (not transaction-mode) Supabase connection, raise the `postgres` role statement timeout for the load, and let pgferry's `sys.*` catalog introspection handle the SQL Server types that no `pgloader` recipe covers well.
+
+## What this guide is for
+
+Use this guide when you have a Microsoft SQL Server database (on-prem, Azure SQL, AWS RDS for SQL Server, etc.) and want it on Supabase Postgres. It assumes you have a Supabase project. For source-side behavior that is not Supabase-specific, read the generic [MSSQL to PostgreSQL guide](/guides/mssql/) alongside this page.
+
+## Why use pgferry instead of generic pgloader advice
+
+For SQL Server, the generic advice is especially weak: `pgloader`'s MSSQL support is thin and largely unmaintained, and most tutorials assume MySQL. `pgferry` is built for this pair:
+
+- It introspects SQL Server through `sys.*` catalog views and applies SQL Server-specific conversions (UUID byte reordering, `datetime2`/`time` scale clamping, `money` → `numeric`).
+- It streams data with chunked, parallel `COPY` and **resumes** from a checkpoint — important over a hosted connection.
+- `pgferry plan` reports computed columns, skipped non-B-tree/filtered indexes, temporal tables, and `NEXT VALUE FOR` defaults *before* PostgreSQL is touched. See [how to read plan output](/operations/how-to-read-plan-output/).
+- It creates objects as the connecting role, sidestepping the ownership/`SET ROLE` errors a `pg_dump`-style restore hits against Supabase's non-superuser role.
+
+## Destination prerequisites
+
+- A Supabase project (note its **project ref**) and the database password from **Project Settings → Database**.
+- Decide the target schema. SQL Server commonly uses `dbo`; pgferry can create and own any PostgreSQL schema name.
+- The Supabase `postgres` role is **not a superuser** but can create schemas, tables, indexes, FKs, sequences, and allow-listed extensions — everything pgferry needs.
+
+## Recommended pgferry config
+
+```toml
+schema = "app"
+on_schema_exists = "error"
+unlogged_tables = false
+resume = true
+validation = "row_count"
+source_snapshot_mode = "single_tx"
+
+[source]
+type = "mssql"
+source_schema = "dbo"
+# dsn supplied via PGFERRY_SOURCE_DSN
+
+[target]
+# dsn supplied via PGFERRY_TARGET_DSN
+
+[type_mapping]
+datetime_as_timestamptz = false
+money_as_numeric = true
+```
+
+`resume = true` requires `unlogged_tables = false`. On MSSQL, `source_snapshot_mode = "single_tx"` uses `SNAPSHOT` isolation — see the [MSSQL guide](/guides/mssql/) for the `ALLOW_SNAPSHOT_ISOLATION` details.
+
+## Supabase DSN, TLS, pooling, and firewall notes
+
+Supabase exposes three connection types. Database name is always `postgres`.
+
+| Type | Host | Port | Username |
+| --- | --- | --- | --- |
+| Direct | `db.<ref>.supabase.co` | `5432` | `postgres` |
+| Session pooler (Supavisor) | `aws-0-<region>.pooler.supabase.com` | `5432` | `postgres.<ref>` |
+| Transaction pooler (Supavisor) | `aws-0-<region>.pooler.supabase.com` | `6543` | `postgres.<ref>` |
+
+- **Use the session pooler (5432) or the direct connection.** Both keep prepared statements and session state that pgferry's `COPY` and DDL pipeline need.
+- **Never use the transaction pooler (6543) for a migration** — transaction mode disables prepared statements and drops session settings.
+- **IPv4-only host?** The direct connection is IPv6-only without the paid IPv4 add-on; the **session pooler is IPv4-native**, so prefer it. Copy the exact host from the dashboard **Connect** dialog.
+- **TLS:** use `?sslmode=require`, or `sslmode=verify-full&sslrootcert=...` with the CA cert from **Project Settings → Database → SSL Configuration**.
+
+Example session-pooler target DSN:
+
+```bash
+export PGFERRY_TARGET_DSN='postgresql://postgres.<ref>:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres?sslmode=require'
+export PGFERRY_SOURCE_DSN='sqlserver://user:pass@mssql-host:1433?database=source_db'
+```
+
+### Statement timeout — the most common Supabase migration failure
+
+Supabase caps the `postgres` role at a **2-minute statement timeout** by default. A large `COPY` chunk or index build dies with `canceling statement due to statement timeout`. Disable it for the load, then restore:
+
+```sql
+alter role postgres set statement_timeout = '0';   -- before
+alter role postgres reset statement_timeout;        -- after cutover
+```
+
+Reconnect for it to take effect.
+
+## Source-specific caveats (SQL Server)
+
+These come from the MSSQL side (full detail in the [MSSQL guide](/guides/mssql/)):
+
+- Choose the right `source_schema` instead of relying on `dbo` blindly.
+- Decide `datetime_as_timestamptz`; keep `money_as_numeric = true` unless you want text preservation.
+- `datetime2`/`time` fractional precision is clamped to PostgreSQL's max scale of **6** (SQL Server allows 7).
+- `uniqueidentifier` values are byte-reordered into standard UUID order.
+- Computed columns are materialized as values and reported for manual recreation.
+- Non-B-tree indexes (columnstore, hash, XML, spatial) and filtered indexes are skipped with warnings.
+- `NEXT VALUE FOR` sequence defaults, system-versioned temporal tables, and `sql_variant` columns produce semantic warnings — recreate via [hooks](/reference/hooks/) or manual DDL.
+- External tables are excluded by default.
+
+## Step-by-step MSSQL to Supabase migration flow
+
+1. Create the Supabase project and copy the session-pooler connection string from **Connect**.
+2. `alter role postgres set statement_timeout = '0';`.
+3. Generate a config with `pgferry wizard` or start from the snippet above.
+4. Export `PGFERRY_SOURCE_DSN` and `PGFERRY_TARGET_DSN`.
+5. Run `pgferry plan migration.toml` and resolve every warning (computed columns, skipped indexes, sequence defaults, temporal tables).
+6. Run `pgferry migrate migration.toml`; rerun on interruption (`resume = true`).
+7. Recreate views, routines, triggers, and `NEXT VALUE FOR` defaults via [hooks](/reference/hooks/).
+
+## Validation and cutover checklist
+
+- `pgferry validate migration.toml` re-runs validation without redoing DDL or `COPY`.
+- Verify computed columns and sequence-backed columns behave correctly on the target.
+- Confirm required extensions are enabled in **Database → Extensions**.
+- Restore the `postgres` role `statement_timeout`.
+- Walk the [cutover checklist](/operations/cutover-checklist/) and [first production migration checklist](/operations/first-production-migration-checklist/).
+
+## Common failures for this provider pair
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `canceling statement due to statement timeout` | Supabase 2-min role timeout | `alter role postgres set statement_timeout = '0'` |
+| `prepared statement ... does not exist` | Connected via transaction pooler (6543) | Use session pooler (5432) or direct |
+| `could not translate host name` | Direct host is IPv6-only | Use the session pooler or enable the IPv4 add-on |
+| `single_tx` fails on a read-only login | Snapshot isolation not enabled | Enable `ALLOW_SNAPSHOT_ISOLATION` or grant `ALTER` (see [MSSQL guide](/guides/mssql/)) |
+| Missing defaults on some columns | `NEXT VALUE FOR` not translated | Recreate sequences/defaults via hooks |
+
+See [common failures and recovery](/operations/common-failures-and-recovery/).
+
+## Related
+
+- [MSSQL to PostgreSQL](/guides/mssql/) — generic source guide
+- [Configuration reference](/reference/configuration/)
+- [Type mapping](/reference/type-mapping/)
+- [MSSQL minimal-safe example](/examples/mssql/minimal-safe/)
+- [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
+- Other destinations: [MSSQL to Neon](/guides/mssql-to-neon/) · [MySQL to Supabase](/guides/mysql-to-supabase/)

--- a/site/src/content/docs/guides/mssql.md
+++ b/site/src/content/docs/guides/mssql.md
@@ -35,3 +35,11 @@ MSSQL support uses `sys.*` catalog introspection and a small set of SQL Server-s
 - **Synonyms**: Introspection follows real objects in `source_schema`. `sys.synonyms` targets are not expanded; point the DSN/schema at underlying tables or use hooks.
 - **Cross-schema foreign keys**: When a FK references another schema, pgferry logs a warning at introspection. The FK may fail in PostgreSQL if the referenced table is not in the target schema; adjust migration order, use hooks, or align schemas.
 - **Azure SQL / connectivity**: Firewalls, TLS, and `encrypt` / trust settings are environment-specific; the config wizard validates DSN shape via `msdsn` but does not cover every hosting matrix.
+
+## Migrating to a managed Postgres provider?
+
+These destination-specific guides add the provider connection, TLS, pooling, and firewall setup on top of the MSSQL behavior above:
+
+- [MSSQL to Supabase](/guides/mssql-to-supabase/)
+- [MSSQL to Neon](/guides/mssql-to-neon/)
+- [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/)

--- a/site/src/content/docs/guides/mysql-to-neon.md
+++ b/site/src/content/docs/guides/mysql-to-neon.md
@@ -1,0 +1,134 @@
+---
+title: MySQL to Neon
+description: A MySQL to Neon migration playbook — move MySQL to Neon serverless Postgres with pgferry, including direct vs pooled endpoints, scale-to-zero, and TLS details generic pgloader guides skip.
+---
+
+This is an operator's playbook for a **MySQL to Neon** migration. It covers the Neon-specific endpoint, scale-to-zero, and TLS details you need to move MySQL into [Neon](https://neon.com/)'s serverless PostgreSQL — the parts generic import tutorials leave out.
+
+If you searched for how to **migrate MySQL to Neon** or **move a MySQL database to Neon Postgres**, the short version is: point `pgferry` at the **unpooled (direct)** Neon endpoint, disable scale-to-zero for the load, and let the [MySQL type mapping](/reference/type-mapping/) handle enums, sets, and unsigned integers that `pgloader` mishandles.
+
+## What this guide is for
+
+Use this guide when you have a live MySQL database (self-hosted, RDS, Aurora MySQL, Cloud SQL, PlanetScale MySQL, etc.) and want it on Neon Postgres. It assumes you have a Neon project and branch. For source-side behavior that is not Neon-specific, read the generic [MySQL to PostgreSQL guide](/guides/mysql/) alongside this page.
+
+## Why use pgferry instead of generic pgloader advice
+
+The usual "mysql to neon" advice is `pgloader`, which struggles on real migrations:
+
+- `pgloader` has no resume. Over a Neon connection that auto-suspends or hiccups, an interrupted load restarts from zero. `pgferry` checkpoints and resumes.
+- MySQL enums, sets, unsigned integers, `tinyint(1)`, and zero dates are explicit, documented knobs in `pgferry`; `pgloader` guesses and frequently picks `text`.
+- `pgferry` streams with chunked, parallel `COPY` and runs a [`plan`](/operations/how-to-read-plan-output/) preflight that surfaces skipped indexes, generated columns, and required extensions before PostgreSQL is touched.
+- `pgferry` creates objects as the connecting role, avoiding the ownership/`SET ROLE` errors that `pg_dump`/`pg_restore` hit against Neon's non-superuser role.
+
+## Destination prerequisites
+
+- A Neon project and branch. Note the default database (`neondb`) and the owner role (`neondb_owner` by default), or create your own.
+- The connection string from the Neon console (**Connect** button), which gives you both pooled and direct host forms.
+- Neon's owner role is a member of `neon_superuser` — **not a true superuser**, but it can create databases, schemas, tables, indexes, FKs, sequences, and allow-listed extensions. That is everything pgferry needs.
+
+## Recommended pgferry config
+
+```toml
+schema = "app"
+on_schema_exists = "error"
+unlogged_tables = false
+resume = true
+validation = "row_count"
+chunk_size = 100000
+source_snapshot_mode = "single_tx"
+
+[source]
+type = "mysql"
+# dsn supplied via PGFERRY_SOURCE_DSN
+
+[target]
+# dsn supplied via PGFERRY_TARGET_DSN
+
+[type_mapping]
+tinyint1_as_boolean = false
+json_as_jsonb = true
+enum_mode = "check"
+set_mode = "text"
+sanitize_json_null_bytes = true
+```
+
+`resume = true` requires `unlogged_tables = false` (see the [configuration reference](/reference/configuration/#important-incompatibilities)). Use `source_snapshot_mode = "single_tx"` for one consistent read view on a live MySQL source.
+
+## Neon DSN, TLS, pooling, and firewall notes
+
+Neon endpoints differ only by a `-pooler` suffix on the endpoint ID:
+
+| Endpoint | Host shape | Use for |
+| --- | --- | --- |
+| Direct (unpooled) | `ep-<id>.<region>.aws.neon.tech` | **Migrations, DDL, bulk load** |
+| Pooled | `ep-<id>-pooler.<region>.aws.neon.tech` | App runtime / many short connections |
+
+- **Use the direct (unpooled) endpoint for the migration.** The pooled endpoint is PgBouncer in transaction mode and breaks session-scoped DDL, temp tables, and the session features pgferry relies on. Neon's own import guidance says to avoid the pooled string for bulk load. The direct endpoint's connection count scales with compute size, which is far more than pgferry needs.
+- **TLS is mandatory.** Neon rejects non-TLS connections. Use `?sslmode=require` at minimum; `sslmode=verify-full` is better and works against the system trust store (Neon uses a public CA). Neon's console strings also add `channel_binding=require`, which the Go/`pgx` driver pgferry uses supports.
+- **IP Allow** (allowlisting) is a paid-plan feature and defaults to open. If you have it enabled, add your migration host's egress IP/CIDR before starting.
+
+Example direct-endpoint target DSN:
+
+```bash
+export PGFERRY_TARGET_DSN='postgresql://neondb_owner:<password>@ep-<id>.<region>.aws.neon.tech/neondb?sslmode=require'
+export PGFERRY_SOURCE_DSN='user:pass@tcp(mysql-host:3306)/source_db'
+```
+
+### Scale-to-zero — the Neon-specific gotcha
+
+Neon computes auto-suspend after a period of inactivity (5 minutes by default; fixed on the Free plan). An active query keeps the compute busy, but to remove any risk of a suspend during quiet gaps in a long load, **disable scale-to-zero (or raise the timeout) for the migration window**, then re-enable it. Set this per branch in **Branches → compute → Edit**. For large datasets, also bump the compute size — more RAM means more `max_connections` and more local disk for index builds.
+
+Neon's `idle_in_transaction_session_timeout` defaults to 5 minutes; keep transactions moving so an idle gap does not terminate one mid-migration.
+
+## Source-specific caveats (MySQL)
+
+Decide these on the MySQL side; they are not Neon-specific:
+
+- `enum_mode` / `set_mode` — how `ENUM` and `SET` land in PostgreSQL.
+- `tinyint1_as_boolean` — only if `tinyint(1)` truly means boolean.
+- `widen_unsigned_integers` / `add_unsigned_checks` — preserve unsigned ranges.
+- `zero_date_mode` — `0000-00-00` → `NULL` or error.
+- Generated columns copy as values, not expressions.
+- `FULLTEXT`, prefix, and expression indexes are reported and skipped.
+- For `_ci` collations, `ci_as_citext = true` needs the `citext` extension — Neon supports it via `CREATE EXTENSION` (or let `pgferry` surface it in `plan`).
+
+See the [MySQL guide](/guides/mysql/) and [type mapping](/reference/type-mapping/) for the complete picture.
+
+## Step-by-step MySQL to Neon migration flow
+
+1. Create the Neon project/branch and copy the **direct** connection string (no `-pooler`).
+2. Disable scale-to-zero for the target branch and, for large data, raise the compute size.
+3. Generate a config with `pgferry wizard` or start from the snippet above.
+4. Export `PGFERRY_SOURCE_DSN` and `PGFERRY_TARGET_DSN`.
+5. Run `pgferry plan migration.toml` and resolve every warning.
+6. Run `pgferry migrate migration.toml`. Rerun on interruption — `resume = true` continues from the checkpoint.
+7. Recreate views, routines, and triggers via [hooks](/reference/hooks/).
+
+## Validation and cutover checklist
+
+- `pgferry validate migration.toml` re-runs validation without redoing DDL or `COPY`.
+- Confirm required extensions exist (`CREATE EXTENSION` for anything `plan` flagged).
+- Re-enable scale-to-zero and restore the compute size if you changed it.
+- Spot-check enum/set and `tinyint(1)` columns.
+- Walk the [cutover checklist](/operations/cutover-checklist/) and [first production migration checklist](/operations/first-production-migration-checklist/).
+
+## Common failures for this provider pair
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Session/DDL errors, temp-table failures | Connected via the `-pooler` endpoint | Use the direct (unpooled) endpoint |
+| Connection refused / SSL required | Missing TLS | Append `?sslmode=require` |
+| Compute suspended mid-load | Scale-to-zero fired during a quiet gap | Disable scale-to-zero for the migration window |
+| `extension "..." is not available` | Extension not in Neon's supported set | Map the type differently or recreate manually |
+| Slow index builds / OOM | Compute too small | Raise the compute size for the load |
+
+See [common failures and recovery](/operations/common-failures-and-recovery/) for the general catalog.
+
+## Related
+
+- [MySQL to PostgreSQL](/guides/mysql/) — generic source guide
+- [Configuration reference](/reference/configuration/)
+- [Type mapping](/reference/type-mapping/)
+- [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
+- [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
+- Other destinations: [MySQL to Supabase](/guides/mysql-to-supabase/) · [MSSQL to Neon](/guides/mssql-to-neon/)

--- a/site/src/content/docs/guides/mysql-to-neon.md
+++ b/site/src/content/docs/guides/mysql-to-neon.md
@@ -131,4 +131,4 @@ See [common failures and recovery](/operations/common-failures-and-recovery/) fo
 - [Type mapping](/reference/type-mapping/)
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
-- Other destinations: [MySQL to Supabase](/guides/mysql-to-supabase/) · [MSSQL to Neon](/guides/mssql-to-neon/)
+- Other destinations: [MySQL to Supabase](/guides/mysql-to-supabase/) · [MySQL to Railway Postgres](/guides/mysql-to-railway-postgres/) · [MySQL to Render Postgres](/guides/mysql-to-render-postgres/) · [MySQL to PlanetScale Postgres](/guides/mysql-to-planetscale-postgres/) · [MSSQL to Neon](/guides/mssql-to-neon/)

--- a/site/src/content/docs/guides/mysql-to-planetscale-postgres.md
+++ b/site/src/content/docs/guides/mysql-to-planetscale-postgres.md
@@ -1,0 +1,128 @@
+---
+title: MySQL to PlanetScale Postgres
+description: A MySQL to PlanetScale Postgres migration playbook — move MySQL into PlanetScale for Postgres with pgferry, covering the direct port, verify-full TLS, PSBouncer, and the postgres-vs-Vitess distinction.
+---
+
+This is an operator's playbook for a **MySQL to PlanetScale Postgres** migration — moving a MySQL database into **PlanetScale for Postgres**, PlanetScale's PostgreSQL product (generally available since September 2025), **not** PlanetScale's legacy MySQL/Vitess platform.
+
+If you searched for how to **migrate MySQL to PlanetScale Postgres** or **move MySQL to PlanetScale for Postgres**, the short version is: point `pgferry` at PlanetScale's **direct port (5432)** with `sslmode=verify-full sslrootcert=system`, not the PSBouncer pooler, and let pgferry's [MySQL type mapping](/reference/type-mapping/) handle enums, sets, and unsigned integers.
+
+## What this guide is for
+
+Use this guide when your source is **MySQL** and your destination is **PlanetScale for Postgres**. Two common points of confusion:
+
+- This is **not** about PlanetScale's MySQL/Vitess product. If you are staying on MySQL, no cross-engine migration is needed. This guide is for teams deliberately moving onto PlanetScale's PostgreSQL offering.
+- PlanetScale for Postgres is real PostgreSQL running on PlanetScale Metal — so a MySQL → PlanetScale Postgres move is a genuine MySQL-to-PostgreSQL migration, with all the type and DDL translation that implies.
+
+For source-side behavior that is not PlanetScale-specific, read the generic [MySQL to PostgreSQL guide](/guides/mysql/) alongside this page.
+
+## Why use pgferry instead of generic pgloader advice
+
+PlanetScale recommends `pg_dump`/`pg_restore` for Postgres-to-Postgres imports, but those are useless for a MySQL **source**. The generic cross-engine tool is `pgloader`, which struggles on real schemas:
+
+- No resume, single long transactions, and weak type fidelity for MySQL enums/sets/unsigned integers.
+- `pgferry` streams with chunked, parallel `COPY`, checkpoints for `resume`, and runs a [`plan`](/operations/how-to-read-plan-output/) preflight.
+- `pgferry` creates objects as the connecting role, so you avoid the ownership/`SET ROLE` errors PlanetScale's docs warn about for non-superuser restores (their guidance to use `--no-owner --no-privileges` is a `pg_dump` concern that simply does not arise with pgferry).
+
+## Destination prerequisites
+
+- A PlanetScale for Postgres database and branch.
+- A role's connection string from **Settings → Roles → View connection strings**. PlanetScale passwords are prefixed `pscale_pw_`. PlanetScale recommends a dedicated role rather than the default `postgres` role for ongoing app traffic.
+- The default `postgres` role is `NOSUPERUSER` but has `CREATEDB`/`CREATEROLE` and can create schemas, tables, indexes, FKs, sequences, and allow-listed extensions — everything pgferry needs.
+
+## Recommended pgferry config
+
+```toml
+schema = "app"
+on_schema_exists = "error"
+unlogged_tables = false
+resume = true
+validation = "row_count"
+chunk_size = 100000
+source_snapshot_mode = "single_tx"
+
+[source]
+type = "mysql"
+# dsn supplied via PGFERRY_SOURCE_DSN
+
+[target]
+# dsn supplied via PGFERRY_TARGET_DSN
+
+[type_mapping]
+tinyint1_as_boolean = false
+json_as_jsonb = true
+enum_mode = "check"
+set_mode = "text"
+sanitize_json_null_bytes = true
+```
+
+`resume = true` requires `unlogged_tables = false` (see the [configuration reference](/reference/configuration/#important-incompatibilities)).
+
+## PlanetScale Postgres DSN, TLS, pooling, and firewall notes
+
+| Endpoint | Port | Use for |
+| --- | --- | --- |
+| Direct Postgres | `5432` | **Migrations, DDL, bulk load** |
+| PSBouncer (pooler) | `6432` | App runtime |
+
+- **Use the direct port (5432) for the migration.** PSBouncer runs in transaction mode and does not keep persistent prepared statements across transactions; PlanetScale's docs require the direct connection for schema changes, ETL/data streaming, and long or multi-statement transactions — exactly what pgferry does.
+- **TLS is required.** PlanetScale documents `sslmode=verify-full` with `sslrootcert=system` (their certs chain to a public CA, so the OS trust store works — no CA file download). They also document `sslnegotiation=direct`.
+- **Host shape:** `{identifier}-{region}-{instance}.horizon.psdb.cloud`. Read the exact host, port, user, and dbname from the generated connection string.
+- **IP restrictions** are an opt-in, per-branch allowlist (default open). If you enable them, add your migration host's egress IP. Private connectivity is available via AWS PrivateLink / GCP Private Service Connect.
+- **Capacity:** PlanetScale advises the target have disk capacity around **150% of the source size**.
+
+Example direct target DSN:
+
+```bash
+export PGFERRY_TARGET_DSN='postgres://postgres.<branch_id>:pscale_pw_<...>@<identifier>-<region>-1.horizon.psdb.cloud:5432/<dbname>?sslmode=verify-full&sslrootcert=system&sslnegotiation=direct'
+export PGFERRY_SOURCE_DSN='user:pass@tcp(mysql-host:3306)/source_db'
+```
+
+## Source-specific caveats (MySQL)
+
+Decide these on the MySQL side (full detail in the [MySQL guide](/guides/mysql/)):
+
+- `enum_mode` / `set_mode` — how `ENUM`/`SET` land in PostgreSQL.
+- `tinyint1_as_boolean` — only if `tinyint(1)` means boolean.
+- `widen_unsigned_integers` / `add_unsigned_checks` — preserve unsigned ranges.
+- `zero_date_mode` — `0000-00-00` → `NULL` or error.
+- Generated columns copy as values; `FULLTEXT`, prefix, and expression indexes are reported and skipped.
+- `ci_as_citext = true` needs `citext` — PlanetScale supports it in its extension set; pre-create extensions your schema requires.
+
+## Step-by-step MySQL to PlanetScale Postgres migration flow
+
+1. Create the PlanetScale Postgres database/branch and copy a role's **direct** (5432) connection string.
+2. Pre-create any required extensions on the target (within PlanetScale's supported set).
+3. Generate a config with `pgferry wizard` or start from the snippet above.
+4. Export `PGFERRY_SOURCE_DSN` and `PGFERRY_TARGET_DSN`.
+5. Run `pgferry plan migration.toml` and resolve every warning.
+6. Run `pgferry migrate migration.toml`; rerun on interruption (`resume = true`).
+7. Recreate views, routines, and triggers via [hooks](/reference/hooks/).
+
+## Validation and cutover checklist
+
+- `pgferry validate migration.toml` re-runs validation without redoing DDL or `COPY`.
+- Confirm every required extension installed (some PlanetScale extensions need elevated handling).
+- Verify you connected on 5432, not 6432, throughout.
+- Walk the [cutover checklist](/operations/cutover-checklist/) and [first production migration checklist](/operations/first-production-migration-checklist/).
+
+## Common failures for this provider pair
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Prepared-statement / session errors | Connected via PSBouncer (6432) | Use the direct port (5432) |
+| TLS handshake / cert error | Missing verify-full params | Use `sslmode=verify-full&sslrootcert=system` |
+| Connection refused after enabling IP restrictions | Migration host not allow-listed | Add your egress IP to the branch allowlist |
+| `extension ... must be installed` | Extension not pre-created/unsupported | Create supported extensions first; map type differently otherwise |
+| Out of disk near the end | Target undersized | Provision ~150% of source size |
+
+See [common failures and recovery](/operations/common-failures-and-recovery/).
+
+## Related
+
+- [MySQL to PostgreSQL](/guides/mysql/) — generic source guide
+- [Configuration reference](/reference/configuration/)
+- [Type mapping](/reference/type-mapping/)
+- [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
+- [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
+- Other destinations: [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/) · [MySQL to Neon](/guides/mysql-to-neon/)

--- a/site/src/content/docs/guides/mysql-to-planetscale-postgres.md
+++ b/site/src/content/docs/guides/mysql-to-planetscale-postgres.md
@@ -125,4 +125,4 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [Type mapping](/reference/type-mapping/)
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
-- Other destinations: [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/) · [MySQL to Neon](/guides/mysql-to-neon/)
+- Other destinations: [MySQL to Supabase](/guides/mysql-to-supabase/) · [MySQL to Neon](/guides/mysql-to-neon/) · [MySQL to Railway Postgres](/guides/mysql-to-railway-postgres/) · [MySQL to Render Postgres](/guides/mysql-to-render-postgres/) · [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/)

--- a/site/src/content/docs/guides/mysql-to-railway-postgres.md
+++ b/site/src/content/docs/guides/mysql-to-railway-postgres.md
@@ -1,0 +1,135 @@
+---
+title: MySQL to Railway Postgres
+description: A MySQL to Railway Postgres migration playbook — move MySQL to a Railway PostgreSQL service with pgferry, covering the public TCP proxy, self-signed TLS, private networking, and egress.
+---
+
+This is an operator's playbook for a **MySQL to Railway Postgres** migration. It covers the Railway-specific connection details — the public TCP proxy, self-signed TLS, and private networking — that you need to move MySQL into a [Railway](https://railway.com/) PostgreSQL service.
+
+If you searched for how to **migrate MySQL to Railway Postgres** or **move a MySQL database to Railway**, the short version is: use Railway's **public proxy URL** (`DATABASE_PUBLIC_URL`) with `sslmode=require` from an external host, run the migration **inside Railway** to avoid egress charges when you can, and let pgferry's [MySQL type mapping](/reference/type-mapping/) handle enums, sets, and unsigned integers.
+
+## What this guide is for
+
+Use this guide when you have a live MySQL database and want it on a Railway-hosted PostgreSQL service. It assumes you have added a Postgres database to a Railway project. For source-side behavior that is not Railway-specific, read the generic [MySQL to PostgreSQL guide](/guides/mysql/) alongside this page.
+
+## Why use pgferry instead of generic pgloader advice
+
+`pgloader` is the usual "mysql to railway postgres" suggestion, and it falls down on real schemas:
+
+- No resume — a drop over Railway's TCP proxy means restarting the whole load. `pgferry` checkpoints and resumes.
+- MySQL enums, sets, unsigned integers, `tinyint(1)`, and zero dates are explicit, documented knobs in `pgferry`.
+- `pgferry` streams with chunked, parallel `COPY` and runs a [`plan`](/operations/how-to-read-plan-output/) preflight that surfaces skipped indexes, generated columns, and required extensions first.
+
+## Destination prerequisites
+
+- A Railway project with a Postgres service. Default database is `railway`, default user is `postgres`.
+- The connection variables from the service's **Variables** tab. Railway's Postgres image runs as a single-tenant container, so the `postgres` role has broad privileges — `CREATE SCHEMA`, `CREATE EXTENSION` (for extensions whose binaries ship in the image), etc.
+- For pgvector or other non-default extensions, deploy the matching Railway template/image variant — the base image only carries the standard contrib set.
+
+## Recommended pgferry config
+
+```toml
+schema = "app"
+on_schema_exists = "error"
+unlogged_tables = false
+resume = true
+validation = "row_count"
+chunk_size = 100000
+source_snapshot_mode = "single_tx"
+
+[source]
+type = "mysql"
+# dsn supplied via PGFERRY_SOURCE_DSN
+
+[target]
+# dsn supplied via PGFERRY_TARGET_DSN
+
+[type_mapping]
+tinyint1_as_boolean = false
+json_as_jsonb = true
+enum_mode = "check"
+set_mode = "text"
+sanitize_json_null_bytes = true
+```
+
+`resume = true` requires `unlogged_tables = false` (see the [configuration reference](/reference/configuration/#important-incompatibilities)).
+
+## Railway DSN, TLS, proxy, and networking notes
+
+Railway exposes two connection URLs on the Postgres service:
+
+| Variable | Host shape | Use from |
+| --- | --- | --- |
+| `DATABASE_URL` (private) | `postgres.railway.internal:5432` | Another service **inside** the same Railway project |
+| `DATABASE_PUBLIC_URL` (public) | `<name>.proxy.rlwy.net:<random-port>` | An **external** migration host |
+
+- **From your laptop or any external host, use `DATABASE_PUBLIC_URL`.** The `.railway.internal` host is not routable outside Railway. The public proxy port is **randomly assigned** — never hardcode `5432` for the external endpoint; read it from the variable.
+- **TLS:** Railway's Postgres image uses a **self-signed** certificate. Use `?sslmode=require` (encrypts the connection without certificate-chain verification). `sslmode=verify-full` will fail because Railway does not publish a CA for the auto-generated cert.
+- **Egress:** traffic through the public proxy leaves Railway's network and **counts toward egress/network billing**. A multi-GB migration over the proxy can add up.
+- **Private networking:** if you run pgferry as a service **inside the same Railway project**, use `DATABASE_URL` (the internal host) — no egress charges, lower latency. Note the private network is IPv6-based; the Go/`pgx` driver pgferry uses handles this as long as the host resolves.
+
+Example external (public proxy) target DSN:
+
+```bash
+export PGFERRY_TARGET_DSN='postgres://postgres:<password>@<name>.proxy.rlwy.net:<proxy-port>/railway?sslmode=require'
+export PGFERRY_SOURCE_DSN='user:pass@tcp(mysql-host:3306)/source_db'
+```
+
+Inside Railway (same project, no egress):
+
+```bash
+export PGFERRY_TARGET_DSN='postgres://postgres:<password>@postgres.railway.internal:5432/railway?sslmode=disable'
+```
+
+### Capacity gotcha
+
+The Railway Postgres service is backed by a volume with a plan-dependent size cap, and WAL plus indexes built during the load consume extra space transiently. Pre-size or upgrade the volume before a large import so you do not run out mid-load.
+
+## Source-specific caveats (MySQL)
+
+Decide these on the MySQL side (full detail in the [MySQL guide](/guides/mysql/)):
+
+- `enum_mode` / `set_mode` — how `ENUM`/`SET` land in PostgreSQL.
+- `tinyint1_as_boolean` — only if `tinyint(1)` means boolean.
+- `widen_unsigned_integers` / `add_unsigned_checks` — preserve unsigned ranges.
+- `zero_date_mode` — `0000-00-00` → `NULL` or error.
+- Generated columns copy as values; `FULLTEXT`, prefix, and expression indexes are reported and skipped.
+- `ci_as_citext = true` needs the `citext` extension (present in the base image's contrib set).
+
+## Step-by-step MySQL to Railway Postgres migration flow
+
+1. Add Postgres to your Railway project and copy `DATABASE_PUBLIC_URL` (or use the internal URL if running inside Railway).
+2. Confirm the volume is large enough for the dataset plus index/WAL overhead.
+3. Generate a config with `pgferry wizard` or start from the snippet above.
+4. Export `PGFERRY_SOURCE_DSN` and `PGFERRY_TARGET_DSN`.
+5. Run `pgferry plan migration.toml` and resolve every warning.
+6. Run `pgferry migrate migration.toml`; rerun on interruption (`resume = true`).
+7. Recreate views, routines, and triggers via [hooks](/reference/hooks/).
+
+## Validation and cutover checklist
+
+- `pgferry validate migration.toml` re-runs validation without redoing DDL or `COPY`.
+- Confirm required extensions exist (and that you used the right image variant for pgvector etc.).
+- Verify the volume has headroom after the load.
+- Spot-check enum/set and `tinyint(1)` columns.
+- Walk the [cutover checklist](/operations/cutover-checklist/) and [first production migration checklist](/operations/first-production-migration-checklist/).
+
+## Common failures for this provider pair
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `could not translate host name "postgres.railway.internal"` | Used the private host from outside Railway | Use `DATABASE_PUBLIC_URL` |
+| TLS / certificate verification error | `verify-full` against a self-signed cert | Use `sslmode=require` |
+| Connection refused on `:5432` externally | Hardcoded port instead of proxy port | Use the random proxy port from `DATABASE_PUBLIC_URL` |
+| `No space left on device` mid-load | Volume too small for data + indexes | Pre-size/upgrade the volume |
+| Unexpected network bill | Bulk load over the public proxy | Run the migration inside Railway (private network) |
+
+See [common failures and recovery](/operations/common-failures-and-recovery/).
+
+## Related
+
+- [MySQL to PostgreSQL](/guides/mysql/) — generic source guide
+- [Configuration reference](/reference/configuration/)
+- [Type mapping](/reference/type-mapping/)
+- [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
+- [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
+- Other destinations: [MySQL to Render Postgres](/guides/mysql-to-render-postgres/) · [MySQL to Neon](/guides/mysql-to-neon/)

--- a/site/src/content/docs/guides/mysql-to-railway-postgres.md
+++ b/site/src/content/docs/guides/mysql-to-railway-postgres.md
@@ -77,8 +77,10 @@ export PGFERRY_SOURCE_DSN='user:pass@tcp(mysql-host:3306)/source_db'
 Inside Railway (same project, no egress):
 
 ```bash
-export PGFERRY_TARGET_DSN='postgres://postgres:<password>@postgres.railway.internal:5432/railway?sslmode=disable'
+export PGFERRY_TARGET_DSN='postgres://postgres:<password>@postgres.railway.internal:5432/railway?sslmode=require'
 ```
+
+The private network is isolated to your Railway project, so `sslmode=disable` also connects internally — but Railway's image serves SSL on the same port, so keep `sslmode=require` to encrypt the wire with no practical downside.
 
 ### Capacity gotcha
 
@@ -132,4 +134,4 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [Type mapping](/reference/type-mapping/)
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
-- Other destinations: [MySQL to Render Postgres](/guides/mysql-to-render-postgres/) · [MySQL to Neon](/guides/mysql-to-neon/)
+- Other destinations: [MySQL to Supabase](/guides/mysql-to-supabase/) · [MySQL to Neon](/guides/mysql-to-neon/) · [MySQL to Render Postgres](/guides/mysql-to-render-postgres/) · [MySQL to PlanetScale Postgres](/guides/mysql-to-planetscale-postgres/)

--- a/site/src/content/docs/guides/mysql-to-render-postgres.md
+++ b/site/src/content/docs/guides/mysql-to-render-postgres.md
@@ -1,0 +1,126 @@
+---
+title: MySQL to Render Postgres
+description: A MySQL to Render Postgres migration playbook — move MySQL to a Render PostgreSQL instance with pgferry, covering internal vs external URLs, required TLS, and inbound IP allowlists.
+---
+
+This is an operator's playbook for a **MySQL to Render Postgres** migration. It covers the Render-specific connection details — external vs internal URLs, required TLS, and the inbound IP allowlist — that you need to move MySQL into a [Render](https://render.com/) PostgreSQL instance.
+
+If you searched for how to **migrate MySQL to Render Postgres** or **move a MySQL database to Render**, the short version is: connect from an external host with Render's **External Database URL** and `sslmode=require`, allow your migration host in the inbound IP rules, never load production data into a Free instance, and let pgferry's [MySQL type mapping](/reference/type-mapping/) handle enums, sets, and unsigned integers.
+
+## What this guide is for
+
+Use this guide when you have a live MySQL database and want it on a Render-hosted PostgreSQL instance. It assumes you have created a Render Postgres instance. For source-side behavior that is not Render-specific, read the generic [MySQL to PostgreSQL guide](/guides/mysql/) alongside this page.
+
+## Why use pgferry instead of generic pgloader advice
+
+`pgloader` is the common "mysql to render postgres" recommendation and it struggles on real workloads:
+
+- No resume — a drop mid-load means starting over. `pgferry` checkpoints and resumes.
+- MySQL enums, sets, unsigned integers, `tinyint(1)`, and zero dates are explicit knobs in `pgferry`.
+- `pgferry` streams with chunked, parallel `COPY` and runs a [`plan`](/operations/how-to-read-plan-output/) preflight surfacing skipped indexes, generated columns, and required extensions first.
+- `pgferry` creates objects as the connecting role — no ownership/`SET ROLE` errors against Render's non-superuser role.
+
+## Destination prerequisites
+
+- A Render Postgres instance. Render auto-generates the database name and user at creation, and these are **immutable** afterward — read them from the instance's **Connect** menu.
+- **Do not use a Free instance for production data.** Free Postgres instances expire 30 days after creation and are capped at 1 GB with no backups. Use a paid instance type sized for your dataset.
+- Render's role is **not a superuser** but owns its database — it can `CREATE SCHEMA`, create tables/indexes/FKs/sequences, and `CREATE EXTENSION` for Render's allow-listed extensions. That covers everything pgferry needs.
+
+## Recommended pgferry config
+
+```toml
+schema = "app"
+on_schema_exists = "error"
+unlogged_tables = false
+resume = true
+validation = "row_count"
+chunk_size = 100000
+source_snapshot_mode = "single_tx"
+
+[source]
+type = "mysql"
+# dsn supplied via PGFERRY_SOURCE_DSN
+
+[target]
+# dsn supplied via PGFERRY_TARGET_DSN
+
+[type_mapping]
+tinyint1_as_boolean = false
+json_as_jsonb = true
+enum_mode = "check"
+set_mode = "text"
+sanitize_json_null_bytes = true
+```
+
+`resume = true` requires `unlogged_tables = false` (see the [configuration reference](/reference/configuration/#important-incompatibilities)).
+
+## Render DSN, TLS, and firewall notes
+
+Render gives every instance two URLs:
+
+| URL | Host shape | Use from |
+| --- | --- | --- |
+| External Database URL | `dpg-<id>-a.<region>-postgres.render.com:5432` | An **external** migration host |
+| Internal Database URL | `dpg-<id>-a` (private) | A Render service in the **same region** |
+
+- **From your laptop or any external host, use the External Database URL.** Only a service running inside Render (same region) can use the internal host.
+- **TLS is required for external connections.** Append `?sslmode=require`. Render manages the certificate; `sslmode=require` encrypts in transit (it does not validate the chain, which is the documented/safe setting).
+- **Inbound IP allowlist:** by default a Render Postgres instance is reachable from any IP (`0.0.0.0/0`), gated only by credentials + SSL. If you have tightened the inbound rules, **add your migration host's IP** (e.g. `203.0.113.45/32`) on the instance's **Networking** section before starting. If a dynamic IP makes that impractical, temporarily widen the rule for the load and tighten it afterward. The allowlist applies only to the external URL — internal connections are always allowed.
+- **Connection limits** scale with instance RAM (100 connections below 8 GB, 200 at 8–16 GB, and up). Keep pgferry's `workers`/`index_workers` within the instance's ceiling.
+
+Example external target DSN:
+
+```bash
+export PGFERRY_TARGET_DSN='postgres://<user>:<password>@dpg-<id>-a.<region>-postgres.render.com:5432/<dbname>?sslmode=require'
+export PGFERRY_SOURCE_DSN='user:pass@tcp(mysql-host:3306)/source_db'
+```
+
+## Source-specific caveats (MySQL)
+
+Decide these on the MySQL side (full detail in the [MySQL guide](/guides/mysql/)):
+
+- `enum_mode` / `set_mode` — how `ENUM`/`SET` land in PostgreSQL.
+- `tinyint1_as_boolean` — only if `tinyint(1)` means boolean.
+- `widen_unsigned_integers` / `add_unsigned_checks` — preserve unsigned ranges.
+- `zero_date_mode` — `0000-00-00` → `NULL` or error.
+- Generated columns copy as values; `FULLTEXT`, prefix, and expression indexes are reported and skipped.
+- `ci_as_citext = true` needs the `citext` extension (`CREATE EXTENSION` works for Render's supported set).
+
+## Step-by-step MySQL to Render Postgres migration flow
+
+1. Create a **paid** Render Postgres instance sized for the dataset; copy the External Database URL.
+2. Add your migration host's IP to the inbound rules if you have restricted them; enable storage autoscaling or pre-provision storage.
+3. Generate a config with `pgferry wizard` or start from the snippet above.
+4. Export `PGFERRY_SOURCE_DSN` and `PGFERRY_TARGET_DSN`.
+5. Run `pgferry plan migration.toml` and resolve every warning.
+6. Run `pgferry migrate migration.toml`; rerun on interruption (`resume = true`).
+7. Recreate views, routines, and triggers via [hooks](/reference/hooks/).
+
+## Validation and cutover checklist
+
+- `pgferry validate migration.toml` re-runs validation without redoing DDL or `COPY`.
+- Confirm required extensions are enabled (`CREATE EXTENSION` for anything `plan` flagged).
+- Always load into the **primary**, never a read replica.
+- Tighten the inbound IP allowlist after the load if you widened it.
+- Walk the [cutover checklist](/operations/cutover-checklist/) and [first production migration checklist](/operations/first-production-migration-checklist/).
+
+## Common failures for this provider pair
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Connection times out from your host | Inbound IP not allow-listed | Add your IP to the instance's inbound rules |
+| `no encryption` / SSL required | Missing TLS | Append `?sslmode=require` |
+| Can't resolve the `dpg-...-a` host | Used the internal URL externally | Use the External Database URL |
+| Data gone after a month | Loaded into a Free instance | Use a paid instance for production |
+| `too many connections` | `workers` above the instance limit | Lower `workers`/`index_workers` or size up |
+
+See [common failures and recovery](/operations/common-failures-and-recovery/).
+
+## Related
+
+- [MySQL to PostgreSQL](/guides/mysql/) — generic source guide
+- [Configuration reference](/reference/configuration/)
+- [Type mapping](/reference/type-mapping/)
+- [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
+- [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
+- Other destinations: [MySQL to Railway Postgres](/guides/mysql-to-railway-postgres/) · [MySQL to Supabase](/guides/mysql-to-supabase/)

--- a/site/src/content/docs/guides/mysql-to-render-postgres.md
+++ b/site/src/content/docs/guides/mysql-to-render-postgres.md
@@ -123,4 +123,4 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [Type mapping](/reference/type-mapping/)
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
-- Other destinations: [MySQL to Railway Postgres](/guides/mysql-to-railway-postgres/) · [MySQL to Supabase](/guides/mysql-to-supabase/)
+- Other destinations: [MySQL to Supabase](/guides/mysql-to-supabase/) · [MySQL to Neon](/guides/mysql-to-neon/) · [MySQL to Railway Postgres](/guides/mysql-to-railway-postgres/) · [MySQL to PlanetScale Postgres](/guides/mysql-to-planetscale-postgres/)

--- a/site/src/content/docs/guides/mysql-to-supabase.md
+++ b/site/src/content/docs/guides/mysql-to-supabase.md
@@ -1,0 +1,144 @@
+---
+title: MySQL to Supabase
+description: A practical MySQL to Supabase migration playbook — move MySQL to Supabase Postgres with pgferry, including pooler, TLS, and statement-timeout setup that generic pgloader advice skips.
+---
+
+This is an operator's playbook for a **MySQL to Supabase** migration. It covers the Supabase-specific connection, pooler, and timeout details you need to move MySQL into [Supabase](https://supabase.com/)'s hosted PostgreSQL without the dead ends that come from generic import advice.
+
+If you searched for how to **migrate MySQL to Supabase** or **move MySQL to Supabase Postgres**, the short version is: point `pgferry` at a session-mode (not transaction-mode) Supabase connection, raise the `postgres` role statement timeout for the load, and let the [MySQL type mapping](/reference/type-mapping/) handle enums, sets, and unsigned integers that `pgloader` mangles.
+
+## What this guide is for
+
+Use this guide when you have a live MySQL database (self-hosted, RDS, Aurora MySQL, Cloud SQL, PlanetScale MySQL, etc.) and you want it running on Supabase Postgres. It assumes you already have a Supabase project. For source-side behavior that is not Supabase-specific, read the generic [MySQL to PostgreSQL guide](/guides/mysql/) alongside this page.
+
+## Why use pgferry instead of generic pgloader advice
+
+Most "mysql to supabase" walkthroughs reach for `pgloader`. On real schemas that path routinely stalls or loses fidelity:
+
+- `pgloader` loads each table in long-running transactions and has no resume — a dropped connection (common over a hosted pooler) means starting over.
+- MySQL enums, sets, unsigned integers, `tinyint(1)` booleans, and zero dates need deliberate decisions. `pgferry` exposes each as an explicit, documented knob; `pgloader` guesses.
+- `pgferry` streams data with chunked, parallel `COPY`, checkpoints progress for `resume`, and runs a [`plan`](/operations/how-to-read-plan-output/) preflight so you see skipped indexes, generated columns, and required extensions *before* PostgreSQL is touched.
+- `pgferry` creates every object as the connecting role, so you never hit the ownership/`SET ROLE` errors that `pg_dump`/`pg_restore` throw against a non-superuser managed role.
+
+## Destination prerequisites
+
+- A Supabase project (note its **project ref**, the `xxxx` in `db.xxxx.supabase.co`).
+- Your database password from **Project Settings → Database** (reset it there if you never saved it).
+- Decide the target schema. Supabase uses the `public` schema by default; pgferry can create and own a dedicated schema instead.
+- The Supabase `postgres` role is **not a superuser** but is the most privileged role on the instance. It can create schemas, tables, indexes, foreign keys, sequences, and allow-listed extensions — everything pgferry needs.
+
+## Recommended pgferry config
+
+```toml
+schema = "app"
+on_schema_exists = "error"
+unlogged_tables = false
+resume = true
+validation = "row_count"
+chunk_size = 100000
+source_snapshot_mode = "single_tx"
+
+[source]
+type = "mysql"
+# dsn supplied via PGFERRY_SOURCE_DSN
+
+[target]
+# dsn supplied via PGFERRY_TARGET_DSN
+
+[type_mapping]
+tinyint1_as_boolean = false
+json_as_jsonb = true
+enum_mode = "check"
+set_mode = "text"
+sanitize_json_null_bytes = true
+```
+
+`resume = true` requires `unlogged_tables = false` (see the [configuration reference](/reference/configuration/#important-incompatibilities)). `source_snapshot_mode = "single_tx"` gives one consistent read view while the MySQL source stays live — see [how to choose snapshot mode](/operations/how-to-choose-snapshot-mode/).
+
+## Supabase DSN, TLS, pooling, and firewall notes
+
+Supabase exposes three connection types. Database name is always `postgres`.
+
+| Type | Host | Port | Username |
+| --- | --- | --- | --- |
+| Direct | `db.<ref>.supabase.co` | `5432` | `postgres` |
+| Session pooler (Supavisor) | `aws-0-<region>.pooler.supabase.com` | `5432` | `postgres.<ref>` |
+| Transaction pooler (Supavisor) | `aws-0-<region>.pooler.supabase.com` | `6543` | `postgres.<ref>` |
+
+- **Use the session pooler (port 5432) or the direct connection for migrations.** Both preserve session state and prepared statements, which pgferry's DDL and `COPY` pipeline depend on.
+- **Do not use the transaction pooler (port 6543).** Transaction mode multiplexes one backend per transaction, disables prepared statements, and drops session-scoped settings — it will break a migration.
+- **IPv4-only migration host?** The direct connection (`db.<ref>.supabase.co`) is IPv6-only unless you enable the paid IPv4 add-on. The **session pooler is IPv4-native with no add-on**, so it is the safest default. Copy the exact host string from the dashboard's **Connect** dialog rather than hand-building it.
+- **TLS** is expected — use at least `?sslmode=require`. For full verification, download the project CA cert from **Project Settings → Database → SSL Configuration** and use `sslmode=verify-full&sslrootcert=/path/to/ca.crt`.
+
+Example session-pooler target DSN:
+
+```bash
+export PGFERRY_TARGET_DSN='postgresql://postgres.<ref>:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres?sslmode=require'
+export PGFERRY_SOURCE_DSN='user:pass@tcp(mysql-host:3306)/source_db'
+```
+
+### Statement timeout — the most common Supabase migration failure
+
+Supabase caps the `postgres` role at a **default 2-minute statement timeout**. A large `COPY` chunk or index build will be killed mid-load with `canceling statement due to statement timeout`. Disable it for the migration window, then revert:
+
+```sql
+-- before the migration
+alter role postgres set statement_timeout = '0';
+-- after cutover, restore a sane default
+alter role postgres reset statement_timeout;
+```
+
+You may need to reconnect (or briefly restart the project) for the change to take effect. If you bumped any PostgREST-facing roles, run `NOTIFY pgrst, 'reload config';`.
+
+## Source-specific caveats (MySQL)
+
+These come from the MySQL side and are not Supabase-specific — decide them deliberately:
+
+- `enum_mode` / `set_mode` — how MySQL `ENUM` and `SET` columns land in PostgreSQL.
+- `tinyint1_as_boolean` — only enable if `tinyint(1)` truly means boolean in your data.
+- `widen_unsigned_integers` / `add_unsigned_checks` — preserve unsigned ranges.
+- `zero_date_mode` — convert `0000-00-00` to `NULL` or error.
+- Generated columns are copied as values, not recreated as expressions.
+- `FULLTEXT`, prefix, and expression indexes are reported and skipped, not guessed.
+- For `_ci` collations, consider `ci_as_citext = true` (Supabase ships the `citext` extension; enable it from **Database → Extensions** if pgferry reports it as required).
+
+See the [MySQL guide](/guides/mysql/) and [type mapping](/reference/type-mapping/) for the full list.
+
+## Step-by-step MySQL to Supabase migration flow
+
+1. Create the Supabase project and grab the session-pooler connection string from the **Connect** dialog.
+2. `alter role postgres set statement_timeout = '0';` (see above).
+3. Generate a config with `pgferry wizard`, or start from the snippet above.
+4. Export `PGFERRY_SOURCE_DSN` and `PGFERRY_TARGET_DSN`.
+5. Run `pgferry plan migration.toml` and resolve every reported warning (skipped indexes, generated columns, required extensions).
+6. Run `pgferry migrate migration.toml`. If interrupted, rerun the same command — `resume = true` continues from the checkpoint.
+7. Recreate views, routines, and triggers via [hooks](/reference/hooks/) — pgferry migrates tables, data, indexes, FKs, and sequences, not application logic.
+
+## Validation and cutover checklist
+
+- `pgferry validate migration.toml` re-runs the `row_count` (or `sampled_hash`) check without redoing DDL or `COPY`.
+- Confirm Supabase **Database → Extensions** has every extension your schema needs enabled.
+- Spot-check enum/set columns and any `tinyint(1)` columns for the mapping you chose.
+- Restore the `postgres` role `statement_timeout`.
+- Walk the full [cutover checklist](/operations/cutover-checklist/) and [first production migration checklist](/operations/first-production-migration-checklist/) before pointing traffic at Supabase.
+
+## Common failures for this provider pair
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `canceling statement due to statement timeout` | Supabase 2-min role timeout | `alter role postgres set statement_timeout = '0'` for the load |
+| `prepared statement ... does not exist` / odd session errors | Connected via transaction pooler (6543) | Use the session pooler (5432) or direct connection |
+| `could not translate host name` / no route | Direct host is IPv6-only on an IPv4 host | Use the session pooler, or enable the IPv4 add-on |
+| `extension "citext" does not exist` (or similar) | Extension not enabled | Enable it in **Database → Extensions** |
+| SSL/connection refused | Missing TLS | Append `?sslmode=require` |
+
+See [common failures and recovery](/operations/common-failures-and-recovery/) for the general catalog.
+
+## Related
+
+- [MySQL to PostgreSQL](/guides/mysql/) — generic source guide
+- [Configuration reference](/reference/configuration/)
+- [Type mapping](/reference/type-mapping/)
+- [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
+- [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
+- Other destinations: [MySQL to Neon](/guides/mysql-to-neon/) · [MSSQL to Supabase](/guides/mssql-to-supabase/)

--- a/site/src/content/docs/guides/mysql-to-supabase.md
+++ b/site/src/content/docs/guides/mysql-to-supabase.md
@@ -141,4 +141,4 @@ See [common failures and recovery](/operations/common-failures-and-recovery/) fo
 - [Type mapping](/reference/type-mapping/)
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
-- Other destinations: [MySQL to Neon](/guides/mysql-to-neon/) · [MSSQL to Supabase](/guides/mssql-to-supabase/)
+- Other destinations: [MySQL to Neon](/guides/mysql-to-neon/) · [MySQL to Railway Postgres](/guides/mysql-to-railway-postgres/) · [MySQL to Render Postgres](/guides/mysql-to-render-postgres/) · [MySQL to PlanetScale Postgres](/guides/mysql-to-planetscale-postgres/) · [MSSQL to Supabase](/guides/mssql-to-supabase/)

--- a/site/src/content/docs/guides/mysql-to-supabase.md
+++ b/site/src/content/docs/guides/mysql-to-supabase.md
@@ -88,7 +88,7 @@ alter role postgres set statement_timeout = '0';
 alter role postgres reset statement_timeout;
 ```
 
-You may need to reconnect (or briefly restart the project) for the change to take effect. If you bumped any PostgREST-facing roles, run `NOTIFY pgrst, 'reload config';`.
+Reconnect for the change to take effect — `ALTER ROLE ... SET` applies to new sessions only.
 
 ## Source-specific caveats (MySQL)
 

--- a/site/src/content/docs/guides/mysql.md
+++ b/site/src/content/docs/guides/mysql.md
@@ -29,3 +29,13 @@ MySQL is still the richest pgferry source because it includes enums, sets, unsig
 - unsupported indexes such as `FULLTEXT`, prefix indexes, and expression indexes are reported and skipped
 - `single_tx` is available when you need one consistent snapshot on a live source
 - zero dates need explicit handling through `zero_date_mode`
+
+## Migrating to a managed Postgres provider?
+
+These destination-specific guides add the provider connection, TLS, pooling, and firewall setup on top of the MySQL behavior above:
+
+- [MySQL to Supabase](/guides/mysql-to-supabase/)
+- [MySQL to Neon](/guides/mysql-to-neon/)
+- [MySQL to Railway Postgres](/guides/mysql-to-railway-postgres/)
+- [MySQL to Render Postgres](/guides/mysql-to-render-postgres/)
+- [MySQL to PlanetScale Postgres](/guides/mysql-to-planetscale-postgres/)


### PR DESCRIPTION
Closes #171.

Adds the first wave of destination-specific SEO guides under `site/src/content/docs/guides/`, targeting high-intent searches where operators are moving **MySQL** or **MSSQL** into a managed PostgreSQL service.

## New guides (8)

| Guide | Primary keyword |
|---|---|
| `mysql-to-supabase.md` | mysql to supabase |
| `mysql-to-neon.md` | mysql to neon |
| `mssql-to-supabase.md` | mssql to supabase |
| `mysql-to-railway-postgres.md` | mysql to railway postgres |
| `mysql-to-render-postgres.md` | mysql to render postgres |
| `mysql-to-planetscale-postgres.md` | mysql to planetscale postgres |
| `mssql-to-neon.md` | mssql to neon |
| `mssql-to-planetscale-postgres.md` | mssql to planetscale postgres |

Each page is a full operator playbook (not a doorway page) following the issue template: what the guide is for, why use pgferry over generic pgloader advice, destination prerequisites, recommended pgferry config, **provider-specific DSN / TLS / pooling / firewall notes**, source-specific caveats, step-by-step flow, validation & cutover checklist, common failures, and related links.

## Accuracy

Provider sections are grounded in each vendor's current official docs:

- **Supabase** — session pooler (5432) vs transaction pooler (6543, no prepared statements), IPv4-native session pooler, and the **2-minute `postgres`-role statement timeout** that kills bulk loads.
- **Neon** — direct (unpooled) vs `-pooler` endpoint, mandatory TLS + `channel_binding`, disabling **scale-to-zero** for the load.
- **PlanetScale** — explicitly disambiguates **PlanetScale for Postgres** (GA Sep 2025, on Metal) from the legacy MySQL/Vitess product; direct port 5432 vs PSBouncer 6432, `sslmode=verify-full sslrootcert=system`.
- **Railway** — `DATABASE_PUBLIC_URL` proxy (random port) vs internal host, self-signed cert → `sslmode=require`, egress cost.
- **Render** — External vs Internal URL, required SSL, inbound IP allowlist, "never use a Free instance for prod".

All pgferry config/flag/CLI claims are checked against the repo's `configuration.md`, `type-mapping.md`, and the existing MySQL/MSSQL guides.

## Cross-linking

- `/guides/` index gains a "By managed Postgres destination" section linking all 8.
- Generic `guides/mysql.md` and `guides/mssql.md` link to their destination guides.
- `examples/mysql/index.md` and `examples/mssql/index.md` link to them.
- Each new page links back to the generic source guide, config reference, type mapping, and operator checklists.

## SEO

Exact `source → destination` phrase appears in title, description, H1, intro paragraph, and a subheading on every page, plus natural long-tail variants ("migrate mysql to neon", "move mysql to supabase postgres", "migrate sql server to supabase").

## Verification

- `bun run build` succeeds (61 pages).
- `bun run check-routes` passes — it validates **every internal link**, so all cross-links resolve with no broken references.

New pages auto-appear in the sidebar (the `guides` directory is autogenerated).