### PR TITLE
Add automatic column collision renames

### DIFF
--- a/column_rename.go
+++ b/column_rename.go
@@ -43,6 +43,7 @@ func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 	sort.Strings(entries)
 
 	renamesByTable := make(map[int]map[string]string)
+	explicitRenamesByTable := make(map[int]map[int]struct{})
 	seenSourceColumns := make(map[string]string, len(entries))
 	var missingTables []string
 	var missingColumns []string
@@ -85,6 +86,10 @@ func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 			renamesByTable[tableIdx] = make(map[string]string)
 		}
 		renamesByTable[tableIdx][normalizeTableFilterKey(oldPGName)] = targetName
+		if explicitRenamesByTable[tableIdx] == nil {
+			explicitRenamesByTable[tableIdx] = make(map[int]struct{})
+		}
+		explicitRenamesByTable[tableIdx][colIdx] = struct{}{}
 	}
 
 	if len(missingTables) > 0 {
@@ -97,7 +102,7 @@ func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 	}
 
 	if hasAutoColumnCollisionRenames(cfg) {
-		applyAutoColumnCollisionRenames(renamed, renamesByTable)
+		applyAutoColumnCollisionRenames(renamed, renamesByTable, explicitRenamesByTable)
 	}
 
 	for i := range renamed.Tables {
@@ -156,7 +161,7 @@ func remapColumnNames(columns []string, renames map[string]string) {
 	}
 }
 
-func applyAutoColumnCollisionRenames(schema *Schema, renamesByTable map[int]map[string]string) {
+func applyAutoColumnCollisionRenames(schema *Schema, renamesByTable map[int]map[string]string, explicitRenamesByTable map[int]map[int]struct{}) {
 	for tableIdx := range schema.Tables {
 		table := &schema.Tables[tableIdx]
 		groups := columnPostgresKeyGroups(*table)
@@ -166,6 +171,9 @@ func applyAutoColumnCollisionRenames(schema *Schema, renamesByTable map[int]map[
 				continue
 			}
 			for _, colIdx := range group {
+				if _, explicit := explicitRenamesByTable[tableIdx][colIdx]; explicit {
+					continue
+				}
 				autoIndexes[colIdx] = struct{}{}
 			}
 		}
@@ -244,6 +252,8 @@ func autoColumnCollisionName(table Table, col Column, usedKeys map[string]struct
 		}
 	}
 	for counter := 2; ; counter++ {
+		// There are finite columns in a table and a fresh suffix each iteration,
+		// so a free PostgreSQL identifier key is eventually found.
 		suffix := fmt.Sprintf("%s_%d", hash[:8], counter)
 		candidate := autoColumnCollisionNameWithSuffix(col.PGName, suffix)
 		if _, exists := usedKeys[postgresIdentifierKey(candidate)]; !exists {

--- a/column_rename.go
+++ b/column_rename.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 )
@@ -10,11 +13,15 @@ func hasColumnRenames(cfg *MigrationConfig) bool {
 	return cfg != nil && len(cfg.ColumnRenames) > 0
 }
 
+func hasAutoColumnCollisionRenames(cfg *MigrationConfig) bool {
+	return cfg != nil && cfg.ColumnCollisionMode == "auto"
+}
+
 func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 	if schema == nil {
 		return nil, nil
 	}
-	if !hasColumnRenames(cfg) {
+	if !hasColumnRenames(cfg) && !hasAutoColumnCollisionRenames(cfg) {
 		return schema, nil
 	}
 
@@ -89,6 +96,10 @@ func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 		return nil, fmt.Errorf("column_renames entries did not match any source column on matched source tables: %s", strings.Join(missingColumns, ", "))
 	}
 
+	if hasAutoColumnCollisionRenames(cfg) {
+		applyAutoColumnCollisionRenames(renamed, renamesByTable)
+	}
+
 	for i := range renamed.Tables {
 		remapTableColumnReferences(&renamed.Tables[i], renamesByTable[i], renamesByTable, tableIndexes)
 	}
@@ -143,4 +154,109 @@ func remapColumnNames(columns []string, renames map[string]string) {
 			columns[i] = target
 		}
 	}
+}
+
+func applyAutoColumnCollisionRenames(schema *Schema, renamesByTable map[int]map[string]string) {
+	for tableIdx := range schema.Tables {
+		table := &schema.Tables[tableIdx]
+		groups := columnPostgresKeyGroups(*table)
+		autoIndexes := make(map[int]struct{})
+		for _, group := range groups {
+			if !canAutoRenameColumnCollision(*table, group) {
+				continue
+			}
+			for _, colIdx := range group {
+				autoIndexes[colIdx] = struct{}{}
+			}
+		}
+		if len(autoIndexes) == 0 {
+			continue
+		}
+
+		usedKeys := make(map[string]struct{}, len(table.Columns))
+		for colIdx, col := range table.Columns {
+			if _, auto := autoIndexes[colIdx]; auto {
+				continue
+			}
+			usedKeys[postgresIdentifierKey(col.PGName)] = struct{}{}
+		}
+
+		for colIdx := range table.Columns {
+			if _, auto := autoIndexes[colIdx]; !auto {
+				continue
+			}
+			oldPGName := table.Columns[colIdx].PGName
+			newPGName := autoColumnCollisionName(*table, table.Columns[colIdx], usedKeys)
+			table.Columns[colIdx].PGName = newPGName
+			usedKeys[postgresIdentifierKey(newPGName)] = struct{}{}
+			if renamesByTable[tableIdx] == nil {
+				renamesByTable[tableIdx] = make(map[string]string)
+			}
+			renamesByTable[tableIdx][normalizeTableFilterKey(oldPGName)] = newPGName
+			log.Printf("column collision auto-rename: %s.%s -> %s", table.SourceName, table.Columns[colIdx].SourceName, newPGName)
+		}
+	}
+}
+
+func columnPostgresKeyGroups(table Table) map[string][]int {
+	groups := make(map[string][]int, len(table.Columns))
+	for i, col := range table.Columns {
+		key := postgresIdentifierKey(col.PGName)
+		groups[key] = append(groups[key], i)
+	}
+	for key, group := range groups {
+		if len(group) < 2 {
+			delete(groups, key)
+		}
+	}
+	return groups
+}
+
+func canAutoRenameColumnCollision(table Table, group []int) bool {
+	seenPGNames := make(map[string]struct{}, len(group))
+	seenRemapKeys := make(map[string]struct{}, len(group))
+	hasOverLimitName := false
+	for _, colIdx := range group {
+		col := table.Columns[colIdx]
+		if _, ok := seenPGNames[col.PGName]; ok {
+			return false
+		}
+		seenPGNames[col.PGName] = struct{}{}
+		remapKey := normalizeTableFilterKey(col.PGName)
+		if _, ok := seenRemapKeys[remapKey]; ok {
+			return false
+		}
+		seenRemapKeys[remapKey] = struct{}{}
+		if len(col.PGName) > postgresMaxIdentifierBytes {
+			hasOverLimitName = true
+		}
+	}
+	return hasOverLimitName
+}
+
+func autoColumnCollisionName(table Table, col Column, usedKeys map[string]struct{}) string {
+	sum := sha256.Sum256([]byte(table.SourceName + "\x00" + table.PGName + "\x00" + col.SourceName + "\x00" + col.PGName))
+	hash := hex.EncodeToString(sum[:])
+	for suffixLen := 8; suffixLen <= 16; suffixLen += 2 {
+		candidate := autoColumnCollisionNameWithSuffix(col.PGName, hash[:suffixLen])
+		if _, exists := usedKeys[postgresIdentifierKey(candidate)]; !exists {
+			return candidate
+		}
+	}
+	for counter := 2; ; counter++ {
+		suffix := fmt.Sprintf("%s_%d", hash[:8], counter)
+		candidate := autoColumnCollisionNameWithSuffix(col.PGName, suffix)
+		if _, exists := usedKeys[postgresIdentifierKey(candidate)]; !exists {
+			return candidate
+		}
+	}
+}
+
+func autoColumnCollisionNameWithSuffix(pgName, suffix string) string {
+	prefixBytes := postgresMaxIdentifierBytes - len(suffix) - 1
+	prefix := strings.TrimRight(truncateIdentifierBytes(pgName, prefixBytes), "_")
+	if prefix == "" {
+		prefix = "col"
+	}
+	return prefix + "_" + suffix
 }

--- a/column_rename_test.go
+++ b/column_rename_test.go
@@ -110,6 +110,127 @@ func TestApplyColumnRenames_ResolvesPostgresTruncationCollision(t *testing.T) {
 	}
 }
 
