### PR TITLE
Require explicit migrate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ pgferry migrate migration.toml
 
 Non-empty `PGFERRY_SOURCE_DSN` and `PGFERRY_TARGET_DSN` override `source.dsn` and `target.dsn`.
 
-`pgferry migration.toml` remains supported as a shorthand for `pgferry migrate migration.toml`.
-
 ## Examples
 
 Use the docs site for copy-pasteable example configs and walkthroughs:

--- a/main.go
+++ b/main.go
@@ -30,9 +30,9 @@ const migrateLogFormatFlagDesc = `With json, one JSON object is written to stdou
 const migrateLogLevelFlagDesc = `Use --log-level=table, or --quiet, to suppress per-chunk row-copy progress and keep one row-copy start/done pair per table. Use --log-level=schema to suppress row-copy progress detail.`
 
 var rootCmd = &cobra.Command{
-	Use:   "pgferry [migration.toml]",
+	Use:   "pgferry",
 	Short: "Source database to PostgreSQL migration tool",
-	Args:  cobra.MaximumNArgs(1),
+	Args:  cobra.NoArgs,
 	RunE:  runRoot,
 }
 
@@ -69,7 +69,6 @@ var generateCmd = &cobra.Command{
 	RunE:    runGenerateWizard,
 }
 
-var rootMigrationRunner = runMigration
 var rootWizardRunner = runGenerateWizard
 var rootWizardModeChecker = canLaunchWizardInteractively
 
@@ -102,8 +101,8 @@ func main() {
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
-	if resolveMigrationConfigPath(args) != "" {
-		return rootMigrationRunner(cmd, args)
+	if len(args) > 0 || strings.TrimSpace(configPath) != "" {
+		return missingMigrationConfigError()
 	}
 	if rootWizardModeChecker(cmd) {
 		return rootWizardRunner(cmd, args)
@@ -132,16 +131,8 @@ func runMigration(cmd *cobra.Command, args []string) error {
 	return runMigrationWithConfig(cfg, opts)
 }
 
-func resolveMigrationConfigPath(args []string) string {
-	cfgPath, err := resolveOptionalConfigPath(configPath, args)
-	if err != nil {
-		return ""
-	}
-	return cfgPath
-}
-
 func missingMigrationConfigError() error {
-	return fmt.Errorf("config file required: pgferry <migration.toml>, pgferry migrate <migration.toml>, or pgferry wizard")
+	return fmt.Errorf("config file required: pgferry migrate <migration.toml> or pgferry wizard")
 }
 
 func canLaunchWizardInteractively(cmd *cobra.Command) bool {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ const migrateLogLevelFlagDesc = `Use --log-level=table, or --quiet, to suppress 
 var rootCmd = &cobra.Command{
 	Use:   "pgferry",
 	Short: "Source database to PostgreSQL migration tool",
-	Args:  cobra.NoArgs,
+	Args:  rootNoArgs,
 	RunE:  runRoot,
 }
 
