### PR TITLE
Avoid cascading truncate before copy

### DIFF
--- a/site/src/content/docs/migration-patterns/schema-only-and-data-only.md
+++ b/site/src/content/docs/migration-patterns/schema-only-and-data-only.md
@@ -17,7 +17,7 @@ Use this when the target schema already exists and you only need to stream data 
 
 If that preflight fails, pgferry aborts before COPY starts so operators are not left guessing whether any data moved or whether trigger state changed permanently.
 
-If your own schema migrator creates the target tables and inserts seed/reference data, use `truncate_before_copy = true` in the data-only config when those rows should be replaced by the source data. pgferry runs `TRUNCATE TABLE ... CASCADE` on the selected target tables after `before_data` hooks and before COPY.
+If your own schema migrator creates the target tables and inserts seed/reference data, use `truncate_before_copy = true` in the data-only config when those rows should be replaced by the source data. pgferry runs `TRUNCATE TABLE ...` on the selected target tables after `before_data` hooks and before COPY. It does not add `CASCADE`, so PostgreSQL will fail rather than silently truncating dependent tables outside the selected scope.
 
 After COPY, pgferry uses `setval` for auto-increment columns. It does not create sequences or change column defaults in `data_only`; keep that DDL in the external schema migrator or the earlier `schema_only` run.
 

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -118,7 +118,7 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | `on_schema_exists` | string | `"error"` | `"error"` aborts if the schema exists. `"recreate"` drops and recreates it. `"use"` requires the schema to already exist and be empty, then pgferry creates objects inside it. |
 | `schema_only` | bool | `false` | Create schema objects only. Skip data COPY. |
 | `data_only` | bool | `false` | Load data into an existing schema, then advance existing sequences with `setval`. Requires the target role to disable and re-enable triggers on the selected target tables during the load. |
-| `truncate_before_copy` | bool | `false` | Run `TRUNCATE TABLE ... CASCADE` on the selected target tables after `before_data` hooks and before COPY. Useful with `data_only` when an external schema migrator pre-seeds reference rows that should be replaced by source data. In full migrations, target tables are normally freshly created, so this is usually a no-op. |
+| `truncate_before_copy` | bool | `false` | Run `TRUNCATE TABLE ...` on the selected target tables after `before_data` hooks and before COPY. Useful with `data_only` when an external schema migrator pre-seeds reference rows that should be replaced by source data. pgferry does not add `CASCADE`, so PostgreSQL rejects the truncate if non-selected tables still reference the selected tables. In full migrations, target tables are normally freshly created, so this is usually a no-op. |
 | `source_snapshot_mode` | string | `"none"` | `"none"` is fastest. `"single_tx"` gives one consistent source snapshot on MySQL, MariaDB, and MSSQL. |
 | `identifier_case` | string | `"snake"` | How source identifiers map to PostgreSQL names. `"snake"` converts `OrderItems` → `order_items`. `"lower"` lowercases only (`OrderItems` → `orderitems`). `"preserve"` keeps the source casing unchanged (`OrderItems` → `OrderItems`); PostgreSQL DDL is always quoted so mixed-case names are safe. |
 | `unlogged_tables` | bool | `true` | Use `UNLOGGED` tables during full loads, then `SET LOGGED` later. |
@@ -141,7 +141,7 @@ Column filters also match source names, not transformed PostgreSQL names. When a
 
 Changing `table_filter_mode`, `include_tables`, `exclude_tables`, `column_filter_mode`, or `exclude_columns` can change the selected migration scope. When `resume = true`, that can invalidate the checkpoint fingerprint and force a fresh run.
 
-`truncate_before_copy` follows the selected table scope after filters. Excluded tables are not named in pgferry's generated `TRUNCATE TABLE ... CASCADE` statement, though PostgreSQL can still truncate dependent tables through `CASCADE`.
+`truncate_before_copy` follows the selected table scope after filters. Excluded tables are not named in pgferry's generated `TRUNCATE TABLE ...` statement. pgferry intentionally omits `CASCADE` so PostgreSQL will fail rather than silently truncating dependent tables outside the selected scope.
 
 ### `[source]`
 

--- a/site/src/content/docs/reference/migration-pipeline.md
+++ b/site/src/content/docs/reference/migration-pipeline.md
@@ -76,7 +76,7 @@ Operational note: before COPY starts, pgferry verifies that the target role can 
 
 This matters because `data_only` loads into a schema where foreign keys and other triggers may already exist. pgferry temporarily disables those triggers during the load so parallel COPY can proceed without immediate FK enforcement.
 