+func TestApplyColumnRenames_AutoResolvesPostgresTruncationCollision(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "KP_SUMINA",
+				PGName:     "KP_SUMINA",
+				Columns: []Column{
+					{SourceName: "% ставка резерва по категории качества", PGName: "% ставка резерва по категории качества"},
+					{SourceName: "% ставка резерва по категории качества КД", PGName: "% ставка резерва по категории качества КД"},
+				},
+				PrimaryKey: &Index{Name: "pk_kp_sumina", Columns: []string{"% ставка резерва по категории качества"}},
+				Indexes: []Index{
+					{Name: "idx_kp_sumina_rate_kd", Columns: []string{"% ставка резерва по категории качества КД"}},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{ColumnCollisionMode: "auto"}
+
+	renamed, err := applyColumnRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyColumnRenames() error: %v", err)
+	}
+	if err := validateGeneratedIdentifiers(renamed, &MigrationConfig{}, defaultTypeMappingConfig()); err != nil {
+		t.Fatalf("validateGeneratedIdentifiers() error: %v", err)
+	}
+
+	first := renamed.Tables[0].Columns[0].PGName
+	second := renamed.Tables[0].Columns[1].PGName
+	if first == "% ставка резерва по категории качества" {
+		t.Fatalf("first colliding column was not renamed")
+	}
+	if second == "% ставка резерва по категории качества КД" {
+		t.Fatalf("second colliding column was not renamed")
+	}
+	if len(first) > postgresMaxIdentifierBytes {
+		t.Fatalf("first auto-renamed column length = %d, want <= %d", len(first), postgresMaxIdentifierBytes)
+	}
+	if len(second) > postgresMaxIdentifierBytes {
+		t.Fatalf("second auto-renamed column length = %d, want <= %d", len(second), postgresMaxIdentifierBytes)
+	}
+	if postgresIdentifierKey(first) == postgresIdentifierKey(second) {
+		t.Fatalf("auto-renamed columns still collide: %q and %q", first, second)
+	}
+	if got := renamed.Tables[0].PrimaryKey.Columns[0]; got != first {
+		t.Fatalf("primary key column = %q, want %q", got, first)
+	}
+	if got := renamed.Tables[0].Indexes[0].Columns[0]; got != second {
+		t.Fatalf("index column = %q, want %q", got, second)
+	}
+	if got := schema.Tables[0].Columns[0].PGName; got != "% ставка резерва по категории качества" {
+		t.Fatalf("original schema mutated: first column PGName = %q", got)
+	}
+}
+
+func TestApplyColumnRenames_AutoKeepsExplicitRename(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "KP_SUMINA",
+				PGName:     "KP_SUMINA",
+				Columns: []Column{
+					{SourceName: "% ставка резерва по категории качества", PGName: "% ставка резерва по категории качества"},
+					{SourceName: "% ставка резерва по категории качества КД", PGName: "% ставка резерва по категории качества КД"},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnCollisionMode: "auto",
+		ColumnRenames: map[string]string{
+			"KP_SUMINA.% ставка резерва по категории качества": "reserve_rate_quality",
+		},
+	}
+
+	renamed, err := applyColumnRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyColumnRenames() error: %v", err)
+	}
+	if got := renamed.Tables[0].Columns[0].PGName; got != "reserve_rate_quality" {
+		t.Fatalf("explicitly renamed column PGName = %q, want reserve_rate_quality", got)
+	}
+	if got := renamed.Tables[0].Columns[1].PGName; got != "% ставка резерва по категории качества КД" {
+		t.Fatalf("non-conflicting column PGName = %q, want original name", got)
+	}
+	if err := validateGeneratedIdentifiers(renamed, &MigrationConfig{}, defaultTypeMappingConfig()); err != nil {
+		t.Fatalf("validateGeneratedIdentifiers() error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_AutoDoesNotGuessExactGeneratedNameCollision(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Accounts",
+				PGName:     "accounts",
+				Columns: []Column{
+					{SourceName: "Email", PGName: "email"},
+					{SourceName: "email", PGName: "email"},
+				},
+				Indexes: []Index{
+					{Name: "idx_accounts_email", Columns: []string{"email"}},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{ColumnCollisionMode: "auto"}
+
+	renamed, err := applyColumnRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyColumnRenames() error: %v", err)
+	}
+	err = validateGeneratedIdentifiers(renamed, &MigrationConfig{}, defaultTypeMappingConfig())
+	if err == nil {
+		t.Fatal("expected exact generated-name collision to remain an error")
+	}
+	if !strings.Contains(err.Error(), `column names on table "accounts": final name "email"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestApplyColumnRenames_RejectsUnknownColumn(t *testing.T) {
 	schema := &Schema{
 		Tables: []Table{

--- a/column_rename_test.go
+++ b/column_rename_test.go
@@ -200,6 +200,148 @@ func TestApplyColumnRenames_AutoKeepsExplicitRename(t *testing.T) {
 	}
 }
 
+func TestApplyColumnRenames_AutoDoesNotOverwriteExplicitRenameCollision(t *testing.T) {
+	explicitTarget := strings.Repeat("x", postgresMaxIdentifierBytes)
+	collidingGeneratedName := explicitTarget + "_source_suffix"
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Measurements",
+				PGName:     "measurements",
+				Columns: []Column{
+					{SourceName: "ExplicitRate", PGName: "explicit_rate"},
+					{SourceName: "GeneratedRate", PGName: collidingGeneratedName},
+				},
+				PrimaryKey: &Index{Name: "pk_measurements", Columns: []string{"explicit_rate"}},
+				Indexes: []Index{
+					{Name: "idx_generated_rate", Columns: []string{collidingGeneratedName}},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		ColumnCollisionMode: "auto",
+		ColumnRenames: map[string]string{
+			"Measurements.ExplicitRate": explicitTarget,
+		},
+	}
+
+	renamed, err := applyColumnRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyColumnRenames() error: %v", err)
+	}
+
+	first := renamed.Tables[0].Columns[0].PGName
+	second := renamed.Tables[0].Columns[1].PGName
+	if first != explicitTarget {
+		t.Fatalf("explicitly renamed column PGName = %q, want %q", first, explicitTarget)
+	}
+	if second == collidingGeneratedName {
+		t.Fatalf("non-explicit colliding column was not auto-renamed")
+	}
+	if postgresIdentifierKey(first) == postgresIdentifierKey(second) {
+		t.Fatalf("auto-renamed column still collides with explicit rename: %q and %q", first, second)
+	}
+	if got := renamed.Tables[0].PrimaryKey.Columns[0]; got != explicitTarget {
+		t.Fatalf("primary key column = %q, want explicit target %q", got, explicitTarget)
+	}
+	if got := renamed.Tables[0].Indexes[0].Columns[0]; got != second {
+		t.Fatalf("index column = %q, want auto target %q", got, second)
+	}
+	if err := validateGeneratedIdentifiers(renamed, &MigrationConfig{}, defaultTypeMappingConfig()); err != nil {
+		t.Fatalf("validateGeneratedIdentifiers() error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_AutoUpdatesForeignKeyRefColumns(t *testing.T) {
+	parentFirst := "parent_reference_code_that_is_long_enough_to_collide_after_postgresql_truncation_a"
+	parentSecond := "parent_reference_code_that_is_long_enough_to_collide_after_postgresql_truncation_b"
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Parents",
+				PGName:     "parents",
+				Columns: []Column{
+					{SourceName: "ReferenceCodeA", PGName: parentFirst},
+					{SourceName: "ReferenceCodeB", PGName: parentSecond},
+				},
+			},
+			{
+				SourceName: "Children",
+				PGName:     "children",
+				Columns: []Column{
+					{SourceName: "ParentCode", PGName: "parent_code"},
+				},
+				ForeignKeys: []ForeignKey{
+					{
+						Name:       "fk_children_parents",
+						Columns:    []string{"parent_code"},
+						RefTable:   "Parents",
+						RefPGTable: "parents",
+						RefColumns: []string{parentSecond},
+					},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{ColumnCollisionMode: "auto"}
+
+	renamed, err := applyColumnRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyColumnRenames() error: %v", err)
+	}
+
+	parentSecondTarget := renamed.Tables[0].Columns[1].PGName
+	if parentSecondTarget == parentSecond {
+		t.Fatalf("referenced parent column was not auto-renamed")
+	}
+	if got := renamed.Tables[1].ForeignKeys[0].RefColumns[0]; got != parentSecondTarget {
+		t.Fatalf("child foreign key ref column = %q, want %q", got, parentSecondTarget)
+	}
+	if err := validateGeneratedIdentifiers(renamed, &MigrationConfig{}, defaultTypeMappingConfig()); err != nil {
+		t.Fatalf("validateGeneratedIdentifiers() error: %v", err)
+	}
+}
+
+func TestApplyColumnRenames_AutoResolvesMultipleCollisionGroupsInOneTable(t *testing.T) {
+	firstGroupA := "alpha_reference_code_that_is_long_enough_to_collide_after_postgresql_truncation_a"
+	firstGroupB := "alpha_reference_code_that_is_long_enough_to_collide_after_postgresql_truncation_b"
+	secondGroupA := "bravo_reference_code_that_is_long_enough_to_collide_after_postgresql_truncation_a"
+	secondGroupB := "bravo_reference_code_that_is_long_enough_to_collide_after_postgresql_truncation_b"
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Events",
+				PGName:     "events",
+				Columns: []Column{
+					{SourceName: "AlphaA", PGName: firstGroupA},
+					{SourceName: "AlphaB", PGName: firstGroupB},
+					{SourceName: "BravoA", PGName: secondGroupA},
+					{SourceName: "BravoB", PGName: secondGroupB},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{ColumnCollisionMode: "auto"}
+
+	renamed, err := applyColumnRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyColumnRenames() error: %v", err)
+	}
+
+	seen := make(map[string]string)
+	for _, col := range renamed.Tables[0].Columns {
+		key := postgresIdentifierKey(col.PGName)
+		if prev, ok := seen[key]; ok {
+			t.Fatalf("columns %q and %q still collide on PostgreSQL key %q", prev, col.PGName, key)
+		}
+		seen[key] = col.PGName
+	}
+	if err := validateGeneratedIdentifiers(renamed, &MigrationConfig{}, defaultTypeMappingConfig()); err != nil {
+		t.Fatalf("validateGeneratedIdentifiers() error: %v", err)
+	}
+}
+
 func TestApplyColumnRenames_AutoDoesNotGuessExactGeneratedNameCollision(t *testing.T) {
 	schema := &Schema{
 		Tables: []Table{

--- a/config.go
+++ b/config.go
@@ -30,6 +30,7 @@ type MigrationConfig struct {
 	ExcludeTables                     []string          `toml:"exclude_tables"`
 	ExcludeColumns                    []string          `toml:"exclude_columns"`
 	ColumnRenames                     map[string]string `toml:"column_renames"`
+	ColumnCollisionMode               string            `toml:"column_collision_mode"` // error|auto
 	OnSchemaExists                    string            `toml:"on_schema_exists"`
 	SchemaOnly                        bool              `toml:"schema_only"`
 	DataOnly                          bool              `toml:"data_only"`
@@ -154,17 +155,18 @@ func applyConfigEnvOverrides(cfg *MigrationConfig) {
 
 func defaultMigrationConfig() MigrationConfig {
 	return MigrationConfig{
-		OnSchemaExists:     "error",
-		TableFilterMode:    "exact",
-		ColumnFilterMode:   "exact",
-		SourceSnapshotMode: "none",
-		UnloggedTables:     true,
-		PreserveDefaults:   true,
-		CleanOrphans:       true,
-		CleanOrphansMode:   "apply",
-		IdentifierCase:     "snake",
-		CopyRiskAnalysis:   true,
-		TypeMapping:        defaultTypeMappingConfig(),
+		OnSchemaExists:      "error",
+		TableFilterMode:     "exact",
+		ColumnFilterMode:    "exact",
+		SourceSnapshotMode:  "none",
+		UnloggedTables:      true,
+		PreserveDefaults:    true,
+		CleanOrphans:        true,
+		CleanOrphansMode:    "apply",
+		IdentifierCase:      "snake",
+		ColumnCollisionMode: "error",
+		CopyRiskAnalysis:    true,
+		TypeMapping:         defaultTypeMappingConfig(),
 	}
 }
 
@@ -226,6 +228,15 @@ func finalizeConfig(cfg *MigrationConfig, configDir string) error {
 	case "snake", "lower", "preserve":
 	default:
 		return fmt.Errorf("identifier_case must be one of: snake, lower, preserve")
+	}
+	cfg.ColumnCollisionMode = strings.ToLower(strings.TrimSpace(cfg.ColumnCollisionMode))
+	if cfg.ColumnCollisionMode == "" {
+		cfg.ColumnCollisionMode = "error"
+	}
+	switch cfg.ColumnCollisionMode {
+	case "error", "auto":
+	default:
+		return fmt.Errorf("column_collision_mode must be one of: error, auto")
 	}
 	includeTables, err := normalizeTableFilterEntries("include_tables", cfg.TableFilterMode, cfg.IncludeTables)
 	if err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -23,6 +23,7 @@ add_unsigned_checks = true
 replicate_on_update_current_timestamp = true
 workers = 8
 truncate_before_copy = true
+column_collision_mode = "auto"
 
 [source]
 type = "mysql"
@@ -84,6 +85,9 @@ after_all = ["post.sql"]
 	}
 	if !cfg.TruncateBeforeCopy {
 		t.Errorf("TruncateBeforeCopy = %t, want true", cfg.TruncateBeforeCopy)
+	}
+	if cfg.ColumnCollisionMode != "auto" {
+		t.Errorf("ColumnCollisionMode = %q, want auto", cfg.ColumnCollisionMode)
 	}
 	if len(cfg.Hooks.BeforeFk) != 1 || cfg.Hooks.BeforeFk[0] != "cleanup.sql" {
 		t.Errorf("Hooks.BeforeFk = %v", cfg.Hooks.BeforeFk)
@@ -2405,5 +2409,25 @@ func TestIdentifierCase_RejectsInvalid(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "preserve") {
 		t.Fatalf("error = %q, want it to list preserve as a valid value", err.Error())
+	}
+}
+
+func TestColumnCollisionMode_RejectsInvalid(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Source.Type = "mysql"
+	cfg.Source.DSN = "user:pass@tcp(127.0.0.1:3306)/db"
+	cfg.Target.DSN = "postgres://u:p@127.0.0.1/db?sslmode=disable"
+	cfg.Schema = "public"
+	cfg.ColumnCollisionMode = "rename"
+
+	err := finalizeConfig(&cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for column_collision_mode = rename")
+	}
+	if !strings.Contains(err.Error(), "column_collision_mode must be one of") {
+		t.Fatalf("error = %q, want column_collision_mode validation message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "auto") {
+		t.Fatalf("error = %q, want it to list auto as a valid value", err.Error())
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -160,6 +160,9 @@ dsn = "postgres://u:p@h:5432/db"
 	if cfg.IdentifierCase != "snake" {
 		t.Errorf("default IdentifierCase = %q, want %q", cfg.IdentifierCase, "snake")
 	}
+	if cfg.ColumnCollisionMode != "error" {
+		t.Errorf("default ColumnCollisionMode = %q, want %q", cfg.ColumnCollisionMode, "error")
+	}
 	wantWorkers := runtime.NumCPU()
 	if wantWorkers < 1 {
 		wantWorkers = 1

--- a/main.go
+++ b/main.go
@@ -198,7 +198,7 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 		mode = "data_only"
 	}
 	log.Printf(
-		"config: mode=%s workers=%d index_workers=%d schema=%s on_schema_exists=%s source_snapshot_mode=%s unlogged_tables=%t preserve_defaults=%t add_unsigned_checks=%t clean_orphans=%t clean_orphans_mode=%s clean_orphans_max_rows=%d identifier_case=%s replicate_on_update_current_timestamp=%t truncate_before_copy=%t chunk_size=%d copy_risk_analysis=%t resume=%t validation=%s",
+		"config: mode=%s workers=%d index_workers=%d schema=%s on_schema_exists=%s source_snapshot_mode=%s unlogged_tables=%t preserve_defaults=%t add_unsigned_checks=%t clean_orphans=%t clean_orphans_mode=%s clean_orphans_max_rows=%d identifier_case=%s column_collision_mode=%s replicate_on_update_current_timestamp=%t truncate_before_copy=%t chunk_size=%d copy_risk_analysis=%t resume=%t validation=%s",
 		mode,
 		cfg.Workers,
 		cfg.IndexWorkers,
@@ -212,6 +212,7 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 		cfg.CleanOrphansMode,
 		cfg.CleanOrphansMaxRows,
 		cfg.IdentifierCase,
+		cfg.ColumnCollisionMode,
 		cfg.ReplicateOnUpdateCurrentTimestamp,
 		cfg.TruncateBeforeCopy,
 		cfg.ChunkSize,

--- a/plan.go
+++ b/plan.go
@@ -175,22 +175,23 @@ type PlanTableFilterReport struct {
 
 // PlanSummary is a high-level snapshot of the planned migration (config echo + table counts).
 type PlanSummary struct {
-	SourceType         string `json:"source_type"`
-	SourceDatabase     string `json:"source_database"`
-	TargetSchema       string `json:"target_schema"`
-	TableCount         int    `json:"table_count"`
-	TotalEstimatedRows int64  `json:"total_estimated_rows,omitempty"`
-	Workers            int    `json:"workers"`
-	IndexWorkers       int    `json:"index_workers"`
-	ChunkSize          int64  `json:"chunk_size"`
-	UnloggedTables     bool   `json:"unlogged_tables"`
-	Resume             bool   `json:"resume"`
-	Validation         string `json:"validation"`
-	SnapshotMode       string `json:"source_snapshot_mode"`
-	CopyRiskAnalysis   bool   `json:"copy_risk_analysis"`
-	PreserveDefaults   bool   `json:"preserve_defaults"`
-	CleanOrphans       bool   `json:"clean_orphans"`
-	IdentifierCase     string `json:"identifier_case"`
+	SourceType          string `json:"source_type"`
+	SourceDatabase      string `json:"source_database"`
+	TargetSchema        string `json:"target_schema"`
+	TableCount          int    `json:"table_count"`
+	TotalEstimatedRows  int64  `json:"total_estimated_rows,omitempty"`
+	Workers             int    `json:"workers"`
+	IndexWorkers        int    `json:"index_workers"`
+	ChunkSize           int64  `json:"chunk_size"`
+	UnloggedTables      bool   `json:"unlogged_tables"`
+	Resume              bool   `json:"resume"`
+	Validation          string `json:"validation"`
+	SnapshotMode        string `json:"source_snapshot_mode"`
+	CopyRiskAnalysis    bool   `json:"copy_risk_analysis"`
+	PreserveDefaults    bool   `json:"preserve_defaults"`
+	CleanOrphans        bool   `json:"clean_orphans"`
+	IdentifierCase      string `json:"identifier_case"`
+	ColumnCollisionMode string `json:"column_collision_mode"`
 }
 
 // PlanReport holds all findings from the plan analysis.
@@ -640,20 +641,21 @@ func buildPlanSummary(schema *Schema, cfg *MigrationConfig, dbName string, copyR
 		return PlanSummary{}
 	}
 	s := PlanSummary{
-		SourceType:       cfg.Source.Type,
-		SourceDatabase:   dbName,
-		TargetSchema:     cfg.Schema,
-		Workers:          cfg.Workers,
-		IndexWorkers:     cfg.IndexWorkers,
-		ChunkSize:        cfg.ChunkSize,
-		UnloggedTables:   cfg.UnloggedTables,
-		Resume:           cfg.Resume,
-		Validation:       cfg.Validation,
-		SnapshotMode:     cfg.SourceSnapshotMode,
-		CopyRiskAnalysis: cfg.CopyRiskAnalysis,
-		PreserveDefaults: cfg.PreserveDefaults,
-		CleanOrphans:     cfg.CleanOrphans,
-		IdentifierCase:   cfg.IdentifierCase,
+		SourceType:          cfg.Source.Type,
+		SourceDatabase:      dbName,
+		TargetSchema:        cfg.Schema,
+		Workers:             cfg.Workers,
+		IndexWorkers:        cfg.IndexWorkers,
+		ChunkSize:           cfg.ChunkSize,
+		UnloggedTables:      cfg.UnloggedTables,
+		Resume:              cfg.Resume,
+		Validation:          cfg.Validation,
+		SnapshotMode:        cfg.SourceSnapshotMode,
+		CopyRiskAnalysis:    cfg.CopyRiskAnalysis,
+		PreserveDefaults:    cfg.PreserveDefaults,
+		CleanOrphans:        cfg.CleanOrphans,
+		IdentifierCase:      cfg.IdentifierCase,
+		ColumnCollisionMode: cfg.ColumnCollisionMode,
 	}
 	if schema != nil {
 		s.TableCount = len(schema.Tables)
@@ -715,6 +717,13 @@ func sumCopyRiskEstimatedRowsByTable(findings []PlanCopyRiskFinding) int64 {
 // struct; SourceType stays empty so we skip printing an empty Summary section.
 func planSummaryHasData(s PlanSummary) bool {
 	return s.SourceType != ""
+}
+
+func planColumnCollisionMode(s PlanSummary) string {
+	if s.ColumnCollisionMode != "" {
+		return s.ColumnCollisionMode
+	}
+	return "error"
 }
 
 func formatInt64Thousands(n int64) string {
@@ -969,8 +978,8 @@ func writePlanText(w io.Writer, report *PlanReport) {
 		}
 		fmt.Fprintf(w, "Config: workers=%d index_workers=%d chunk_size=%d resume=%t validation=%s\n",
 			s.Workers, s.IndexWorkers, s.ChunkSize, s.Resume, s.Validation)
-		fmt.Fprintf(w, "        source_snapshot_mode=%s copy_risk_analysis=%t unlogged_tables=%t preserve_defaults=%t clean_orphans=%t identifier_case=%s\n",
-			s.SnapshotMode, s.CopyRiskAnalysis, s.UnloggedTables, s.PreserveDefaults, s.CleanOrphans, s.IdentifierCase)
+		fmt.Fprintf(w, "        source_snapshot_mode=%s copy_risk_analysis=%t unlogged_tables=%t preserve_defaults=%t clean_orphans=%t identifier_case=%s column_collision_mode=%s\n",
+			s.SnapshotMode, s.CopyRiskAnalysis, s.UnloggedTables, s.PreserveDefaults, s.CleanOrphans, s.IdentifierCase, planColumnCollisionMode(s))
 		fmt.Fprintln(w)
 		writePlanETAText(w, report.ETA)
 	}

--- a/plan.go
+++ b/plan.go
@@ -655,7 +655,7 @@ func buildPlanSummary(schema *Schema, cfg *MigrationConfig, dbName string, copyR
 		PreserveDefaults:    cfg.PreserveDefaults,
 		CleanOrphans:        cfg.CleanOrphans,
 		IdentifierCase:      cfg.IdentifierCase,
-		ColumnCollisionMode: cfg.ColumnCollisionMode,
+		ColumnCollisionMode: columnCollisionModeOrDefault(cfg.ColumnCollisionMode),
 	}
 	if schema != nil {
 		s.TableCount = len(schema.Tables)
@@ -719,9 +719,9 @@ func planSummaryHasData(s PlanSummary) bool {
 	return s.SourceType != ""
 }
 
-func planColumnCollisionMode(s PlanSummary) string {
-	if s.ColumnCollisionMode != "" {
-		return s.ColumnCollisionMode
+func columnCollisionModeOrDefault(mode string) string {
+	if mode != "" {
+		return mode
 	}
 	return "error"
 }
@@ -979,7 +979,7 @@ func writePlanText(w io.Writer, report *PlanReport) {
 		fmt.Fprintf(w, "Config: workers=%d index_workers=%d chunk_size=%d resume=%t validation=%s\n",
 			s.Workers, s.IndexWorkers, s.ChunkSize, s.Resume, s.Validation)
 		fmt.Fprintf(w, "        source_snapshot_mode=%s copy_risk_analysis=%t unlogged_tables=%t preserve_defaults=%t clean_orphans=%t identifier_case=%s column_collision_mode=%s\n",
-			s.SnapshotMode, s.CopyRiskAnalysis, s.UnloggedTables, s.PreserveDefaults, s.CleanOrphans, s.IdentifierCase, planColumnCollisionMode(s))
+			s.SnapshotMode, s.CopyRiskAnalysis, s.UnloggedTables, s.PreserveDefaults, s.CleanOrphans, s.IdentifierCase, columnCollisionModeOrDefault(s.ColumnCollisionMode))
 		fmt.Fprintln(w)
 		writePlanETAText(w, report.ETA)
 	}

--- a/plan_test.go
+++ b/plan_test.go
@@ -53,8 +53,12 @@ func TestBuildPlanSummary_TotalEstimatedRows(t *testing.T) {
 		CopyRiskAnalysis: false,
 	}
 	risks := []PlanCopyRiskFinding{{Table: "t", EstimatedRows: 1_000_000}}
-	if got := buildPlanSummary(schema, cfg, "main", risks, nil, false).TotalEstimatedRows; got != 0 {
+	summary := buildPlanSummary(schema, cfg, "main", risks, nil, false)
+	if got := summary.TotalEstimatedRows; got != 0 {
 		t.Fatalf("copy risk disabled: TotalEstimatedRows = %d, want 0", got)
+	}
+	if got := summary.ColumnCollisionMode; got != "error" {
+		t.Fatalf("ColumnCollisionMode = %q, want error", got)
 	}
 	if got := buildPlanSummary(schema, cfg, "main", risks, nil, true).TotalEstimatedRows; got != 1_000_000 {
 		t.Fatalf("copy risk enabled: TotalEstimatedRows = %d, want 1000000", got)

--- a/schema.go
+++ b/schema.go
@@ -41,7 +41,14 @@ func pgIdent(name string) string {
 }
 
 func postgresIdentifierKey(name string) string {
-	if len(name) <= postgresMaxIdentifierBytes {
+	return truncateIdentifierBytes(name, postgresMaxIdentifierBytes)
+}
+
+func truncateIdentifierBytes(name string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(name) <= maxBytes {
 		return name
 	}
 
@@ -51,7 +58,7 @@ func postgresIdentifierKey(name string) string {
 		if r == utf8.RuneError {
 			_, width = utf8.DecodeRuneInString(name[i:])
 		}
-		if i+width > postgresMaxIdentifierBytes {
+		if i+width > maxBytes {
 			break
 		}
 		end = i + width

--- a/site/src/content/docs/get-started/advanced-options.md
+++ b/site/src/content/docs/get-started/advanced-options.md
@@ -110,6 +110,14 @@ To keep a source column but choose its target PostgreSQL name explicitly, use `c
 
 Rename keys use source `TableName.ColumnName` values after table and column filters. Rename values are final PostgreSQL column names, so pgferry does not apply `identifier_case` to them, and they must fit PostgreSQL's 63-byte identifier limit. This is useful when two long source column names would otherwise collide after PostgreSQL's identifier limit.
 
+If many long columns collide only because PostgreSQL truncates identifiers to 63 bytes, opt into deterministic automatic names:
+
+```toml
+column_collision_mode = "auto"
+```
+
+Explicit `column_renames` still take precedence. Automatic renames are limited to truncation-only column collisions within a table; exact generated-name collisions and non-column object collisions still stop with an error so you can choose the target names deliberately.
+
 - [How to read plan output](/operations/how-to-read-plan-output/)
 
 ## Hooks

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -116,6 +116,7 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | `exclude_tables` | array of strings | `[]` | Source tables to skip. Applied after `include_tables`, so excludes win when both match the same table. |
 | `exclude_columns` | array of strings | `[]` | Source columns to skip. Use `ColumnName` to skip matching columns in any table, or `TableName.ColumnName` to scope a rule to one source table. Entries are exact by default, or glob patterns in either the table or column part when `column_filter_mode = "glob"`. |
 | `[column_renames]` | table of strings | `{}` | Explicit target column names keyed by source `TableName.ColumnName`. Values are final PostgreSQL column names and are applied after table and column filters. |
+| `column_collision_mode` | string | `"error"` | `"error"` reports generated PostgreSQL identifier collisions. `"auto"` automatically renames truncation-only column collisions within a table using deterministic hashed names. |
 | `on_schema_exists` | string | `"error"` | `"error"` aborts if the schema exists. `"recreate"` drops and recreates it. `"use"` requires the schema to already exist and be empty, then pgferry creates objects inside it. |
 | `schema_only` | bool | `false` | Create schema objects only. Skip data COPY. |
 | `data_only` | bool | `false` | Load data into an existing schema, then advance existing sequences with `setval`. Requires the target role to disable and re-enable triggers on the selected target tables during the load. |
@@ -148,7 +149,15 @@ Column renames override the target PostgreSQL name for a source column without c
 "KP_SUMINA.% ставка резерва по категории качества КД" = "reserve_rate_quality_kd"
 ```
 
-Changing `table_filter_mode`, `include_tables`, `exclude_tables`, `column_filter_mode`, `exclude_columns`, or `column_renames` can change the selected migration scope or target schema. When `resume = true`, that can invalidate the checkpoint fingerprint and force a fresh run.
+For large schemas with many long source column names, `column_collision_mode = "auto"` can resolve PostgreSQL truncation collisions without listing every column manually:
+
+```toml
+column_collision_mode = "auto"
+```
+
+Automatic collision renames are applied after explicit `[column_renames]`, so explicit mappings take precedence. pgferry only auto-renames column groups whose generated names are distinct before PostgreSQL's 63-byte truncation but collide after that limit. Exact generated-name collisions, table/index/constraint/type collisions, and ambiguous column references still fail and require explicit renames or manual handling. Each generated target name uses a UTF-8-safe prefix plus a stable hash and is logged during planning, validation, and migration.
+
+Changing `table_filter_mode`, `include_tables`, `exclude_tables`, `column_filter_mode`, `exclude_columns`, `column_renames`, or `column_collision_mode` can change the selected migration scope or target schema. When `resume = true`, that can invalidate the checkpoint fingerprint and force a fresh run.
 
 `truncate_before_copy` follows the selected table scope after filters. Excluded tables are not named in pgferry's generated `TRUNCATE TABLE ...` statement. pgferry intentionally omits `CASCADE` so PostgreSQL will fail rather than silently truncating dependent tables outside the selected scope.
 

--- a/site/src/content/docs/reference/conventions-and-limitations.md
+++ b/site/src/content/docs/reference/conventions-and-limitations.md
@@ -28,6 +28,8 @@ PostgreSQL SQL is emitted as `"app"."users"` rather than `app.users` under all t
 
 PostgreSQL compares only the first 63 bytes of an identifier. pgferry checks generated names using that effective PostgreSQL limit and reports collisions before running target DDL. If two source column names still collide after the selected `identifier_case` mode, use `[column_renames]` to choose explicit target names for those source columns.
 
+For bulk cases where distinct long column names collide only after PostgreSQL truncation, set `column_collision_mode = "auto"` to let pgferry generate deterministic hashed target names. This mode is intentionally narrow: exact generated-name collisions and non-column object collisions still require explicit renames or manual handling.
+
 ## Auto-increment and sequences
 
 MySQL and MariaDB `auto_increment`, SQLite integer primary key auto-increment behavior, and MSSQL `IDENTITY` columns are recreated as PostgreSQL sequences after data load.


### PR DESCRIPTION
## Summary

Adds opt-in automatic target-column remapping for PostgreSQL truncation-only column identifier collisions via `column_collision_mode = "auto"`.

Explicit `[column_renames]` remain authoritative. Auto mode only handles groups of distinct generated column names that collide after PostgreSQL's 63-byte identifier limit; exact generated-name collisions and non-column object collisions still fail so operators can choose names deliberately.

## Impact

This reduces migration setup work for large schemas with many long source column names while preserving the default fail-fast behavior. Generated names use a UTF-8-safe prefix plus a stable hash and are logged during plan, validate, and migrate flows.

Docs were updated for the new config option and behavior.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go build -o build/pgferry .`
- `cd site && bun run build && bun run check-routes`