@@ -101,13 +101,20 @@ func main() {
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
-	if len(args) > 0 || strings.TrimSpace(configPath) != "" {
+	if strings.TrimSpace(configPath) != "" {
 		return missingMigrationConfigError()
 	}
 	if rootWizardModeChecker(cmd) {
 		return rootWizardRunner(cmd, args)
 	}
 	return missingMigrationConfigError()
+}
+
+func rootNoArgs(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return missingMigrationConfigError()
+	}
+	return nil
 }
 
 func runMigration(cmd *cobra.Command, args []string) error {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ const migrateLogLevelFlagDesc = `Use --log-level=table, or --quiet, to suppress 
 var rootCmd = &cobra.Command{
 	Use:   "pgferry",
 	Short: "Source database to PostgreSQL migration tool",
-	Args:  rootNoArgs,
+	Args:  rejectRootArgs,
 	RunE:  runRoot,
 }
 
@@ -102,17 +102,17 @@ func main() {
 
 func runRoot(cmd *cobra.Command, args []string) error {
 	if strings.TrimSpace(configPath) != "" {
-		return missingMigrationConfigError()
+		return rootMigrationCommandRequiredError()
 	}
 	if rootWizardModeChecker(cmd) {
 		return rootWizardRunner(cmd, args)
 	}
-	return missingMigrationConfigError()
+	return rootMigrationCommandRequiredError()
 }
 
-func rootNoArgs(cmd *cobra.Command, args []string) error {
+func rejectRootArgs(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
-		return missingMigrationConfigError()
+		return rootMigrationCommandRequiredError()
 	}
 	return nil
 }
@@ -139,7 +139,11 @@ func runMigration(cmd *cobra.Command, args []string) error {
 }
 
 func missingMigrationConfigError() error {
-	return fmt.Errorf("config file required: pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard")
+	return fmt.Errorf("config file required: pgferry migrate <migration.toml> or pgferry migrate --config <migration.toml>")
+}
+
+func rootMigrationCommandRequiredError() error {
+	return fmt.Errorf("use pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard")
 }
 
 func canLaunchWizardInteractively(cmd *cobra.Command) bool {

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func runMigration(cmd *cobra.Command, args []string) error {
 }
 
 func missingMigrationConfigError() error {
-	return fmt.Errorf("config file required: pgferry migrate <migration.toml> or pgferry wizard")
+	return fmt.Errorf("config file required: pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard")
 }
 
 func canLaunchWizardInteractively(cmd *cobra.Command) bool {

--- a/main_test.go
+++ b/main_test.go
@@ -48,7 +48,7 @@ func TestRootCommand_WithConfigArgShowsMigrateGuidance(t *testing.T) {
 	if err == nil {
 		t.Fatal("rootCmd.Execute() error = nil, want error")
 	}
-	want := "config file required: pgferry migrate <migration.toml> or pgferry wizard"
+	want := "config file required: pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard"
 	if !strings.Contains(err.Error(), want) {
 		t.Fatalf("rootCmd.Execute() error = %q, want to contain %q", err.Error(), want)
 	}
@@ -77,7 +77,7 @@ func TestRunRoot_WithConfigFlagReturnsConfigError(t *testing.T) {
 	if err == nil {
 		t.Fatal("runRoot() error = nil, want error")
 	}
-	want := "config file required: pgferry migrate <migration.toml> or pgferry wizard"
+	want := "config file required: pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard"
 	if err.Error() != want {
 		t.Fatalf("runRoot() error = %q, want %q", err.Error(), want)
 	}
@@ -95,7 +95,7 @@ func TestRunRoot_NoArgsNonInteractiveReturnsConfigError(t *testing.T) {
 	if err == nil {
 		t.Fatal("runRoot() error = nil, want error")
 	}
-	want := "config file required: pgferry migrate <migration.toml> or pgferry wizard"
+	want := "config file required: pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard"
 	if err.Error() != want {
 		t.Fatalf("runRoot() error = %q, want %q", err.Error(), want)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -48,7 +48,7 @@ func TestRootCommand_WithConfigArgShowsMigrateGuidance(t *testing.T) {
 	if err == nil {
 		t.Fatal("rootCmd.Execute() error = nil, want error")
 	}
-	want := "config file required: pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard"
+	want := "use pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard"
 	if !strings.Contains(err.Error(), want) {
 		t.Fatalf("rootCmd.Execute() error = %q, want to contain %q", err.Error(), want)
 	}
@@ -77,7 +77,7 @@ func TestRunRoot_WithConfigFlagReturnsConfigError(t *testing.T) {
 	if err == nil {
 		t.Fatal("runRoot() error = nil, want error")
 	}
-	want := "config file required: pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard"
+	want := "use pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard"
 	if err.Error() != want {
 		t.Fatalf("runRoot() error = %q, want %q", err.Error(), want)
 	}
@@ -95,9 +95,26 @@ func TestRunRoot_NoArgsNonInteractiveReturnsConfigError(t *testing.T) {
 	if err == nil {
 		t.Fatal("runRoot() error = nil, want error")
 	}
-	want := "config file required: pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard"
+	want := "use pgferry migrate <migration.toml>, pgferry migrate --config <migration.toml>, or pgferry wizard"
 	if err.Error() != want {
 		t.Fatalf("runRoot() error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRunMigration_NoConfigReturnsConfigRequiredError(t *testing.T) {
+	prev := configPath
+	configPath = ""
+	t.Cleanup(func() {
+		configPath = prev
+	})
+
+	err := runMigration(&cobra.Command{}, nil)
+	if err == nil {
+		t.Fatal("runMigration() error = nil, want error")
+	}
+	want := "config file required: pgferry migrate <migration.toml> or pgferry migrate --config <migration.toml>"
+	if err.Error() != want {
+		t.Fatalf("runMigration() error = %q, want %q", err.Error(), want)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -15,19 +15,13 @@ import (
 
 func TestRunRoot_NoArgsInteractiveLaunchesWizard(t *testing.T) {
 	prevWizardRunner := rootWizardRunner
-	prevMigrationRunner := rootMigrationRunner
 	prevWizardModeChecker := rootWizardModeChecker
 	rootWizardRunner = func(cmd *cobra.Command, args []string) error {
 		return errors.New("wizard called")
 	}
-	rootMigrationRunner = func(cmd *cobra.Command, args []string) error {
-		t.Fatal("migration runner should not be called")
-		return nil
-	}
 	rootWizardModeChecker = func(cmd *cobra.Command) bool { return true }
 	t.Cleanup(func() {
 		rootWizardRunner = prevWizardRunner
-		rootMigrationRunner = prevMigrationRunner
 		rootWizardModeChecker = prevWizardModeChecker
 		configPath = ""
 	})
@@ -38,31 +32,53 @@ func TestRunRoot_NoArgsInteractiveLaunchesWizard(t *testing.T) {
 	}
 }
 
-func TestRunRoot_WithConfigRunsMigration(t *testing.T) {
+func TestRunRoot_WithConfigReturnsConfigError(t *testing.T) {
 	prevWizardRunner := rootWizardRunner
-	prevMigrationRunner := rootMigrationRunner
 	prevWizardModeChecker := rootWizardModeChecker
 	rootWizardRunner = func(cmd *cobra.Command, args []string) error {
 		t.Fatal("wizard runner should not be called")
 		return nil
 	}
-	rootMigrationRunner = func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 || args[0] != "migration.toml" {
-			t.Fatalf("args = %v, want [migration.toml]", args)
-		}
-		return errors.New("migration called")
-	}
 	rootWizardModeChecker = func(cmd *cobra.Command) bool { return true }
 	t.Cleanup(func() {
 		rootWizardRunner = prevWizardRunner
-		rootMigrationRunner = prevMigrationRunner
 		rootWizardModeChecker = prevWizardModeChecker
 		configPath = ""
 	})
 
 	err := runRoot(&cobra.Command{}, []string{"migration.toml"})
-	if err == nil || err.Error() != "migration called" {
-		t.Fatalf("runRoot() error = %v, want migration called", err)
+	if err == nil {
+		t.Fatal("runRoot() error = nil, want error")
+	}
+	want := "config file required: pgferry migrate <migration.toml> or pgferry wizard"
+	if err.Error() != want {
+		t.Fatalf("runRoot() error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRunRoot_WithConfigFlagReturnsConfigError(t *testing.T) {
+	prev := configPath
+	prevWizardRunner := rootWizardRunner
+	prevWizardModeChecker := rootWizardModeChecker
+	configPath = "migration.toml"
+	rootWizardRunner = func(cmd *cobra.Command, args []string) error {
+		t.Fatal("wizard runner should not be called")
+		return nil
+	}
+	rootWizardModeChecker = func(cmd *cobra.Command) bool { return true }
+	t.Cleanup(func() {
+		configPath = prev
+		rootWizardRunner = prevWizardRunner
+		rootWizardModeChecker = prevWizardModeChecker
+	})
+
+	err := runRoot(&cobra.Command{}, nil)
+	if err == nil {
+		t.Fatal("runRoot() error = nil, want error")
+	}
+	want := "config file required: pgferry migrate <migration.toml> or pgferry wizard"
+	if err.Error() != want {
+		t.Fatalf("runRoot() error = %q, want %q", err.Error(), want)
 	}
 }
 
@@ -78,7 +94,7 @@ func TestRunRoot_NoArgsNonInteractiveReturnsConfigError(t *testing.T) {
 	if err == nil {
 		t.Fatal("runRoot() error = nil, want error")
 	}
-	want := "config file required: pgferry <migration.toml>, pgferry migrate <migration.toml>, or pgferry wizard"
+	want := "config file required: pgferry migrate <migration.toml> or pgferry wizard"
 	if err.Error() != want {
 		t.Fatalf("runRoot() error = %q, want %q", err.Error(), want)
 	}
@@ -91,9 +107,12 @@ func TestRunMigration_UsesConfigFlag(t *testing.T) {
 		configPath = prev
 	})
 
-	got := resolveMigrationConfigPath(nil)
+	got, err := resolveOptionalConfigPath(configPath, nil)
+	if err != nil {
+		t.Fatalf("resolveOptionalConfigPath() error = %v", err)
+	}
 	if got != "migration.toml" {
-		t.Fatalf("resolveMigrationConfigPath(nil) = %q, want migration.toml", got)
+		t.Fatalf("resolveOptionalConfigPath(configPath, nil) = %q, want migration.toml", got)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -32,27 +32,28 @@ func TestRunRoot_NoArgsInteractiveLaunchesWizard(t *testing.T) {
 	}
 }
 
-func TestRunRoot_WithConfigReturnsConfigError(t *testing.T) {
-	prevWizardRunner := rootWizardRunner
-	prevWizardModeChecker := rootWizardModeChecker
-	rootWizardRunner = func(cmd *cobra.Command, args []string) error {
-		t.Fatal("wizard runner should not be called")
-		return nil
-	}
-	rootWizardModeChecker = func(cmd *cobra.Command) bool { return true }
+func TestRootCommand_WithConfigArgShowsMigrateGuidance(t *testing.T) {
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"migration.toml"})
 	t.Cleanup(func() {
-		rootWizardRunner = prevWizardRunner
-		rootWizardModeChecker = prevWizardModeChecker
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
 		configPath = ""
 	})
 
-	err := runRoot(&cobra.Command{}, []string{"migration.toml"})
+	err := rootCmd.Execute()
 	if err == nil {
-		t.Fatal("runRoot() error = nil, want error")
+		t.Fatal("rootCmd.Execute() error = nil, want error")
 	}
 	want := "config file required: pgferry migrate <migration.toml> or pgferry wizard"
-	if err.Error() != want {
-		t.Fatalf("runRoot() error = %q, want %q", err.Error(), want)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("rootCmd.Execute() error = %q, want to contain %q", err.Error(), want)
+	}
+	if !strings.Contains(buf.String(), want) {
+		t.Fatalf("rootCmd output = %q, want to contain %q", buf.String(), want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Remove the root-command shorthand that allowed `pgferry migration.toml` to start a migration. The root command now requires no positional args, and config paths must be passed through `pgferry migrate <migration.toml>`.

## Impact

This avoids accidentally starting a migration when the explicit `migrate` subcommand is omitted. `pgferry migrate migration.toml` and `pgferry migrate --config migration.toml` remain supported.

## Validation

- `go fmt ./...`
- `go test ./... -count=1`
- `go vet ./...`
- `go build -o build/pgferry .`
- `build/pgferry migration.toml` exits non-zero with help instead of running migration
- `build/pgferry --config migration.toml` exits non-zero with the explicit migrate guidance