### PR TITLE
Detect identifier truncation collisions and add column renames

### DIFF
--- a/column_rename.go
+++ b/column_rename.go
@@ -68,7 +68,7 @@ func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 
 		sourceKey := fmt.Sprintf("%s.%s", normalizeTableFilterKey(renamed.Tables[tableIdx].SourceName), normalizeTableFilterKey(renamed.Tables[tableIdx].Columns[colIdx].SourceName))
 		if prev, ok := seenSourceColumns[sourceKey]; ok {
-			return nil, fmt.Errorf("column_renames entries %q and %q both target source column %s", prev, entry, sourceKey)
+			return nil, fmt.Errorf("column_renames entries %q and %q both map to source column %s", prev, entry, sourceKey)
 		}
 		seenSourceColumns[sourceKey] = entry
 

--- a/column_rename.go
+++ b/column_rename.go
@@ -12,7 +12,7 @@ func hasColumnRenames(cfg *MigrationConfig) bool {
 
 func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 	if schema == nil {
-		return &Schema{}, nil
+		return nil, nil
 	}
 	if !hasColumnRenames(cfg) {
 		return schema, nil
@@ -37,28 +37,32 @@ func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 
 	renamesByTable := make(map[int]map[string]string)
 	seenSourceColumns := make(map[string]string, len(entries))
-	var missing []string
+	var missingTables []string
+	var missingColumns []string
 
 	for _, entry := range entries {
 		targetName := strings.TrimSpace(cfg.ColumnRenames[entry])
 		if targetName == "" {
 			return nil, fmt.Errorf("column_renames entry %q has an empty target column name", entry)
 		}
+		if len(targetName) > postgresMaxIdentifierBytes {
+			return nil, fmt.Errorf("column_renames entry %q: target name %q exceeds PostgreSQL's %d-byte identifier limit", entry, targetName, postgresMaxIdentifierBytes)
+		}
 
-		tableName, columnName, qualified := splitColumnFilterEntry(entry)
-		if !qualified || strings.TrimSpace(tableName) == "" || strings.TrimSpace(columnName) == "" {
+		tableName, columnName, err := splitColumnRenameEntry(entry)
+		if err != nil {
 			return nil, fmt.Errorf("column_renames entry %q must be qualified as TableName.ColumnName", entry)
 		}
 
 		tableIdx, ok := tableIndexes[normalizeTableFilterKey(tableName)]
 		if !ok {
-			missing = append(missing, entry)
+			missingTables = append(missingTables, entry)
 			continue
 		}
 
 		colIdx := findSourceColumnIndex(renamed.Tables[tableIdx], columnName)
 		if colIdx < 0 {
-			missing = append(missing, entry)
+			missingColumns = append(missingColumns, entry)
 			continue
 		}
 
@@ -76,9 +80,13 @@ func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 		renamesByTable[tableIdx][normalizeTableFilterKey(oldPGName)] = targetName
 	}
 
-	if len(missing) > 0 {
-		sort.Strings(missing)
-		return nil, fmt.Errorf("column_renames entries did not match any source column in the migrated schema (table may have been excluded by table filters): %s", strings.Join(missing, ", "))
+	if len(missingTables) > 0 {
+		sort.Strings(missingTables)
+		return nil, fmt.Errorf("column_renames entries did not match any source table in the migrated schema (table may have been excluded by table filters): %s", strings.Join(missingTables, ", "))
+	}
+	if len(missingColumns) > 0 {
+		sort.Strings(missingColumns)
+		return nil, fmt.Errorf("column_renames entries did not match any source column on matched source tables: %s", strings.Join(missingColumns, ", "))
 	}
 
 	for i := range renamed.Tables {
@@ -86,6 +94,20 @@ func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 	}
 
 	return renamed, nil
+}
+
+func splitColumnRenameEntry(entry string) (string, string, error) {
+	entry = strings.TrimSpace(entry)
+	if strings.Count(entry, ".") != 1 {
+		return "", "", fmt.Errorf("invalid column rename entry")
+	}
+	tableName, columnName, _ := strings.Cut(entry, ".")
+	tableName = strings.TrimSpace(tableName)
+	columnName = strings.TrimSpace(columnName)
+	if tableName == "" || columnName == "" {
+		return "", "", fmt.Errorf("invalid column rename entry")
+	}
+	return tableName, columnName, nil
 }
 
 func findSourceColumnIndex(table Table, sourceName string) int {

--- a/column_rename.go
+++ b/column_rename.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func hasColumnRenames(cfg *MigrationConfig) bool {
+	return cfg != nil && len(cfg.ColumnRenames) > 0
+}
+
+func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
+	if schema == nil {
+		return &Schema{}, nil
+	}
+	if !hasColumnRenames(cfg) {
+		return schema, nil
+	}
+
+	renamed := &Schema{Tables: make([]Table, len(schema.Tables))}
+	tableIndexes := make(map[string]int, len(schema.Tables))
+	for i, table := range schema.Tables {
+		renamed.Tables[i] = cloneTable(table)
+		key := normalizeTableFilterKey(table.SourceName)
+		if prev, ok := tableIndexes[key]; ok {
+			return nil, fmt.Errorf("source schema contains ambiguous table names %q and %q; column_renames match source tables case-insensitively", schema.Tables[prev].SourceName, table.SourceName)
+		}
+		tableIndexes[key] = i
+	}
+
+	entries := make([]string, 0, len(cfg.ColumnRenames))
+	for entry := range cfg.ColumnRenames {
+		entries = append(entries, entry)
+	}
+	sort.Strings(entries)
+
+	renamesByTable := make(map[int]map[string]string)
+	seenSourceColumns := make(map[string]string, len(entries))
+	var missing []string
+
+	for _, entry := range entries {
+		targetName := strings.TrimSpace(cfg.ColumnRenames[entry])
+		if targetName == "" {
+			return nil, fmt.Errorf("column_renames entry %q has an empty target column name", entry)
+		}
+
+		tableName, columnName, qualified := splitColumnFilterEntry(entry)
+		if !qualified || strings.TrimSpace(tableName) == "" || strings.TrimSpace(columnName) == "" {
+			return nil, fmt.Errorf("column_renames entry %q must be qualified as TableName.ColumnName", entry)
+		}
+
+		tableIdx, ok := tableIndexes[normalizeTableFilterKey(tableName)]
+		if !ok {
+			missing = append(missing, entry)
+			continue
+		}
+
+		colIdx := findSourceColumnIndex(renamed.Tables[tableIdx], columnName)
+		if colIdx < 0 {
+			missing = append(missing, entry)
+			continue
+		}
+
+		sourceKey := fmt.Sprintf("%s.%s", normalizeTableFilterKey(renamed.Tables[tableIdx].SourceName), normalizeTableFilterKey(renamed.Tables[tableIdx].Columns[colIdx].SourceName))
+		if prev, ok := seenSourceColumns[sourceKey]; ok {
+			return nil, fmt.Errorf("column_renames entries %q and %q both target source column %s", prev, entry, sourceKey)
+		}
+		seenSourceColumns[sourceKey] = entry
+
+		oldPGName := renamed.Tables[tableIdx].Columns[colIdx].PGName
+		renamed.Tables[tableIdx].Columns[colIdx].PGName = targetName
+		if renamesByTable[tableIdx] == nil {
+			renamesByTable[tableIdx] = make(map[string]string)
+		}
+		renamesByTable[tableIdx][normalizeTableFilterKey(oldPGName)] = targetName
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf("column_renames entries did not match any source column in the migrated schema (table may have been excluded by table filters): %s", strings.Join(missing, ", "))
+	}
+
+	for i := range renamed.Tables {
+		remapTableColumnReferences(&renamed.Tables[i], renamesByTable[i], renamesByTable, tableIndexes)
+	}
+
+	return renamed, nil
+}
+
+func findSourceColumnIndex(table Table, sourceName string) int {
+	for i, col := range table.Columns {
+		if strings.EqualFold(col.SourceName, sourceName) {
+			return i
+		}
+	}
+	return -1
+}
+
+func remapTableColumnReferences(table *Table, localRenames map[string]string, renamesByTable map[int]map[string]string, tableIndexes map[string]int) {
+	if table.PrimaryKey != nil {
+		remapColumnNames(table.PrimaryKey.Columns, localRenames)
+	}
+	for i := range table.Indexes {
+		remapColumnNames(table.Indexes[i].Columns, localRenames)
+	}
+	for i := range table.ForeignKeys {
+		remapColumnNames(table.ForeignKeys[i].Columns, localRenames)
+		if refIdx, ok := tableIndexes[normalizeTableFilterKey(table.ForeignKeys[i].RefTable)]; ok {
+			remapColumnNames(table.ForeignKeys[i].RefColumns, renamesByTable[refIdx])
+		}
+	}
+}
+
+func remapColumnNames(columns []string, renames map[string]string) {
+	if len(renames) == 0 {
+		return
+	}
+	for i, col := range columns {
+		if target, ok := renames[normalizeTableFilterKey(col)]; ok {
+			columns[i] = target
+		}
+	}
+}

--- a/column_rename_test.go
+++ b/column_rename_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyColumnRenames_UpdatesColumnsIndexesAndForeignKeys(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Parents",
+				PGName:     "parents",
+				Columns: []Column{
+					{SourceName: "Code", PGName: "code"},
+				},
+				PrimaryKey: &Index{Name: "pk_parents", Columns: []string{"code"}},
+				Indexes: []Index{
+					{Name: "idx_parent_code", Columns: []string{"code"}},
+				},
+			},
+			{
+				SourceName: "Children",
+				PGName:     "children",
+				Columns: []Column{
+					{SourceName: "ParentCode", PGName: "parent_code"},
+				},
+				ForeignKeys: []ForeignKey{
+					{
+						Name:       "fk_children_parents",
+						Columns:    []string{"parent_code"},
+						RefTable:   "Parents",
+						RefPGTable: "parents",
+						RefColumns: []string{"code"},
+					},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnRenames: map[string]string{
+			"Parents.Code":        "parent_code_target",
+			"Children.ParentCode": "child_parent_code_target",
+		},
+	}
+
+	renamed, err := applyColumnRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyColumnRenames() error: %v", err)
+	}
+
+	parent := renamed.Tables[0]
+	if got := parent.Columns[0].PGName; got != "parent_code_target" {
+		t.Fatalf("parent column PGName = %q, want parent_code_target", got)
+	}
+	if got := parent.PrimaryKey.Columns[0]; got != "parent_code_target" {
+		t.Fatalf("parent primary key column = %q, want parent_code_target", got)
+	}
+	if got := parent.Indexes[0].Columns[0]; got != "parent_code_target" {
+		t.Fatalf("parent index column = %q, want parent_code_target", got)
+	}
+
+	child := renamed.Tables[1]
+	if got := child.Columns[0].PGName; got != "child_parent_code_target" {
+		t.Fatalf("child column PGName = %q, want child_parent_code_target", got)
+	}
+	if got := child.ForeignKeys[0].Columns[0]; got != "child_parent_code_target" {
+		t.Fatalf("child foreign key column = %q, want child_parent_code_target", got)
+	}
+	if got := child.ForeignKeys[0].RefColumns[0]; got != "parent_code_target" {
+		t.Fatalf("child foreign key ref column = %q, want parent_code_target", got)
+	}
+	if got := schema.Tables[0].Columns[0].PGName; got != "code" {
+		t.Fatalf("original schema mutated: parent column PGName = %q", got)
+	}
+}
+
+func TestApplyColumnRenames_ResolvesPostgresTruncationCollision(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "KP_SUMINA",
+				PGName:     "KP_SUMINA",
+				Columns: []Column{
+					{SourceName: "% ставка резерва по категории качества", PGName: "% ставка резерва по категории качества"},
+					{SourceName: "% ставка резерва по категории качества КД", PGName: "% ставка резерва по категории качества КД"},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnRenames: map[string]string{
+			"KP_SUMINA.% ставка резерва по категории качества":    "reserve_rate_quality",
+			"KP_SUMINA.% ставка резерва по категории качества КД": "reserve_rate_quality_kd",
+		},
+	}
+
+	renamed, err := applyColumnRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyColumnRenames() error: %v", err)
+	}
+	if err := validateGeneratedIdentifiers(renamed, &MigrationConfig{}, defaultTypeMappingConfig()); err != nil {
+		t.Fatalf("validateGeneratedIdentifiers() error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_RejectsUnknownColumn(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnRenames: map[string]string{
+			"Orders.Missing": "missing_target",
+		},
+	}
+
+	_, err := applyColumnRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "column_renames entries did not match any source column") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_RejectsUnqualifiedEntry(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnRenames: map[string]string{
+			"ID": "id_target",
+		},
+	}
+
+	_, err := applyColumnRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `column_renames entry "ID" must be qualified as TableName.ColumnName`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/column_rename_test.go
+++ b/column_rename_test.go
@@ -73,6 +73,12 @@ func TestApplyColumnRenames_UpdatesColumnsIndexesAndForeignKeys(t *testing.T) {
 	if got := schema.Tables[0].Columns[0].PGName; got != "code" {
 		t.Fatalf("original schema mutated: parent column PGName = %q", got)
 	}
+	if got := schema.Tables[1].ForeignKeys[0].Columns[0]; got != "parent_code" {
+		t.Fatalf("original schema mutated: child foreign key column = %q", got)
+	}
+	if got := schema.Tables[1].ForeignKeys[0].RefColumns[0]; got != "code" {
+		t.Fatalf("original schema mutated: child foreign key ref column = %q", got)
+	}
 }
 
 func TestApplyColumnRenames_ResolvesPostgresTruncationCollision(t *testing.T) {
@@ -275,7 +281,7 @@ func TestApplyColumnRenames_RejectsDuplicateSourceColumnMapping(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), `both target source column orders.id`) {
+	if !strings.Contains(err.Error(), `both map to source column orders.id`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/column_rename_test.go
+++ b/column_rename_test.go
@@ -124,7 +124,32 @@ func TestApplyColumnRenames_RejectsUnknownColumn(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "column_renames entries did not match any source column") {
+	if !strings.Contains(err.Error(), "column_renames entries did not match any source column on matched source tables: Orders.Missing") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_RejectsUnknownTable(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnRenames: map[string]string{
+			"Customers.ID": "customer_id",
+		},
+	}
+
+	_, err := applyColumnRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "column_renames entries did not match any source table in the migrated schema") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -151,5 +176,173 @@ func TestApplyColumnRenames_RejectsUnqualifiedEntry(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `column_renames entry "ID" must be qualified as TableName.ColumnName`) {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_RejectsSchemaQualifiedEntry(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnRenames: map[string]string{
+			"dbo.Orders.ID": "id_target",
+		},
+	}
+
+	_, err := applyColumnRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `column_renames entry "dbo.Orders.ID" must be qualified as TableName.ColumnName`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_RejectsEmptyTargetName(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnRenames: map[string]string{
+			"Orders.ID": "   ",
+		},
+	}
+
+	_, err := applyColumnRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `column_renames entry "Orders.ID" has an empty target column name`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_RejectsTargetNameOverPostgresLimit(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnRenames: map[string]string{
+			"Orders.ID": strings.Repeat("x", postgresMaxIdentifierBytes+1),
+		},
+	}
+
+	_, err := applyColumnRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "exceeds PostgreSQL's 63-byte identifier limit") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_RejectsDuplicateSourceColumnMapping(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnRenames: map[string]string{
+			"Orders.ID": "id_target",
+			"orders.id": "id_target_again",
+		},
+	}
+
+	_, err := applyColumnRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `both target source column orders.id`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_MatchesSourceNamesCaseInsensitively(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnRenames: map[string]string{
+			"orders.id": "order_id",
+		},
+	}
+
+	renamed, err := applyColumnRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyColumnRenames() error: %v", err)
+	}
+	if got := renamed.Tables[0].Columns[0].PGName; got != "order_id" {
+		t.Fatalf("column PGName = %q, want order_id", got)
+	}
+}
+
+func TestApplyColumnRenames_RejectsAmbiguousTableNames(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Orders",
+				PGName:     "orders",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+			{
+				SourceName: "orders",
+				PGName:     "orders_lower",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnRenames: map[string]string{
+			"Orders.ID": "order_id",
+		},
+	}
+
+	_, err := applyColumnRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "source schema contains ambiguous table names") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_NilSchemaReturnsNil(t *testing.T) {
+	renamed, err := applyColumnRenames(nil, &MigrationConfig{
+		ColumnRenames: map[string]string{"Orders.ID": "order_id"},
+	})
+	if err != nil {
+		t.Fatalf("applyColumnRenames() error: %v", err)
+	}
+	if renamed != nil {
+		t.Fatalf("renamed schema = %#v, want nil", renamed)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -29,6 +29,7 @@ type MigrationConfig struct {
 	IncludeTables                     []string          `toml:"include_tables"`
 	ExcludeTables                     []string          `toml:"exclude_tables"`
 	ExcludeColumns                    []string          `toml:"exclude_columns"`
+	ColumnRenames                     map[string]string `toml:"column_renames"`
 	OnSchemaExists                    string            `toml:"on_schema_exists"`
 	SchemaOnly                        bool              `toml:"schema_only"`
 	DataOnly                          bool              `toml:"data_only"`

--- a/config_test.go
+++ b/config_test.go
@@ -36,6 +36,9 @@ before_data = ["pre.sql"]
 after_data = []
 before_fk = ["cleanup.sql"]
 after_all = ["post.sql"]
+
+[column_renames]
+"Orders.RowVersion" = "row_version_target"
 `
 	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
 		t.Fatal(err)
@@ -84,6 +87,9 @@ after_all = ["post.sql"]
 	}
 	if len(cfg.Hooks.BeforeFk) != 1 || cfg.Hooks.BeforeFk[0] != "cleanup.sql" {
 		t.Errorf("Hooks.BeforeFk = %v", cfg.Hooks.BeforeFk)
+	}
+	if cfg.ColumnRenames["Orders.RowVersion"] != "row_version_target" {
+		t.Errorf("ColumnRenames = %v", cfg.ColumnRenames)
 	}
 	if cfg.configDir != dir {
 		t.Errorf("configDir = %q, want %q", cfg.configDir, dir)

--- a/identifier_validation.go
+++ b/identifier_validation.go
@@ -349,7 +349,7 @@ func validateGeneratedIdentifiers(schema *Schema, cfg *MigrationConfig, typeMap 
 		b.WriteString(strings.Join(collision.origins, "; "))
 		b.WriteByte('\n')
 	}
-	b.WriteString("Hint: rename the conflicting source objects, set identifier_case = \"preserve\" to keep original casing (PostgreSQL will quote them), fall back to identifier_case = \"lower\" if normalization caused the collision, or migrate the conflicting objects manually with hooks.")
+	b.WriteString("Hint: use [column_renames] to choose explicit target names for conflicting source columns, rename the conflicting source objects, set identifier_case = \"preserve\" to keep original casing (PostgreSQL will quote them), fall back to identifier_case = \"lower\" if normalization caused the collision, or migrate the conflicting objects manually with hooks.")
 
 	return errors.New(b.String())
 }

--- a/identifier_validation.go
+++ b/identifier_validation.go
@@ -50,6 +50,7 @@ func (c *identifierCollector) add(scopeKey, label, name, origin, key, class stri
 	} else if ns.label != label || ns.options != opts {
 		panic(fmt.Sprintf("identifier namespace %q registered with inconsistent metadata", scopeKey))
 	}
+	name = postgresIdentifierKey(name)
 	ns.entries[name] = append(ns.entries[name], identifierEntry{
 		origin: origin,
 		key:    key,

--- a/identifier_validation_test.go
+++ b/identifier_validation_test.go
@@ -69,6 +69,9 @@ func TestValidateGeneratedIdentifiers_ColumnCollisionAfterPostgresTruncation(t *
 	if !strings.Contains(err.Error(), `column names on table "KP_SUMINA": final name "% ставка резерва по категории каче"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if !strings.Contains(err.Error(), "[column_renames]") {
+		t.Fatalf("error should mention column_renames remediation: %v", err)
+	}
 }
 
 func TestValidateGeneratedIdentifiers_AllowsSameColumnNameAcrossTables(t *testing.T) {

--- a/identifier_validation_test.go
+++ b/identifier_validation_test.go
@@ -48,6 +48,29 @@ func TestValidateGeneratedIdentifiers_ColumnCollisionWithinTable(t *testing.T) {
 	}
 }
 
+func TestValidateGeneratedIdentifiers_ColumnCollisionAfterPostgresTruncation(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "KP_SUMINA",
+				PGName:     "KP_SUMINA",
+				Columns: []Column{
+					{SourceName: "% ставка резерва по категории качества", PGName: "% ставка резерва по категории качества"},
+					{SourceName: "% ставка резерва по категории качества КД", PGName: "% ставка резерва по категории качества КД"},
+				},
+			},
+		},
+	}
+
+	err := validateGeneratedIdentifiers(schema, &MigrationConfig{}, defaultTypeMappingConfig())
+	if err == nil {
+		t.Fatal("expected collision error")
+	}
+	if !strings.Contains(err.Error(), `column names on table "KP_SUMINA": final name "% ставка резерва по категории каче"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestValidateGeneratedIdentifiers_AllowsSameColumnNameAcrossTables(t *testing.T) {
 	schema := &Schema{
 		Tables: []Table{

--- a/main.go
+++ b/main.go
@@ -289,6 +289,9 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 		return fmt.Errorf("apply column renames: %w", err)
 	}
 	schema = renamedSchema
+	if hasColumnRenames(cfg) && cfg.Resume {
+		log.Printf("column renames: resume enabled; changing column_renames between runs can invalidate the checkpoint")
+	}
 	log.Printf("found %d tables", len(schema.Tables))
 	for _, t := range schema.Tables {
 		log.Printf("  %s → %s (%d cols, %d indexes, %d fks)",

--- a/main.go
+++ b/main.go
@@ -284,6 +284,11 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 			log.Printf("column filter: resume enabled; changing column_filter_mode/exclude_columns between runs can invalidate the checkpoint")
 		}
 	}
+	renamedSchema, err := applyColumnRenames(schema, cfg)
+	if err != nil {
+		return fmt.Errorf("apply column renames: %w", err)
+	}
+	schema = renamedSchema
 	log.Printf("found %d tables", len(schema.Tables))
 	for _, t := range schema.Tables {
 		log.Printf("  %s → %s (%d cols, %d indexes, %d fks)",

--- a/plan.go
+++ b/plan.go
@@ -506,6 +506,11 @@ func runPlanWithConfig(cfg *MigrationConfig, out io.Writer, opts PlanOptions) er
 	if hasColumnFilters(cfg) {
 		logColumnFilterReport(columnFilterReport)
 	}
+	renamedSchema, err := applyColumnRenames(schema, cfg)
+	if err != nil {
+		return fmt.Errorf("apply column renames: %w", err)
+	}
+	schema = renamedSchema
 
 	sourceObjects, err := src.IntrospectSourceObjects(sourceDB, dbName)
 	if err != nil {

--- a/plan.go
+++ b/plan.go
@@ -512,6 +512,11 @@ func runPlanWithConfig(cfg *MigrationConfig, out io.Writer, opts PlanOptions) er
 	}
 	schema = renamedSchema
 
+	typeMap := effectiveTypeMapping(cfg)
+	if err := validateGeneratedIdentifiers(schema, cfg, typeMap); err != nil {
+		return err
+	}
+
 	sourceObjects, err := src.IntrospectSourceObjects(sourceDB, dbName)
 	if err != nil {
 		return fmt.Errorf("introspect source objects: %w", err)
@@ -520,7 +525,6 @@ func runPlanWithConfig(cfg *MigrationConfig, out io.Writer, opts PlanOptions) er
 		sourceObjects.Triggers = filterTriggersBySelectedTables(sourceObjects.Triggers, schema)
 	}
 
-	typeMap := effectiveTypeMapping(cfg)
 	semanticWarnings, err := introspectSourceSchemaSemanticWarnings(sourceDB, src, dbName)
 	if err != nil {
 		return fmt.Errorf("introspect schema semantics: %w", err)

--- a/schema.go
+++ b/schema.go
@@ -3,7 +3,10 @@ package main
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
+
+const postgresMaxIdentifierBytes = 63
 
 // toSnakeCase converts camelCase/PascalCase to snake_case.
 // Consecutive uppercase runs are treated as acronyms:
@@ -35,4 +38,23 @@ func toSnakeCase(s string) string {
 // relying on a manually maintained keyword list and keeps generated SQL stable.
 func pgIdent(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+func postgresIdentifierKey(name string) string {
+	if len(name) <= postgresMaxIdentifierBytes {
+		return name
+	}
+
+	end := 0
+	for i, r := range name {
+		width := utf8.RuneLen(r)
+		if r == utf8.RuneError {
+			_, width = utf8.DecodeRuneInString(name[i:])
+		}
+		if i+width > postgresMaxIdentifierBytes {
+			break
+		}
+		end = i + width
+	}
+	return name[:end]
 }

--- a/site/src/content/docs/get-started/advanced-options.md
+++ b/site/src/content/docs/get-started/advanced-options.md
@@ -108,7 +108,7 @@ To keep a source column but choose its target PostgreSQL name explicitly, use `c
 "KP_SUMINA.% ставка резерва по категории качества КД" = "reserve_rate_quality_kd"
 ```
 
-Rename keys use source `TableName.ColumnName` values after table and column filters. Rename values are final PostgreSQL column names, so pgferry does not apply `identifier_case` to them. This is useful when two long source column names would otherwise collide after PostgreSQL's 63-byte identifier limit.
+Rename keys use source `TableName.ColumnName` values after table and column filters. Rename values are final PostgreSQL column names, so pgferry does not apply `identifier_case` to them, and they must fit PostgreSQL's 63-byte identifier limit. This is useful when two long source column names would otherwise collide after PostgreSQL's identifier limit.
 
 - [How to read plan output](/operations/how-to-read-plan-output/)
 

--- a/site/src/content/docs/get-started/advanced-options.md
+++ b/site/src/content/docs/get-started/advanced-options.md
@@ -100,6 +100,16 @@ exclude_columns = ["RowVersion", "audit_*.sys_*"]
 
 When a column is excluded, pgferry omits it from schema creation and data COPY. Primary keys, plain-column indexes, and foreign keys that reference excluded columns are skipped. pgferry cannot inspect arbitrary expression index definitions for excluded column references; expression indexes are already reported as unsupported and skipped separately.
 
+To keep a source column but choose its target PostgreSQL name explicitly, use `column_renames`:
+
+```toml
+[column_renames]
+"KP_SUMINA.% ставка резерва по категории качества" = "reserve_rate_quality"
+"KP_SUMINA.% ставка резерва по категории качества КД" = "reserve_rate_quality_kd"
+```
+
+Rename keys use source `TableName.ColumnName` values after table and column filters. Rename values are final PostgreSQL column names, so pgferry does not apply `identifier_case` to them. This is useful when two long source column names would otherwise collide after PostgreSQL's 63-byte identifier limit.
+
 - [How to read plan output](/operations/how-to-read-plan-output/)
 
 ## Hooks

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -115,6 +115,7 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | `include_tables` | array of strings | `[]` | If non-empty, only migrate these source tables. Entries are exact names by default, or glob patterns when `table_filter_mode = "glob"`. |
 | `exclude_tables` | array of strings | `[]` | Source tables to skip. Applied after `include_tables`, so excludes win when both match the same table. |
 | `exclude_columns` | array of strings | `[]` | Source columns to skip. Use `ColumnName` to skip matching columns in any table, or `TableName.ColumnName` to scope a rule to one source table. Entries are exact by default, or glob patterns in either the table or column part when `column_filter_mode = "glob"`. |
+| `[column_renames]` | table of strings | `{}` | Explicit target column names keyed by source `TableName.ColumnName`. Values are final PostgreSQL column names and are applied after table and column filters. |
 | `on_schema_exists` | string | `"error"` | `"error"` aborts if the schema exists. `"recreate"` drops and recreates it. `"use"` requires the schema to already exist and be empty, then pgferry creates objects inside it. |
 | `schema_only` | bool | `false` | Create schema objects only. Skip data COPY. |
 | `data_only` | bool | `false` | Load data into an existing schema, then advance existing sequences with `setval`. Requires the target role to disable and re-enable triggers on the selected target tables during the load. |
@@ -139,7 +140,15 @@ Table filters always match source table names, not the transformed PostgreSQL na
 
 Column filters also match source names, not transformed PostgreSQL names. When a column is excluded, pgferry omits it from `CREATE TABLE`, source `SELECT`, and target `COPY`. Primary keys, plain-column indexes, and foreign keys that reference excluded columns are skipped. pgferry cannot inspect arbitrary expression index definitions for excluded column references; expression indexes are already reported as unsupported and skipped separately. If a filter entry matches no source column in the migrated schema, pgferry fails early.
 
-Changing `table_filter_mode`, `include_tables`, `exclude_tables`, `column_filter_mode`, or `exclude_columns` can change the selected migration scope. When `resume = true`, that can invalidate the checkpoint fingerprint and force a fresh run.
+Column renames override the target PostgreSQL name for a source column without changing source reads. Keys must be source-qualified as `TableName.ColumnName`, matched case-insensitively after table and column filters. Values are not passed through `identifier_case`; they are used as the final quoted PostgreSQL names. Primary keys, plain-column indexes, and foreign keys are updated to reference the renamed target columns.
+
+```toml
+[column_renames]
+"KP_SUMINA.% ставка резерва по категории качества" = "reserve_rate_quality"
+"KP_SUMINA.% ставка резерва по категории качества КД" = "reserve_rate_quality_kd"
+```
+
+Changing `table_filter_mode`, `include_tables`, `exclude_tables`, `column_filter_mode`, `exclude_columns`, or `column_renames` can change the selected migration scope or target schema. When `resume = true`, that can invalidate the checkpoint fingerprint and force a fresh run.
 
 `truncate_before_copy` follows the selected table scope after filters. Excluded tables are not named in pgferry's generated `TRUNCATE TABLE ... CASCADE` statement, though PostgreSQL can still truncate dependent tables through `CASCADE`.
 

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -140,7 +140,7 @@ Table filters always match source table names, not the transformed PostgreSQL na
 
 Column filters also match source names, not transformed PostgreSQL names. When a column is excluded, pgferry omits it from `CREATE TABLE`, source `SELECT`, and target `COPY`. Primary keys, plain-column indexes, and foreign keys that reference excluded columns are skipped. pgferry cannot inspect arbitrary expression index definitions for excluded column references; expression indexes are already reported as unsupported and skipped separately. If a filter entry matches no source column in the migrated schema, pgferry fails early.
 
-Column renames override the target PostgreSQL name for a source column without changing source reads. Keys must be source-qualified as `TableName.ColumnName`, matched case-insensitively after table and column filters. Values are not passed through `identifier_case`; they are used as the final quoted PostgreSQL names. Primary keys, plain-column indexes, and foreign keys are updated to reference the renamed target columns.
+Column renames override the target PostgreSQL name for a source column without changing source reads. Keys must be source-qualified as `TableName.ColumnName`, matched case-insensitively after table and column filters; schema-qualified keys such as `dbo.Table.Column` are not supported. Values are not passed through `identifier_case`; they are used as the final quoted PostgreSQL names and must fit PostgreSQL's 63-byte identifier limit. Primary keys, plain-column indexes, and foreign keys are updated to reference the renamed target columns.
 
 ```toml
 [column_renames]

--- a/site/src/content/docs/reference/conventions-and-limitations.md
+++ b/site/src/content/docs/reference/conventions-and-limitations.md
@@ -26,6 +26,8 @@ Examples:
 
 PostgreSQL SQL is emitted as `"app"."users"` rather than `app.users` under all three modes.
 
+PostgreSQL compares only the first 63 bytes of an identifier. pgferry checks generated names using that effective PostgreSQL limit and reports collisions before running target DDL. If two source column names still collide after the selected `identifier_case` mode, use `[column_renames]` to choose explicit target names for those source columns.
+
 ## Auto-increment and sequences
 
 MySQL and MariaDB `auto_increment`, SQLite integer primary key auto-increment behavior, and MSSQL `IDENTITY` columns are recreated as PostgreSQL sequences after data load.

--- a/validate_cmd.go
+++ b/validate_cmd.go
@@ -140,7 +140,11 @@ func loadValidateSchema(ctx context.Context, src SourceDB, pgPool *pgxpool.Pool,
 	if hasColumnFilters(cfg) {
 		logColumnFilterReport(columnFilterReport)
 	}
-	return filteredSchema, nil
+	renamedSchema, err := applyColumnRenames(filteredSchema, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("apply column renames: %w", err)
+	}
+	return renamedSchema, nil
 }
 
 func logStandaloneValidationPlan(mode string) {

--- a/validate_cmd.go
+++ b/validate_cmd.go
@@ -79,6 +79,9 @@ func runValidateWithConfig(cfg *MigrationConfig) error {
 	}
 
 	typeMap := effectiveTypeMapping(cfg)
+	if err := validateGeneratedIdentifiers(schema, cfg, typeMap); err != nil {
+		return err
+	}
 	logStandaloneValidationPlan(mode)
 	log.Printf("running standalone validation (mode=%s)...", mode)
 	if _, err := validateMigration(ctx, src, cfg.Source.DSN, pgPool, schema, cfg.Schema, mode, cfg.Workers, typeMap); err != nil {


### PR DESCRIPTION
## Summary

- detect PostgreSQL 63-byte effective identifier collisions before running target DDL
- add `[column_renames]` target column rename mappings keyed by source `TableName.ColumnName`
- apply rename mappings across migrate, plan, standalone validate, indexes, FKs, checkpoints, and docs

## Root cause

PostgreSQL compares identifiers using a 63-byte effective name. pgferry previously validated generated identifiers by the full Go string, so distinct source column names could pass validation and later collide inside `CREATE TABLE` after PostgreSQL truncated them.

## User impact

Users can now get an early, actionable collision error. If two source column names would collide at PostgreSQL identifier length, they can keep both source columns and choose explicit target names with `[column_renames]`.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go build -o build/pgferry .`
- `cd site && bun run build && bun run check-routes`