-When an external schema migrator also inserts seed or reference rows, set `truncate_before_copy = true` in the data-only config. pgferry will run one `TRUNCATE TABLE ... CASCADE` statement for the selected target tables after `before_data` hooks and before COPY, so duplicate source rows do not collide with pre-seeded target rows.
+When an external schema migrator also inserts seed or reference rows, set `truncate_before_copy = true` in the data-only config. pgferry will run one `TRUNCATE TABLE ...` statement for the selected target tables after `before_data` hooks and before COPY, so duplicate source rows do not collide with pre-seeded target rows. pgferry does not add `CASCADE`; if non-selected tables still reference the selected tables, PostgreSQL will reject the truncate instead of deleting out-of-scope rows.
 
 After COPY, pgferry advances existing auto-increment sequences with `setval`. It does not create sequences or change column defaults in `data_only`; the pre-existing schema is expected to own that DDL.
 

--- a/truncate.go
+++ b/truncate.go
@@ -17,7 +17,7 @@ func truncateTargetTablesBeforeCopy(ctx context.Context, exec statementExecutor,
 		targets[i] = fmt.Sprintf("%s.%s", pgIdent(pgSchema), pgIdent(t.PGName))
 	}
 
-	q := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", strings.Join(targets, ", "))
-	log.Printf("truncating target tables before COPY (CASCADE may affect dependent tables outside migration scope): %s", strings.Join(targets, ", "))
+	q := fmt.Sprintf("TRUNCATE TABLE %s", strings.Join(targets, ", "))
+	log.Printf("truncating target tables before COPY without CASCADE: %s", strings.Join(targets, ", "))
 	return execSQL(ctx, exec, "truncate target tables before copy", q)
 }

--- a/truncate_test.go
+++ b/truncate_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestTruncateTargetTablesBeforeCopy_GeneratesSingleCascadeStatement(t *testing.T) {
+func TestTruncateTargetTablesBeforeCopy_GeneratesSingleNonCascadeStatement(t *testing.T) {
 	exec := &recordingStatementExecutor{}
 	schema := &Schema{Tables: []Table{
 		{PGName: "users"},
@@ -20,13 +20,13 @@ func TestTruncateTargetTablesBeforeCopy_GeneratesSingleCascadeStatement(t *testi
 		t.Fatalf("truncateTargetTablesBeforeCopy() error: %v", err)
 	}
 
-	want := `TRUNCATE TABLE "app"."users", "app"."order""items" CASCADE`
+	want := `TRUNCATE TABLE "app"."users", "app"."order""items"`
 	if len(exec.calls) != 1 || exec.calls[0] != want {
 		t.Fatalf("exec calls = %v, want [%q]", exec.calls, want)
 	}
 }
 
-func TestTruncateTargetTablesBeforeCopy_LogsCascadeScope(t *testing.T) {
+func TestTruncateTargetTablesBeforeCopy_LogsNonCascadeScope(t *testing.T) {
 	var buf bytes.Buffer
 	prev := log.Writer()
 	log.SetOutput(&buf)
@@ -42,7 +42,7 @@ func TestTruncateTargetTablesBeforeCopy_LogsCascadeScope(t *testing.T) {
 		t.Fatalf("truncateTargetTablesBeforeCopy() error: %v", err)
 	}
 
-	want := `truncating target tables before COPY (CASCADE may affect dependent tables outside migration scope): "app"."orders", "app"."order_items"`
+	want := `truncating target tables before COPY without CASCADE: "app"."orders", "app"."order_items"`
 	if !strings.Contains(buf.String(), want) {
 		t.Fatalf("log output = %q, want %q", buf.String(), want)
 	}
@@ -60,7 +60,7 @@ func TestTruncateTargetTablesBeforeCopy_SkipsEmptySchema(t *testing.T) {
 }
 
 func TestTruncateTargetTablesBeforeCopy_WrapsExecError(t *testing.T) {
-	truncateSQL := `TRUNCATE TABLE "app"."users" CASCADE`
+	truncateSQL := `TRUNCATE TABLE "app"."users"`
 	execErr := errors.New("permission denied")
 	exec := &recordingStatementExecutor{
 		errByQuery: map[string]error{truncateSQL: execErr},


### PR DESCRIPTION
## Summary

- Stop generating `TRUNCATE TABLE ... CASCADE` for `truncate_before_copy`.
- Keep truncation scoped to the selected target tables so PostgreSQL fails on out-of-scope FK dependencies instead of silently deleting already-migrated data.
- Update truncate tests and documentation to describe the non-CASCADE behavior.

## Root Cause

`TRUNCATE ... CASCADE` follows PostgreSQL FK dependencies through `pg_constraint`, including across schema boundaries. In data-only multi-schema runs, a later schema truncate could cascade into tables already loaded by an earlier schema, and pgferry would not revisit those tables.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `cd site && bun run build && bun run check-routes`

Closes #232