### PR TITLE
Add migrate log level controls

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ const migrateLogFormatFlagShort = "migrate progress: text or json"
 // migrateLogFormatFlagDesc documents JSON mode for migrateCmd.Long and site docs.
 const migrateLogFormatFlagDesc = `With json, one JSON object is written to stdout when the run finishes; human messages remain on stderr. JSON fields: version, duration_ms, mode, validation, success, error, stage (on failure), tables_migrated (omitted when zero).`
 
+const migrateLogLevelFlagDesc = `Use --log-level=table, or --quiet, to suppress per-chunk row-copy progress and keep one row-copy start/done pair per table. Use --log-level=schema to suppress row-copy progress detail.`
+
 var rootCmd = &cobra.Command{
 	Use:   "pgferry [migration.toml]",
 	Short: "Source database to PostgreSQL migration tool",
@@ -54,7 +56,7 @@ var migrateCmd = &cobra.Command{
 	Use:     "migrate [migration.toml]",
 	Aliases: []string{"run"},
 	Short:   "Run a migration from a TOML config file",
-	Long:    "Run a migration from a TOML config file.\n\n" + migrateLogFormatFlagDesc,
+	Long:    "Run a migration from a TOML config file.\n\n" + migrateLogFormatFlagDesc + "\n\n" + migrateLogLevelFlagDesc,
 	Args:    cobra.MaximumNArgs(1),
 	RunE:    runMigration,
 }
@@ -76,6 +78,8 @@ func init() {
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 	rootCmd.Flags().StringVar(&configPath, "config", "", "path to migration TOML config file")
 	rootCmd.PersistentFlags().String("log-format", "text", migrateLogFormatFlagShort)
+	rootCmd.PersistentFlags().String("log-level", migrateLogLevelVerbose, "row-copy progress detail: verbose, table, or schema")
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "suppress per-chunk row-copy progress (same as --log-level=table)")
 	migrateCmd.Flags().StringVar(&configPath, "config", "", "path to migration TOML config file")
 	versionCmd.Flags().BoolVarP(&versionVerbose, "verbose", "v", false, "print detailed build metadata")
 	rootCmd.AddCommand(versionCmd)
@@ -444,6 +448,7 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 					ChunkSize:           cfg.ChunkSize,
 					Resume:              cfg.Resume,
 					ConfigDir:           cfg.configDir,
+					LogLevel:            opts.LogLevel,
 					ResumeCompatibility: resumeCompatibility,
 				})
 			},

--- a/migrate.go
+++ b/migrate.go
@@ -380,6 +380,10 @@ func migrateDataSingleTx(ctx context.Context, cfg migrateDataConfig) error {
 		chunks := planChunks(min, max, cfg.ChunkSize)
 		colSelectList := buildColumnSelectList(cfg.Src, t, cfg.TypeMap)
 		pgCols := tablePGCopyColumns(t)
+		chunksToCopy := pendingChunks(t.SourceName, chunks, mgr)
+		if len(chunksToCopy) == 0 {
+			continue
+		}
 		if isVerboseMigrateLogLevel(cfg.LogLevel) {
 			log.Printf("  [%s] %d chunks (key=%s, range=%d..%d)", t.SourceName, len(chunks), key.SourceColumn, min, max)
 		}
@@ -387,10 +391,7 @@ func migrateDataSingleTx(ctx context.Context, cfg migrateDataConfig) error {
 			log.Printf("  [%s] starting row copy", t.SourceName)
 		}
 		var copied int64
-		for _, chunk := range chunks {
-			if mgr.IsChunkCompleted(t.SourceName, chunk.Index) {
-				continue
-			}
+		for _, chunk := range chunksToCopy {
 			count, copyErr := migrateChunkFromSource(ctx, cfg.Src, tx, cfg.Pool, t, cfg.PGSchema, cfg.TypeMap, *key, chunk, colSelectList, pgCols, cfg.LogLevel)
 			if copyErr != nil {
 				return fmt.Errorf("table %s chunk %d: %w", t.SourceName, chunk.Index, copyErr)
@@ -414,6 +415,17 @@ func migrateDataSingleTx(ctx context.Context, cfg migrateDataConfig) error {
 		log.Printf("WARN: failed to delete checkpoint: %v", err)
 	}
 	return nil
+}
+
+func pendingChunks(tableName string, chunks []Chunk, mgr checkpointManager) []Chunk {
+	pending := make([]Chunk, 0, len(chunks))
+	for _, chunk := range chunks {
+		if mgr.IsChunkCompleted(tableName, chunk.Index) {
+			continue
+		}
+		pending = append(pending, chunk)
+	}
+	return pending
 }
 
 func openMigrationSourceDB(src SourceDB, srcDSN string) (*sql.DB, error) {

--- a/migrate.go
+++ b/migrate.go
@@ -27,6 +27,7 @@ type migrateDataConfig struct {
 	ChunkSize          int64
 	Resume             bool
 	ConfigDir          string
+	LogLevel           string
 	// ResumeCompatibility is used only when Resume=true to validate that an
 	// existing checkpoint still matches the current migration shape.
 	ResumeCompatibility checkpointCompatibility
@@ -44,7 +45,7 @@ func migrateData(ctx context.Context, cfg migrateDataConfig) error {
 
 func migrateDataParallel(ctx context.Context, cfg migrateDataConfig) error {
 	// Plan chunks for each table
-	plans, err := buildChunkPlans(ctx, cfg.Src, cfg.SrcDSN, cfg.Schema, cfg.ChunkSize, cfg.TypeMap, cfg.Workers)
+	plans, err := buildChunkPlans(ctx, cfg.Src, cfg.SrcDSN, cfg.Schema, cfg.ChunkSize, cfg.TypeMap, cfg.Workers, cfg.LogLevel)
 	if err != nil {
 		return err
 	}
@@ -64,6 +65,7 @@ func migrateDataParallel(ctx context.Context, cfg migrateDataConfig) error {
 	}
 
 	workItems := buildParallelMigrationWorkItems(plans, mgr)
+	progress := newMigrationProgressLogger(cfg.LogLevel, workItems)
 	if err := runParallelMigrationWorkers(
 		ctx,
 		cfg.Workers,
@@ -74,9 +76,15 @@ func migrateDataParallel(ctx context.Context, cfg migrateDataConfig) error {
 		mgr,
 		func(ctx context.Context, source dbQuerier, item migrationWorkItem) (int64, error) {
 			if item.ChunkKey == nil {
-				return migrateTableFromSourceFull(ctx, cfg.Src, source, cfg.Pool, item.Table, cfg.PGSchema, cfg.TypeMap, item.PGCopyColumns)
+				return migrateTableFromSourceFull(ctx, cfg.Src, source, cfg.Pool, item.Table, cfg.PGSchema, cfg.TypeMap, item.PGCopyColumns, cfg.LogLevel)
 			}
-			return migrateChunkFromSource(ctx, cfg.Src, source, cfg.Pool, item.Table, cfg.PGSchema, cfg.TypeMap, *item.ChunkKey, item.Chunk, item.ColumnSelectList, item.PGCopyColumns)
+			progress.StartChunkedTable(item.Table.SourceName)
+			count, err := migrateChunkFromSource(ctx, cfg.Src, source, cfg.Pool, item.Table, cfg.PGSchema, cfg.TypeMap, *item.ChunkKey, item.Chunk, item.ColumnSelectList, item.PGCopyColumns, cfg.LogLevel)
+			if err != nil {
+				return 0, err
+			}
+			progress.FinishChunk(item.Table.SourceName, count)
+			return count, nil
 		},
 	); err != nil {
 		// Flush partial progress so a resumed run can skip completed work.
@@ -350,7 +358,7 @@ func migrateDataSingleTx(ctx context.Context, cfg migrateDataConfig) error {
 				log.Printf("  [%s] skipping (completed in previous run)", t.SourceName)
 				continue
 			}
-			count, copyErr := migrateTableFromSourceFull(ctx, cfg.Src, tx, cfg.Pool, t, cfg.PGSchema, cfg.TypeMap, tablePGCopyColumns(t))
+			count, copyErr := migrateTableFromSourceFull(ctx, cfg.Src, tx, cfg.Pool, t, cfg.PGSchema, cfg.TypeMap, tablePGCopyColumns(t), cfg.LogLevel)
 			if copyErr != nil {
 				return fmt.Errorf("table %s: %w", t.SourceName, copyErr)
 			}
@@ -372,16 +380,26 @@ func migrateDataSingleTx(ctx context.Context, cfg migrateDataConfig) error {
 		chunks := planChunks(min, max, cfg.ChunkSize)
 		colSelectList := buildColumnSelectList(cfg.Src, t, cfg.TypeMap)
 		pgCols := tablePGCopyColumns(t)
-		log.Printf("  [%s] %d chunks (key=%s, range=%d..%d)", t.SourceName, len(chunks), key.SourceColumn, min, max)
+		if isVerboseMigrateLogLevel(cfg.LogLevel) {
+			log.Printf("  [%s] %d chunks (key=%s, range=%d..%d)", t.SourceName, len(chunks), key.SourceColumn, min, max)
+		}
+		if isTableMigrateLogLevel(cfg.LogLevel) {
+			log.Printf("  [%s] starting row copy", t.SourceName)
+		}
+		var copied int64
 		for _, chunk := range chunks {
 			if mgr.IsChunkCompleted(t.SourceName, chunk.Index) {
 				continue
 			}
-			count, copyErr := migrateChunkFromSource(ctx, cfg.Src, tx, cfg.Pool, t, cfg.PGSchema, cfg.TypeMap, *key, chunk, colSelectList, pgCols)
+			count, copyErr := migrateChunkFromSource(ctx, cfg.Src, tx, cfg.Pool, t, cfg.PGSchema, cfg.TypeMap, *key, chunk, colSelectList, pgCols, cfg.LogLevel)
 			if copyErr != nil {
 				return fmt.Errorf("table %s chunk %d: %w", t.SourceName, chunk.Index, copyErr)
 			}
+			copied += count
 			mgr.RecordChunk(t.SourceName, chunk.Index, count, len(chunks))
+		}
+		if isTableMigrateLogLevel(cfg.LogLevel) {
+			log.Printf("  [%s] done (%d rows copied)", t.SourceName, copied)
 		}
 	}
 
@@ -430,31 +448,131 @@ type dbQuerier interface {
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
 }
 
-func migrateTableFromSourceFull(ctx context.Context, src SourceDB, source dbQuerier, pool *pgxpool.Pool, table Table, pgSchema string, typeMap TypeMappingConfig, pgCopyColumns []string) (int64, error) {
-	log.Printf("  [%s] starting row copy", table.SourceName)
+func migrateTableFromSourceFull(ctx context.Context, src SourceDB, source dbQuerier, pool *pgxpool.Pool, table Table, pgSchema string, typeMap TypeMappingConfig, pgCopyColumns []string, logLevel string) (int64, error) {
+	if shouldLogTableRowCopy(logLevel) {
+		log.Printf("  [%s] starting row copy", table.SourceName)
+	}
 
 	query := buildSourceSelectQuery(src, table, typeMap)
-	count, err := copyFromSource(ctx, source, pool, table, pgSchema, typeMap, src, query, pgCopyColumns)
+	count, err := copyFromSource(ctx, source, pool, table, pgSchema, typeMap, src, query, pgCopyColumns, logLevel)
 	if err != nil {
 		return 0, err
 	}
 
-	log.Printf("  [%s] done (%d rows copied)", table.SourceName, count)
+	if shouldLogTableRowCopy(logLevel) {
+		log.Printf("  [%s] done (%d rows copied)", table.SourceName, count)
+	}
 	return count, nil
 }
 
 // migrateChunkFromSource copies a single chunk using an existing source querier.
-func migrateChunkFromSource(ctx context.Context, src SourceDB, source dbQuerier, pool *pgxpool.Pool, table Table, pgSchema string, typeMap TypeMappingConfig, key ChunkKey, chunk Chunk, columnSelectList string, pgCopyColumns []string) (int64, error) {
-	log.Printf("  [%s] chunk %d starting", table.SourceName, chunk.Index)
+func migrateChunkFromSource(ctx context.Context, src SourceDB, source dbQuerier, pool *pgxpool.Pool, table Table, pgSchema string, typeMap TypeMappingConfig, key ChunkKey, chunk Chunk, columnSelectList string, pgCopyColumns []string, logLevel string) (int64, error) {
+	logChunkProgress(logLevel, table.SourceName, chunk.Index, "starting", 0)
 
 	query := buildChunkedSelectQuery(src, table, key, chunk, columnSelectList)
-	count, err := copyFromSource(ctx, source, pool, table, pgSchema, typeMap, src, query, pgCopyColumns)
+	count, err := copyFromSource(ctx, source, pool, table, pgSchema, typeMap, src, query, pgCopyColumns, logLevel)
 	if err != nil {
 		return 0, err
 	}
 
-	log.Printf("  [%s] chunk %d done (%d rows)", table.SourceName, chunk.Index, count)
+	logChunkProgress(logLevel, table.SourceName, chunk.Index, "done", count)
 	return count, nil
+}
+
+type migrationProgressLogger struct {
+	logLevel string
+	mu       sync.Mutex
+	tables   map[string]*migrationTableProgress
+}
+
+type migrationTableProgress struct {
+	totalChunks    int
+	finishedChunks int
+	copiedRows     int64
+	started        bool
+	done           bool
+}
+
+func newMigrationProgressLogger(logLevel string, workItems []migrationWorkItem) *migrationProgressLogger {
+	p := &migrationProgressLogger{
+		logLevel: logLevel,
+		tables:   make(map[string]*migrationTableProgress),
+	}
+	if !isTableMigrateLogLevel(logLevel) {
+		return p
+	}
+	for _, item := range workItems {
+		if item.ChunkKey == nil {
+			continue
+		}
+		tableName := item.Table.SourceName
+		if p.tables[tableName] == nil {
+			p.tables[tableName] = &migrationTableProgress{}
+		}
+		p.tables[tableName].totalChunks++
+	}
+	return p
+}
+
+func (p *migrationProgressLogger) StartChunkedTable(tableName string) {
+	if p == nil || !isTableMigrateLogLevel(p.logLevel) {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	table := p.tables[tableName]
+	if table == nil || table.started {
+		return
+	}
+	table.started = true
+	log.Printf("  [%s] starting row copy", tableName)
+}
+
+func (p *migrationProgressLogger) FinishChunk(tableName string, copiedRows int64) {
+	if p == nil || !isTableMigrateLogLevel(p.logLevel) {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	table := p.tables[tableName]
+	if table == nil || table.done {
+		return
+	}
+	table.finishedChunks++
+	table.copiedRows += copiedRows
+	if table.finishedChunks == table.totalChunks {
+		table.done = true
+		log.Printf("  [%s] done (%d rows copied)", tableName, table.copiedRows)
+	}
+}
+
+func logChunkProgress(logLevel, tableName string, chunkIndex int, state string, rows int64) {
+	if !isVerboseMigrateLogLevel(logLevel) {
+		return
+	}
+	if state == "done" {
+		log.Printf("  [%s] chunk %d done (%d rows)", tableName, chunkIndex, rows)
+		return
+	}
+	log.Printf("  [%s] chunk %d %s", tableName, chunkIndex, state)
+}
+
+func isVerboseMigrateLogLevel(logLevel string) bool {
+	return logLevel == "" || logLevel == migrateLogLevelVerbose
+}
+
+func isTableMigrateLogLevel(logLevel string) bool {
+	return logLevel == migrateLogLevelTable
+}
+
+func shouldLogTableRowCopy(logLevel string) bool {
+	return isVerboseMigrateLogLevel(logLevel) || isTableMigrateLogLevel(logLevel)
+}
+
+func shouldLogRowCopyProgress(logLevel string) bool {
+	return isVerboseMigrateLogLevel(logLevel)
 }
 
 // tablePGCopyColumns returns PostgreSQL column names in table.Columns order for COPY.
@@ -467,7 +585,7 @@ func tablePGCopyColumns(table Table) []string {
 }
 
 // copyFromSource runs a SELECT query on the source and streams results into PG via COPY.
-func copyFromSource(ctx context.Context, source dbQuerier, pool *pgxpool.Pool, table Table, pgSchema string, typeMap TypeMappingConfig, src SourceDB, query string, pgColumns []string) (int64, error) {
+func copyFromSource(ctx context.Context, source dbQuerier, pool *pgxpool.Pool, table Table, pgSchema string, typeMap TypeMappingConfig, src SourceDB, query string, pgColumns []string, logLevel string) (int64, error) {
 	conn, err := pool.Acquire(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("acquire pg conn: %w", err)
@@ -480,7 +598,7 @@ func copyFromSource(ctx context.Context, source dbQuerier, pool *pgxpool.Pool, t
 	}
 	defer rows.Close()
 
-	rs := newRowSource(rows, table, src, typeMap)
+	rs := newRowSource(rows, table, src, typeMap, logLevel)
 
 	count, err := conn.Conn().CopyFrom(
 		ctx,
@@ -497,7 +615,7 @@ func copyFromSource(ctx context.Context, source dbQuerier, pool *pgxpool.Pool, t
 // buildChunkPlans creates chunk plans for all tables by querying MIN/MAX on chunkable tables.
 // typeMap must be the same validated TypeMappingConfig used for the data migration so
 // ColumnSelectList matches buildSourceSelectQuery / columnSelectExpr semantics.
-func buildChunkPlans(ctx context.Context, src SourceDB, srcDSN string, schema *Schema, chunkSize int64, typeMap TypeMappingConfig, workers int) ([]ChunkPlan, error) {
+func buildChunkPlans(ctx context.Context, src SourceDB, srcDSN string, schema *Schema, chunkSize int64, typeMap TypeMappingConfig, workers int, logLevel string) ([]ChunkPlan, error) {
 	return buildChunkPlansWithDeps(
 		ctx,
 		src,
@@ -505,6 +623,7 @@ func buildChunkPlans(ctx context.Context, src SourceDB, srcDSN string, schema *S
 		chunkSize,
 		typeMap,
 		chunkPlanningWorkers(workers, src),
+		logLevel,
 		chunkPlanningDeps{
 			openSource: func() (migrationWorkerSource, error) {
 				srcDB, err := openMigrationSourceDB(src, srcDSN)
@@ -531,7 +650,7 @@ type chunkPlanningJob struct {
 	pgCopyColumns    []string
 }
 
-func buildChunkPlansWithDeps(ctx context.Context, src SourceDB, schema *Schema, chunkSize int64, typeMap TypeMappingConfig, workers int, deps chunkPlanningDeps) ([]ChunkPlan, error) {
+func buildChunkPlansWithDeps(ctx context.Context, src SourceDB, schema *Schema, chunkSize int64, typeMap TypeMappingConfig, workers int, logLevel string, deps chunkPlanningDeps) ([]ChunkPlan, error) {
 	plans := make([]ChunkPlan, len(schema.Tables))
 	jobs := make([]chunkPlanningJob, 0, len(schema.Tables))
 	nonChunkable := 0
@@ -648,7 +767,9 @@ func buildChunkPlansWithDeps(ctx context.Context, src SourceDB, schema *Schema, 
 						ColumnSelectList: job.columnSelectList,
 						PGCopyColumns:    job.pgCopyColumns,
 					}
-					log.Printf("  [%s] %d chunks (key=%s, range=%d..%d)", job.table.SourceName, len(chunks), job.key.SourceColumn, min, max)
+					if isVerboseMigrateLogLevel(logLevel) {
+						log.Printf("  [%s] %d chunks (key=%s, range=%d..%d)", job.table.SourceName, len(chunks), job.key.SourceColumn, min, max)
+					}
 				}
 			}
 		}()
@@ -709,9 +830,10 @@ type rowSource struct {
 	copied       int64
 	tableName    string
 	lastLog      time.Time
+	logLevel     string
 }
 
-func newRowSource(rows *sql.Rows, table Table, src SourceDB, typeMap TypeMappingConfig) *rowSource {
+func newRowSource(rows *sql.Rows, table Table, src SourceDB, typeMap TypeMappingConfig, logLevel string) *rowSource {
 	numCols := len(table.Columns)
 	scanDest := make([]any, numCols)
 	scanPtrs := make([]any, numCols)
@@ -728,6 +850,7 @@ func newRowSource(rows *sql.Rows, table Table, src SourceDB, typeMap TypeMapping
 		values:       make([]any, numCols),
 		tableName:    table.SourceName,
 		lastLog:      time.Now(),
+		logLevel:     logLevel,
 	}
 }
 
@@ -752,7 +875,7 @@ func (r *rowSource) Next() bool {
 	}
 
 	r.copied++
-	if shouldSampleProgressLogTime(r.copied) {
+	if shouldLogRowCopyProgress(r.logLevel) && shouldSampleProgressLogTime(r.copied) {
 		if now := time.Now(); now.Sub(r.lastLog) >= 10*time.Second {
 			log.Printf("  [%s] progress: %d rows copied", r.tableName, r.copied)
 			r.lastLog = now

--- a/migrate_summary.go
+++ b/migrate_summary.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strconv"
 	"strings"
 	"time"
 
@@ -59,12 +58,14 @@ func migrateOptionsFromCmd(cmd *cobra.Command) (MigrateOptions, error) {
 	if err != nil {
 		return MigrateOptions{}, err
 	}
-	if v, ok := commandFlagString(cmd, "quiet"); ok {
-		quiet, err := strconv.ParseBool(v)
+	if quiet, ok, err := commandFlagBool(cmd, "quiet"); ok {
 		if err != nil {
 			return MigrateOptions{}, err
 		}
 		if quiet {
+			if commandFlagChanged(cmd, "log-level") {
+				return MigrateOptions{}, fmt.Errorf("cannot combine --quiet with --log-level")
+			}
 			ll = migrateLogLevelTable
 		}
 	}
@@ -81,6 +82,33 @@ func commandFlagString(cmd *cobra.Command, name string) (string, bool) {
 		return "", false
 	}
 	return flag.Value.String(), true
+}
+
+func commandFlagBool(cmd *cobra.Command, name string) (bool, bool, error) {
+	if cmd == nil {
+		return false, false, nil
+	}
+	switch {
+	case cmd.Flags().Lookup(name) != nil:
+		v, err := cmd.Flags().GetBool(name)
+		return v, true, err
+	case cmd.PersistentFlags().Lookup(name) != nil:
+		v, err := cmd.PersistentFlags().GetBool(name)
+		return v, true, err
+	case cmd.InheritedFlags().Lookup(name) != nil:
+		v, err := cmd.InheritedFlags().GetBool(name)
+		return v, true, err
+	default:
+		return false, false, nil
+	}
+}
+
+func commandFlagChanged(cmd *cobra.Command, name string) bool {
+	if cmd == nil {
+		return false
+	}
+	flag := cmd.Flag(name)
+	return flag != nil && flag.Changed
 }
 
 func parseMigrateLogFormat(s string) (string, error) {

--- a/migrate_summary.go
+++ b/migrate_summary.go
@@ -4,10 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+)
+
+const (
+	migrateLogLevelVerbose = "verbose"
+	migrateLogLevelTable   = "table"
+	migrateLogLevelSchema  = "schema"
 )
 
 // MigrateOptions configures migrate execution (CLI passes flags; wizard uses zero value).
@@ -15,6 +22,9 @@ type MigrateOptions struct {
 	// LogFormat is "text" (default) or "json". When "json", a single JSON summary
 	// line is written to stdout at the end; human diagnostics remain on stderr.
 	LogFormat string
+	// LogLevel controls row-copy progress detail: verbose logs per-chunk progress,
+	// table logs one row-copy start/done pair per table, and schema suppresses row-copy detail.
+	LogLevel string
 }
 
 // migrateJSONSummary is the machine-readable migrate run outcome (stdout when --log-format json).
@@ -29,22 +39,48 @@ type migrateJSONSummary struct {
 	TablesMigrated int    `json:"tables_migrated,omitempty"`
 }
 
-// migrateOptionsFromCmd reads --log-format (default text). cmd may be nil (tests).
-// If the flag is not registered on cmd (e.g. bare cobra.Command in tests), text is used.
+// migrateOptionsFromCmd reads migrate flags. cmd may be nil (tests).
+// If flags are not registered on cmd (e.g. bare cobra.Command in tests), defaults are used.
 func migrateOptionsFromCmd(cmd *cobra.Command) (MigrateOptions, error) {
-	s := "text"
-	if cmd != nil && cmd.Flags().Lookup("log-format") != nil {
-		v, err := cmd.Flags().GetString("log-format")
-		if err != nil {
-			return MigrateOptions{}, err
-		}
-		s = v
+	logFormat := "text"
+	if v, ok := commandFlagString(cmd, "log-format"); ok {
+		logFormat = v
 	}
-	lf, err := parseMigrateLogFormat(s)
+	lf, err := parseMigrateLogFormat(logFormat)
 	if err != nil {
 		return MigrateOptions{}, err
 	}
-	return MigrateOptions{LogFormat: lf}, nil
+
+	logLevel := migrateLogLevelVerbose
+	if v, ok := commandFlagString(cmd, "log-level"); ok {
+		logLevel = v
+	}
+	ll, err := parseMigrateLogLevel(logLevel)
+	if err != nil {
+		return MigrateOptions{}, err
+	}
+	if v, ok := commandFlagString(cmd, "quiet"); ok {
+		quiet, err := strconv.ParseBool(v)
+		if err != nil {
+			return MigrateOptions{}, err
+		}
+		if quiet {
+			ll = migrateLogLevelTable
+		}
+	}
+
+	return MigrateOptions{LogFormat: lf, LogLevel: ll}, nil
+}
+
+func commandFlagString(cmd *cobra.Command, name string) (string, bool) {
+	if cmd == nil {
+		return "", false
+	}
+	flag := cmd.Flag(name)
+	if flag == nil {
+		return "", false
+	}
+	return flag.Value.String(), true
 }
 
 func parseMigrateLogFormat(s string) (string, error) {
@@ -59,6 +95,19 @@ func parseMigrateLogFormat(s string) (string, error) {
 		return "json", nil
 	default:
 		return "", fmt.Errorf("--log-format must be text or json")
+	}
+}
+
+func parseMigrateLogLevel(s string) (string, error) {
+	v := strings.ToLower(strings.TrimSpace(s))
+	if v == "" {
+		return migrateLogLevelVerbose, nil
+	}
+	switch v {
+	case migrateLogLevelVerbose, migrateLogLevelTable, migrateLogLevelSchema:
+		return v, nil
+	default:
+		return "", fmt.Errorf("--log-level must be verbose, table, or schema")
 	}
 }
 

--- a/migrate_summary_test.go
+++ b/migrate_summary_test.go
@@ -51,18 +51,41 @@ func TestMigrateOptionsFromCmdLogLevelAndQuiet(t *testing.T) {
 		t.Fatalf("LogLevel = %q, want table", opts.LogLevel)
 	}
 
-	if err := cmd.Flags().Set("log-level", "verbose"); err != nil {
-		t.Fatalf("set log-level: %v", err)
-	}
-	if err := cmd.Flags().Set("quiet", "true"); err != nil {
+	quietCmd := &cobra.Command{}
+	quietCmd.Flags().String("log-format", "text", "")
+	quietCmd.Flags().String("log-level", "verbose", "")
+	quietCmd.Flags().BoolP("quiet", "q", false, "")
+	if err := quietCmd.Flags().Set("quiet", "true"); err != nil {
 		t.Fatalf("set quiet: %v", err)
 	}
-	opts, err = migrateOptionsFromCmd(cmd)
+	opts, err = migrateOptionsFromCmd(quietCmd)
 	if err != nil {
 		t.Fatalf("quiet: %v", err)
 	}
 	if opts.LogLevel != migrateLogLevelTable {
 		t.Fatalf("quiet LogLevel = %q, want table", opts.LogLevel)
+	}
+}
+
+func TestMigrateOptionsFromCmdRejectsQuietWithExplicitLogLevel(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("log-format", "text", "")
+	cmd.Flags().String("log-level", "verbose", "")
+	cmd.Flags().BoolP("quiet", "q", false, "")
+
+	if err := cmd.Flags().Set("log-level", "schema"); err != nil {
+		t.Fatalf("set log-level: %v", err)
+	}
+	if err := cmd.Flags().Set("quiet", "true"); err != nil {
+		t.Fatalf("set quiet: %v", err)
+	}
+
+	_, err := migrateOptionsFromCmd(cmd)
+	if err == nil {
+		t.Fatal("expected error for --quiet with explicit --log-level")
+	}
+	if !strings.Contains(err.Error(), "cannot combine --quiet with --log-level") {
+		t.Fatalf("error = %q, want quiet/log-level conflict", err.Error())
 	}
 }
 

--- a/migrate_summary_test.go
+++ b/migrate_summary_test.go
@@ -19,12 +19,77 @@ func TestMigrateOptionsFromCmd(t *testing.T) {
 	if opts.LogFormat != "text" {
 		t.Fatalf("nil cmd: LogFormat = %q, want text", opts.LogFormat)
 	}
+	if opts.LogLevel != migrateLogLevelVerbose {
+		t.Fatalf("nil cmd: LogLevel = %q, want verbose", opts.LogLevel)
+	}
 	opts, err = migrateOptionsFromCmd(&cobra.Command{})
 	if err != nil {
 		t.Fatalf("bare cmd: %v", err)
 	}
 	if opts.LogFormat != "text" {
 		t.Fatalf("bare cmd: LogFormat = %q, want text", opts.LogFormat)
+	}
+	if opts.LogLevel != migrateLogLevelVerbose {
+		t.Fatalf("bare cmd: LogLevel = %q, want verbose", opts.LogLevel)
+	}
+}
+
+func TestMigrateOptionsFromCmdLogLevelAndQuiet(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("log-format", "text", "")
+	cmd.Flags().String("log-level", "verbose", "")
+	cmd.Flags().BoolP("quiet", "q", false, "")
+
+	if err := cmd.Flags().Set("log-level", "table"); err != nil {
+		t.Fatalf("set log-level: %v", err)
+	}
+	opts, err := migrateOptionsFromCmd(cmd)
+	if err != nil {
+		t.Fatalf("log-level table: %v", err)
+	}
+	if opts.LogLevel != migrateLogLevelTable {
+		t.Fatalf("LogLevel = %q, want table", opts.LogLevel)
+	}
+
+	if err := cmd.Flags().Set("log-level", "verbose"); err != nil {
+		t.Fatalf("set log-level: %v", err)
+	}
+	if err := cmd.Flags().Set("quiet", "true"); err != nil {
+		t.Fatalf("set quiet: %v", err)
+	}
+	opts, err = migrateOptionsFromCmd(cmd)
+	if err != nil {
+		t.Fatalf("quiet: %v", err)
+	}
+	if opts.LogLevel != migrateLogLevelTable {
+		t.Fatalf("quiet LogLevel = %q, want table", opts.LogLevel)
+	}
+}
+
+func TestMigrateOptionsFromCmdReadsInheritedFlags(t *testing.T) {
+	parent := &cobra.Command{Use: "pgferry"}
+	child := &cobra.Command{Use: "migrate"}
+	parent.PersistentFlags().String("log-format", "text", "")
+	parent.PersistentFlags().String("log-level", migrateLogLevelVerbose, "")
+	parent.PersistentFlags().BoolP("quiet", "q", false, "")
+	parent.AddCommand(child)
+
+	if err := parent.PersistentFlags().Set("log-format", "json"); err != nil {
+		t.Fatalf("set log-format: %v", err)
+	}
+	if err := parent.PersistentFlags().Set("quiet", "true"); err != nil {
+		t.Fatalf("set quiet: %v", err)
+	}
+
+	opts, err := migrateOptionsFromCmd(child)
+	if err != nil {
+		t.Fatalf("inherited flags: %v", err)
+	}
+	if opts.LogFormat != "json" {
+		t.Fatalf("LogFormat = %q, want json", opts.LogFormat)
+	}
+	if opts.LogLevel != migrateLogLevelTable {
+		t.Fatalf("LogLevel = %q, want table", opts.LogLevel)
 	}
 }
 
@@ -54,6 +119,37 @@ func TestParseMigrateLogFormat(t *testing.T) {
 		}
 		if got != tt.want {
 			t.Fatalf("parseMigrateLogFormat(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParseMigrateLogLevel(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"verbose", migrateLogLevelVerbose, false},
+		{"VERBOSE", migrateLogLevelVerbose, false},
+		{"table", migrateLogLevelTable, false},
+		{"schema", migrateLogLevelSchema, false},
+		{"", migrateLogLevelVerbose, false},
+		{"  table  ", migrateLogLevelTable, false},
+		{"debug", "", true},
+	}
+	for _, tt := range tests {
+		got, err := parseMigrateLogLevel(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("parseMigrateLogLevel(%q) err = nil, want error", tt.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("parseMigrateLogLevel(%q): %v", tt.in, err)
+		}
+		if got != tt.want {
+			t.Fatalf("parseMigrateLogLevel(%q) = %q, want %q", tt.in, got, tt.want)
 		}
 	}
 }

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 	"slices"
 	"strings"
@@ -32,6 +34,44 @@ func TestShouldSampleProgressLogTime(t *testing.T) {
 	}
 }
 
+func TestLogChunkProgressHonorsLogLevel(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() {
+		log.SetOutput(orig)
+	})
+
+	logChunkProgress(migrateLogLevelVerbose, "users", 7, "starting", 0)
+	logChunkProgress(migrateLogLevelTable, "users", 8, "starting", 0)
+	logChunkProgress(migrateLogLevelSchema, "users", 9, "done", 12)
+
+	got := buf.String()
+	if !strings.Contains(got, "[users] chunk 7 starting") {
+		t.Fatalf("verbose chunk log missing from %q", got)
+	}
+	if strings.Contains(got, "chunk 8") || strings.Contains(got, "chunk 9") {
+		t.Fatalf("non-verbose chunk log was emitted: %q", got)
+	}
+}
+
+func TestShouldLogRowCopyProgressOnlyInVerboseMode(t *testing.T) {
+	tests := []struct {
+		logLevel string
+		want     bool
+	}{
+		{"", true},
+		{migrateLogLevelVerbose, true},
+		{migrateLogLevelTable, false},
+		{migrateLogLevelSchema, false},
+	}
+	for _, tt := range tests {
+		if got := shouldLogRowCopyProgress(tt.logLevel); got != tt.want {
+			t.Fatalf("shouldLogRowCopyProgress(%q) = %v, want %v", tt.logLevel, got, tt.want)
+		}
+	}
+}
+
 func TestNewRowSourcePreallocatesBuffers(t *testing.T) {
 	table := Table{
 		SourceName: "users",
@@ -42,7 +82,7 @@ func TestNewRowSourcePreallocatesBuffers(t *testing.T) {
 		},
 	}
 
-	rs := newRowSource(nil, table, &sqliteSourceDB{}, defaultTypeMappingConfig())
+	rs := newRowSource(nil, table, &sqliteSourceDB{}, defaultTypeMappingConfig(), migrateLogLevelVerbose)
 
 	if len(rs.scanDest) != len(table.Columns) {
 		t.Fatalf("scanDest len = %d, want %d", len(rs.scanDest), len(table.Columns))
@@ -359,7 +399,7 @@ func TestBuildChunkPlansWithDeps_UsesBoundedConcurrencyAndPreservesTableOrder(t 
 	)
 	done := make(chan struct{})
 	go func() {
-		plans, err = buildChunkPlansWithDeps(context.Background(), src, schema, 100, defaultTypeMappingConfig(), 2, deps)
+		plans, err = buildChunkPlansWithDeps(context.Background(), src, schema, 100, defaultTypeMappingConfig(), 2, migrateLogLevelVerbose, deps)
 		close(done)
 	}()
 
@@ -418,6 +458,7 @@ func TestBuildChunkPlansWithDeps_CancelsSiblingQueriesAfterFirstError(t *testing
 		100,
 		defaultTypeMappingConfig(),
 		2,
+		migrateLogLevelVerbose,
 		chunkPlanningDeps{
 			openSource: func() (migrationWorkerSource, error) {
 				return &fakeMigrationWorkerSource{id: 1, closeMu: &sync.Mutex{}, closeCounts: map[int]int{}}, nil
@@ -465,6 +506,7 @@ func TestBuildChunkPlansWithDeps_OpenSourceErrorIncludesTableName(t *testing.T) 
 		100,
 		defaultTypeMappingConfig(),
 		1,
+		migrateLogLevelVerbose,
 		chunkPlanningDeps{
 			openSource: func() (migrationWorkerSource, error) {
 				return nil, errors.New("dial tcp timeout")

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -72,6 +72,92 @@ func TestShouldLogRowCopyProgressOnlyInVerboseMode(t *testing.T) {
 	}
 }
 
+func TestShouldLogTableRowCopySuppressesSchemaMode(t *testing.T) {
+	tests := []struct {
+		logLevel string
+		want     bool
+	}{
+		{"", true},
+		{migrateLogLevelVerbose, true},
+		{migrateLogLevelTable, true},
+		{migrateLogLevelSchema, false},
+	}
+	for _, tt := range tests {
+		if got := shouldLogTableRowCopy(tt.logLevel); got != tt.want {
+			t.Fatalf("shouldLogTableRowCopy(%q) = %v, want %v", tt.logLevel, got, tt.want)
+		}
+	}
+}
+
+func TestMigrationProgressLoggerTableLevelLogsOnceAndDoneAfterLastChunk(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() {
+		log.SetOutput(orig)
+	})
+
+	progress := newMigrationProgressLogger(migrateLogLevelTable, []migrationWorkItem{
+		{Table: Table{SourceName: "multi"}, ChunkKey: &ChunkKey{SourceColumn: "id"}, Chunk: Chunk{Index: 0}},
+		{Table: Table{SourceName: "multi"}, ChunkKey: &ChunkKey{SourceColumn: "id"}, Chunk: Chunk{Index: 1}},
+		{Table: Table{SourceName: "single"}, ChunkKey: &ChunkKey{SourceColumn: "id"}, Chunk: Chunk{Index: 0}},
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			progress.StartChunkedTable("multi")
+		}()
+	}
+	wg.Wait()
+	if got := strings.Count(buf.String(), "[multi] starting row copy"); got != 1 {
+		t.Fatalf("multi start log count = %d, want 1; logs: %q", got, buf.String())
+	}
+
+	progress.FinishChunk("multi", 3)
+	if strings.Contains(buf.String(), "[multi] done") {
+		t.Fatalf("multi done logged before last chunk: %q", buf.String())
+	}
+
+	progress.FinishChunk("single", 5)
+	if !strings.Contains(buf.String(), "[single] done (5 rows copied)") {
+		t.Fatalf("single chunk done log missing: %q", buf.String())
+	}
+
+	progress.FinishChunk("multi", 7)
+	if got := strings.Count(buf.String(), "[multi] done (10 rows copied)"); got != 1 {
+		t.Fatalf("multi done log count = %d, want 1; logs: %q", got, buf.String())
+	}
+}
+
+func TestPendingChunksSkipsCompletedChunks(t *testing.T) {
+	mgr := &fakeMigrationCheckpointManager{
+		doneChunks: map[string]map[int]bool{
+			"users": {
+				0: true,
+				1: true,
+			},
+		},
+	}
+	chunks := []Chunk{
+		{Index: 0},
+		{Index: 1},
+		{Index: 2},
+	}
+
+	got := pendingChunks("users", chunks, mgr)
+	if len(got) != 1 || got[0].Index != 2 {
+		t.Fatalf("pendingChunks = %+v, want only chunk 2", got)
+	}
+
+	mgr.doneChunks["users"][2] = true
+	if got := pendingChunks("users", chunks, mgr); len(got) != 0 {
+		t.Fatalf("pendingChunks with all chunks complete = %+v, want none", got)
+	}
+}
+
 func TestNewRowSourcePreallocatesBuffers(t *testing.T) {
 	table := Table{
 		SourceName: "users",

--- a/row_transform_test.go
+++ b/row_transform_test.go
@@ -33,7 +33,7 @@ func TestNewRowSourcePrecomputesTransformers(t *testing.T) {
 		},
 	}
 
-	rs := newRowSource(nil, table, &sqliteSourceDB{}, defaultTypeMappingConfig())
+	rs := newRowSource(nil, table, &sqliteSourceDB{}, defaultTypeMappingConfig(), migrateLogLevelVerbose)
 
 	if len(rs.transformers) != len(table.Columns) {
 		t.Fatalf("transformers len = %d, want %d", len(rs.transformers), len(table.Columns))

--- a/site/src/content/docs/get-started/advanced-options.md
+++ b/site/src/content/docs/get-started/advanced-options.md
@@ -155,7 +155,7 @@ pgferry migrate migration.toml --quiet
 pgferry migrate migration.toml --log-level table
 ```
 
-`--log-level verbose` keeps the default per-chunk progress. `--log-level table` logs one row-copy start/done pair per table. `--log-level schema` suppresses row-copy detail while leaving warnings, errors, and stage-level messages visible.
+`--log-level verbose` keeps the default per-chunk progress. `--log-level table` logs one row-copy start/done pair per table. `--log-level schema` suppresses row-copy detail while leaving warnings, errors, and stage-level messages visible. Do not combine `--quiet` with an explicit `--log-level`; choose one form.
 
 ## Config path inspection
 

--- a/site/src/content/docs/get-started/advanced-options.md
+++ b/site/src/content/docs/get-started/advanced-options.md
@@ -148,6 +148,15 @@ pgferry migrate migration.toml --log-format json | jq '.success'
 
 The JSON fields: `version`, `duration_ms`, `mode`, `validation`, `success`, `error` and `stage` (on failure), `tables_migrated` (omitted when zero).
 
+For large chunked tables, default progress includes each chunk start and finish. Use table-level logging when you want a readable operator stream without external filters:
+
+```bash
+pgferry migrate migration.toml --quiet
+pgferry migrate migration.toml --log-level table
+```
+
+`--log-level verbose` keeps the default per-chunk progress. `--log-level table` logs one row-copy start/done pair per table. `--log-level schema` suppresses row-copy detail while leaving warnings, errors, and stage-level messages visible.
+
 ## Config path inspection
 
 Hooks and checkpoints live relative to your config file, which can get confusing when scripts move things around. `pgferry config paths` shows you exactly where pgferry will look — including whether each hook file actually exists on disk.

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -20,6 +20,16 @@ Shorthand: `pgferry run` is the same as `migrate`, and `generate` / `init` are a
 
 The wizard keeps the default path short, then offers an optional advanced section for `validation`, `resume`, `chunk_size`, and `index_workers`. If you skip that section, the generated TOML stays on the minimal safe/default path.
 
+## CLI logging flags
+
+These are command-line flags, not TOML keys:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--log-format` | `text` | Values: `text`, `json`. `json` writes one machine-readable summary object to stdout when `migrate` finishes. Human progress and errors stay on stderr. |
+| `--log-level` | `verbose` | Values: `verbose`, `table`, `schema`. Controls row-copy progress detail. `verbose` includes per-chunk start/done logs. `table` emits one row-copy start/done pair per table. `schema` suppresses row-copy detail. |
+| `--quiet`, `-q` | `false` | Shorthand for `--log-level table`. |
+
 ## Minimal config
 
 ```toml

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -28,7 +28,7 @@ These are command-line flags, not TOML keys:
 | --- | --- | --- |
 | `--log-format` | `text` | Values: `text`, `json`. `json` writes one machine-readable summary object to stdout when `migrate` finishes. Human progress and errors stay on stderr. |
 | `--log-level` | `verbose` | Values: `verbose`, `table`, `schema`. Controls row-copy progress detail. `verbose` includes per-chunk start/done logs. `table` emits one row-copy start/done pair per table. `schema` suppresses row-copy detail. |
-| `--quiet`, `-q` | `false` | Shorthand for `--log-level table`. |
+| `--quiet`, `-q` | `false` | Shorthand for `--log-level table`. Cannot be combined with an explicit `--log-level`. |
 
 ## Minimal config
 


### PR DESCRIPTION
## Summary

Adds row-copy verbosity controls for `pgferry migrate` so large chunked migrations can suppress per-chunk progress noise without external filters.

- Adds `--log-level=verbose|table|schema` and `--quiet` / `-q`.
- Keeps existing behavior as `verbose` by default.
- Makes `table` emit one row-copy start/done pair per table while suppressing chunk and periodic row progress logs.
- Makes `schema` suppress row-copy detail while preserving warnings, errors, and stage-level messages.
- Documents the new CLI flags in the site docs.

Fixes #225.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go build -o build/pgferry .`
- `npm run build` from `site/`

Note: `npm ci` is currently blocked by the existing `@astrojs/starlight` package/lock mismatch (`package.json` has 0.39.3, lockfile has 0.39.2), so the site build was validated after `npm install --package-lock=false --no-audit --no-fund` without changing tracked package metadata.