### PR TITLE
Add table name remapping

### DIFF
--- a/column_rename.go
+++ b/column_rename.go
@@ -13,8 +13,96 @@ func hasColumnRenames(cfg *MigrationConfig) bool {
 	return cfg != nil && len(cfg.ColumnRenames) > 0
 }
 
+func hasTableRenames(cfg *MigrationConfig) bool {
+	return cfg != nil && len(cfg.TableRenames) > 0
+}
+
+func hasAutoTableCollisionRenames(cfg *MigrationConfig) bool {
+	return cfg != nil && cfg.TableCollisionMode == "auto"
+}
+
 func hasAutoColumnCollisionRenames(cfg *MigrationConfig) bool {
 	return cfg != nil && cfg.ColumnCollisionMode == "auto"
+}
+
+func applySchemaRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
+	renamedSchema, err := applyTableRenames(schema, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("apply table renames: %w", err)
+	}
+	renamedSchema, err = applyColumnRenames(renamedSchema, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("apply column renames: %w", err)
+	}
+	return renamedSchema, nil
+}
+
+func applyTableRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
+	if schema == nil {
+		return nil, nil
+	}
+	if !hasTableRenames(cfg) && !hasAutoTableCollisionRenames(cfg) {
+		return schema, nil
+	}
+
+	renamed := &Schema{Tables: make([]Table, len(schema.Tables))}
+	tableIndexes := make(map[string]int, len(schema.Tables))
+	for i, table := range schema.Tables {
+		renamed.Tables[i] = cloneTable(table)
+		key := normalizeTableFilterKey(table.SourceName)
+		if prev, ok := tableIndexes[key]; ok {
+			return nil, fmt.Errorf("source schema contains ambiguous table names %q and %q; table_renames match source tables case-insensitively", schema.Tables[prev].SourceName, table.SourceName)
+		}
+		tableIndexes[key] = i
+	}
+
+	tableRenames := make(map[string]string)
+	explicitRenames := make(map[int]struct{})
+	entries := make([]string, 0, len(cfg.TableRenames))
+	for entry := range cfg.TableRenames {
+		entries = append(entries, entry)
+	}
+	sort.Strings(entries)
+
+	seenSourceTables := make(map[string]string, len(entries))
+	var missingTables []string
+	for _, entry := range entries {
+		targetName := strings.TrimSpace(cfg.TableRenames[entry])
+		if targetName == "" {
+			return nil, fmt.Errorf("table_renames entry %q has an empty target table name", entry)
+		}
+		if len(targetName) > postgresMaxIdentifierBytes {
+			return nil, fmt.Errorf("table_renames entry %q: target name %q exceeds PostgreSQL's %d-byte identifier limit", entry, targetName, postgresMaxIdentifierBytes)
+		}
+
+		sourceName := strings.TrimSpace(entry)
+		tableIdx, ok := tableIndexes[normalizeTableFilterKey(sourceName)]
+		if !ok {
+			missingTables = append(missingTables, entry)
+			continue
+		}
+
+		sourceKey := normalizeTableFilterKey(renamed.Tables[tableIdx].SourceName)
+		if prev, ok := seenSourceTables[sourceKey]; ok {
+			return nil, fmt.Errorf("table_renames entries %q and %q both map to source table %s", prev, entry, sourceKey)
+		}
+		seenSourceTables[sourceKey] = entry
+
+		renamed.Tables[tableIdx].PGName = targetName
+		tableRenames[sourceKey] = targetName
+		explicitRenames[tableIdx] = struct{}{}
+	}
+
+	if len(missingTables) > 0 {
+		sort.Strings(missingTables)
+		return nil, fmt.Errorf("table_renames entries did not match any source table in the migrated schema (table may have been excluded by table filters): %s", strings.Join(missingTables, ", "))
+	}
+
+	if hasAutoTableCollisionRenames(cfg) {
+		applyAutoTableCollisionRenames(renamed, tableRenames, explicitRenames)
+	}
+	remapForeignKeyTableReferences(renamed, tableRenames)
+	return renamed, nil
 }
 
 func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
@@ -110,6 +198,122 @@ func applyColumnRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 	}
 
 	return renamed, nil
+}
+
+func remapForeignKeyTableReferences(schema *Schema, tableRenames map[string]string) {
+	if len(tableRenames) == 0 {
+		return
+	}
+	for tableIdx := range schema.Tables {
+		for fkIdx := range schema.Tables[tableIdx].ForeignKeys {
+			fk := &schema.Tables[tableIdx].ForeignKeys[fkIdx]
+			if target, ok := tableRenames[normalizeTableFilterKey(fk.RefTable)]; ok {
+				fk.RefPGTable = target
+			}
+		}
+	}
+}
+
+func applyAutoTableCollisionRenames(schema *Schema, tableRenames map[string]string, explicitRenames map[int]struct{}) {
+	groups := tablePostgresKeyGroups(schema)
+	autoIndexes := make(map[int]struct{})
+	for _, group := range groups {
+		if !canAutoRenameTableCollision(schema, group) {
+			continue
+		}
+		for _, tableIdx := range group {
+			if _, explicit := explicitRenames[tableIdx]; explicit {
+				continue
+			}
+			autoIndexes[tableIdx] = struct{}{}
+		}
+	}
+	if len(autoIndexes) == 0 {
+		return
+	}
+
+	usedKeys := make(map[string]struct{}, len(schema.Tables))
+	for tableIdx, table := range schema.Tables {
+		if _, auto := autoIndexes[tableIdx]; auto {
+			continue
+		}
+		usedKeys[postgresIdentifierKey(table.PGName)] = struct{}{}
+	}
+
+	for tableIdx := range schema.Tables {
+		if _, auto := autoIndexes[tableIdx]; !auto {
+			continue
+		}
+		table := &schema.Tables[tableIdx]
+		newPGName := autoTableCollisionName(*table, usedKeys)
+		table.PGName = newPGName
+		usedKeys[postgresIdentifierKey(newPGName)] = struct{}{}
+		tableRenames[normalizeTableFilterKey(table.SourceName)] = newPGName
+		log.Printf("table collision auto-rename: %s -> %s", table.SourceName, newPGName)
+	}
+}
+
+func tablePostgresKeyGroups(schema *Schema) map[string][]int {
+	groups := make(map[string][]int, len(schema.Tables))
+	for i, table := range schema.Tables {
+		key := postgresIdentifierKey(table.PGName)
+		groups[key] = append(groups[key], i)
+	}
+	for key, group := range groups {
+		if len(group) < 2 {
+			delete(groups, key)
+		}
+	}
+	return groups
+}
+
+func canAutoRenameTableCollision(schema *Schema, group []int) bool {
+	seenPGNames := make(map[string]struct{}, len(group))
+	seenRemapKeys := make(map[string]struct{}, len(group))
+	hasOverLimitName := false
+	for _, tableIdx := range group {
+		table := schema.Tables[tableIdx]
+		if _, ok := seenPGNames[table.PGName]; ok {
+			return false
+		}
+		seenPGNames[table.PGName] = struct{}{}
+		remapKey := normalizeTableFilterKey(table.PGName)
+		if _, ok := seenRemapKeys[remapKey]; ok {
+			return false
+		}
+		seenRemapKeys[remapKey] = struct{}{}
+		if len(table.PGName) > postgresMaxIdentifierBytes {
+			hasOverLimitName = true
+		}
+	}
+	return hasOverLimitName
+}
+
+func autoTableCollisionName(table Table, usedKeys map[string]struct{}) string {
+	sum := sha256.Sum256([]byte(table.SourceName + "\x00" + table.PGName))
+	hash := hex.EncodeToString(sum[:])
+	for suffixLen := 8; suffixLen <= 16; suffixLen += 2 {
+		candidate := autoTableCollisionNameWithSuffix(table.PGName, hash[:suffixLen])
+		if _, exists := usedKeys[postgresIdentifierKey(candidate)]; !exists {
+			return candidate
+		}
+	}
+	for counter := 2; ; counter++ {
+		suffix := fmt.Sprintf("%s_%d", hash[:8], counter)
+		candidate := autoTableCollisionNameWithSuffix(table.PGName, suffix)
+		if _, exists := usedKeys[postgresIdentifierKey(candidate)]; !exists {
+			return candidate
+		}
+	}
+}
+
+func autoTableCollisionNameWithSuffix(pgName, suffix string) string {
+	prefixBytes := postgresMaxIdentifierBytes - len(suffix) - 1
+	prefix := strings.TrimRight(truncateIdentifierBytes(pgName, prefixBytes), "_")
+	if prefix == "" {
+		prefix = "table"
+	}
+	return prefix + "_" + suffix
 }
 
 func splitColumnRenameEntry(entry string) (string, string, error) {

--- a/column_rename.go
+++ b/column_rename.go
@@ -84,7 +84,7 @@ func applyTableRenames(schema *Schema, cfg *MigrationConfig) (*Schema, error) {
 
 		sourceKey := normalizeTableFilterKey(renamed.Tables[tableIdx].SourceName)
 		if prev, ok := seenSourceTables[sourceKey]; ok {
-			return nil, fmt.Errorf("table_renames entries %q and %q both map to source table %s", prev, entry, sourceKey)
+			return nil, fmt.Errorf("table_renames entries %q and %q both map to source table %q", prev, entry, sourceKey)
 		}
 		seenSourceTables[sourceKey] = entry
 

--- a/column_rename.go
+++ b/column_rename.go
@@ -273,6 +273,9 @@ func canAutoRenameTableCollision(schema *Schema, group []int) bool {
 	hasOverLimitName := false
 	for _, tableIdx := range group {
 		table := schema.Tables[tableIdx]
+		// Keep both checks: identical generated names are exact collisions, while
+		// normalized remap keys catch case-only differences that PostgreSQL also
+		// treats as the same effective identifier.
 		if _, ok := seenPGNames[table.PGName]; ok {
 			return false
 		}

--- a/config.go
+++ b/config.go
@@ -67,6 +67,8 @@ type MigrationConfig struct {
 	IncludeTables                     []string               `toml:"include_tables"`
 	ExcludeTables                     []string               `toml:"exclude_tables"`
 	ExcludeColumns                    []string               `toml:"exclude_columns"`
+	TableRenames                      map[string]string      `toml:"table_renames"`
+	TableCollisionMode                string                 `toml:"table_collision_mode"` // error|auto
 	ColumnRenames                     map[string]string      `toml:"column_renames"`
 	ColumnCollisionMode               string                 `toml:"column_collision_mode"` // error|auto
 	OnSchemaExists                    string                 `toml:"on_schema_exists"`
@@ -197,6 +199,7 @@ func defaultMigrationConfig() MigrationConfig {
 		OnSchemaExists:      "error",
 		TableFilterMode:     "exact",
 		ColumnFilterMode:    "exact",
+		TableCollisionMode:  "error",
 		ColumnCollisionMode: "error",
 		TruncateBeforeCopy:  truncateBeforeCopyOff,
 		SourceSnapshotMode:  "none",
@@ -268,6 +271,15 @@ func finalizeConfig(cfg *MigrationConfig, configDir string) error {
 	case "snake", "lower", "preserve":
 	default:
 		return fmt.Errorf("identifier_case must be one of: snake, lower, preserve")
+	}
+	cfg.TableCollisionMode = strings.ToLower(strings.TrimSpace(cfg.TableCollisionMode))
+	if cfg.TableCollisionMode == "" {
+		cfg.TableCollisionMode = "error"
+	}
+	switch cfg.TableCollisionMode {
+	case "error", "auto":
+	default:
+		return fmt.Errorf("table_collision_mode must be one of: error, auto")
 	}
 	cfg.ColumnCollisionMode = strings.ToLower(strings.TrimSpace(cfg.ColumnCollisionMode))
 	if cfg.ColumnCollisionMode == "" {

--- a/config_test.go
+++ b/config_test.go
@@ -24,6 +24,7 @@ add_unsigned_checks = true
 replicate_on_update_current_timestamp = true
 workers = 8
 truncate_before_copy = true
+table_collision_mode = "auto"
 column_collision_mode = "auto"
 
 [source]
@@ -38,6 +39,9 @@ before_data = ["pre.sql"]
 after_data = []
 before_fk = ["cleanup.sql"]
 after_all = ["post.sql"]
+
+[table_renames]
+Orders = "order_records"
 
 [column_renames]
 "Orders.RowVersion" = "row_version_target"
@@ -87,6 +91,9 @@ after_all = ["post.sql"]
 	if cfg.TruncateBeforeCopy != truncateBeforeCopyPerRun {
 		t.Errorf("TruncateBeforeCopy = %s, want %s", cfg.TruncateBeforeCopy, truncateBeforeCopyPerRun)
 	}
+	if cfg.TableCollisionMode != "auto" {
+		t.Errorf("TableCollisionMode = %q, want auto", cfg.TableCollisionMode)
+	}
 	if cfg.ColumnCollisionMode != "auto" {
 		t.Errorf("ColumnCollisionMode = %q, want auto", cfg.ColumnCollisionMode)
 	}
@@ -95,6 +102,9 @@ after_all = ["post.sql"]
 	}
 	if cfg.ColumnRenames["Orders.RowVersion"] != "row_version_target" {
 		t.Errorf("ColumnRenames = %v", cfg.ColumnRenames)
+	}
+	if cfg.TableRenames["Orders"] != "order_records" {
+		t.Errorf("TableRenames = %v", cfg.TableRenames)
 	}
 	if cfg.configDir != dir {
 		t.Errorf("configDir = %q, want %q", cfg.configDir, dir)
@@ -160,6 +170,9 @@ dsn = "postgres://u:p@h:5432/db"
 	}
 	if cfg.IdentifierCase != "snake" {
 		t.Errorf("default IdentifierCase = %q, want %q", cfg.IdentifierCase, "snake")
+	}
+	if cfg.TableCollisionMode != "error" {
+		t.Errorf("default TableCollisionMode = %q, want %q", cfg.TableCollisionMode, "error")
 	}
 	if cfg.ColumnCollisionMode != "error" {
 		t.Errorf("default ColumnCollisionMode = %q, want %q", cfg.ColumnCollisionMode, "error")
@@ -2543,6 +2556,26 @@ func TestColumnCollisionMode_RejectsInvalid(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "column_collision_mode must be one of") {
 		t.Fatalf("error = %q, want column_collision_mode validation message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "auto") {
+		t.Fatalf("error = %q, want it to list auto as a valid value", err.Error())
+	}
+}
+
+func TestTableCollisionMode_RejectsInvalid(t *testing.T) {
+	cfg := defaultMigrationConfig()
+	cfg.Source.Type = "mysql"
+	cfg.Source.DSN = "user:pass@tcp(127.0.0.1:3306)/db"
+	cfg.Target.DSN = "postgres://u:p@127.0.0.1/db?sslmode=disable"
+	cfg.Schema = "public"
+	cfg.TableCollisionMode = "rename"
+
+	err := finalizeConfig(&cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for table_collision_mode = rename")
+	}
+	if !strings.Contains(err.Error(), "table_collision_mode must be one of") {
+		t.Fatalf("error = %q, want table_collision_mode validation message", err.Error())
 	}
 	if !strings.Contains(err.Error(), "auto") {
 		t.Fatalf("error = %q, want it to list auto as a valid value", err.Error())

--- a/identifier_validation.go
+++ b/identifier_validation.go
@@ -349,7 +349,7 @@ func validateGeneratedIdentifiers(schema *Schema, cfg *MigrationConfig, typeMap 
 		b.WriteString(strings.Join(collision.origins, "; "))
 		b.WriteByte('\n')
 	}
-	b.WriteString("Hint: use [column_renames] to choose explicit target names for conflicting source columns, rename the conflicting source objects, set identifier_case = \"preserve\" to keep original casing (PostgreSQL will quote them), fall back to identifier_case = \"lower\" if normalization caused the collision, or migrate the conflicting objects manually with hooks.")
+	b.WriteString("Hint: use [table_renames] or [column_renames] to choose explicit target names for conflicting source objects, rename the conflicting source objects, set identifier_case = \"preserve\" to keep original casing (PostgreSQL will quote them), fall back to identifier_case = \"lower\" if normalization caused the collision, or migrate the conflicting objects manually with hooks.")
 
 	return errors.New(b.String())
 }

--- a/main.go
+++ b/main.go
@@ -198,7 +198,7 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 		mode = "data_only"
 	}
 	log.Printf(
-		"config: mode=%s workers=%d index_workers=%d schema=%s on_schema_exists=%s source_snapshot_mode=%s unlogged_tables=%t preserve_defaults=%t add_unsigned_checks=%t clean_orphans=%t clean_orphans_mode=%s clean_orphans_max_rows=%d identifier_case=%s column_collision_mode=%s replicate_on_update_current_timestamp=%t truncate_before_copy=%s chunk_size=%d copy_risk_analysis=%t resume=%t validation=%s",
+		"config: mode=%s workers=%d index_workers=%d schema=%s on_schema_exists=%s source_snapshot_mode=%s unlogged_tables=%t preserve_defaults=%t add_unsigned_checks=%t clean_orphans=%t clean_orphans_mode=%s clean_orphans_max_rows=%d identifier_case=%s table_collision_mode=%s column_collision_mode=%s replicate_on_update_current_timestamp=%t truncate_before_copy=%s chunk_size=%d copy_risk_analysis=%t resume=%t validation=%s",
 		mode,
 		cfg.Workers,
 		cfg.IndexWorkers,
@@ -212,6 +212,7 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 		cfg.CleanOrphansMode,
 		cfg.CleanOrphansMaxRows,
 		cfg.IdentifierCase,
+		cfg.TableCollisionMode,
 		cfg.ColumnCollisionMode,
 		cfg.ReplicateOnUpdateCurrentTimestamp,
 		cfg.TruncateBeforeCopy,
@@ -287,11 +288,14 @@ func runMigrationWithConfig(cfg *MigrationConfig, opts MigrateOptions) (err erro
 			log.Printf("column filter: resume enabled; changing column_filter_mode/exclude_columns between runs can invalidate the checkpoint")
 		}
 	}
-	renamedSchema, err := applyColumnRenames(schema, cfg)
+	renamedSchema, err := applySchemaRenames(schema, cfg)
 	if err != nil {
-		return fmt.Errorf("apply column renames: %w", err)
+		return err
 	}
 	schema = renamedSchema
+	if hasTableRenames(cfg) && cfg.Resume {
+		log.Printf("table renames: resume enabled; changing table_renames between runs can invalidate the checkpoint")
+	}
 	if hasColumnRenames(cfg) && cfg.Resume {
 		log.Printf("column renames: resume enabled; changing column_renames between runs can invalidate the checkpoint")
 	}

--- a/plan.go
+++ b/plan.go
@@ -657,7 +657,7 @@ func buildPlanSummary(schema *Schema, cfg *MigrationConfig, dbName string, copyR
 		CleanOrphans:        cfg.CleanOrphans,
 		IdentifierCase:      cfg.IdentifierCase,
 		TableCollisionMode:  collisionModeOrDefault(cfg.TableCollisionMode),
-		ColumnCollisionMode: columnCollisionModeOrDefault(cfg.ColumnCollisionMode),
+		ColumnCollisionMode: collisionModeOrDefault(cfg.ColumnCollisionMode),
 	}
 	if schema != nil {
 		s.TableCount = len(schema.Tables)
@@ -719,10 +719,6 @@ func sumCopyRiskEstimatedRowsByTable(findings []PlanCopyRiskFinding) int64 {
 // struct; SourceType stays empty so we skip printing an empty Summary section.
 func planSummaryHasData(s PlanSummary) bool {
 	return s.SourceType != ""
-}
-
-func columnCollisionModeOrDefault(mode string) string {
-	return collisionModeOrDefault(mode)
 }
 
 func collisionModeOrDefault(mode string) string {
@@ -985,7 +981,7 @@ func writePlanText(w io.Writer, report *PlanReport) {
 		fmt.Fprintf(w, "Config: workers=%d index_workers=%d chunk_size=%d resume=%t validation=%s\n",
 			s.Workers, s.IndexWorkers, s.ChunkSize, s.Resume, s.Validation)
 		fmt.Fprintf(w, "        source_snapshot_mode=%s copy_risk_analysis=%t unlogged_tables=%t preserve_defaults=%t clean_orphans=%t identifier_case=%s table_collision_mode=%s column_collision_mode=%s\n",
-			s.SnapshotMode, s.CopyRiskAnalysis, s.UnloggedTables, s.PreserveDefaults, s.CleanOrphans, s.IdentifierCase, collisionModeOrDefault(s.TableCollisionMode), columnCollisionModeOrDefault(s.ColumnCollisionMode))
+			s.SnapshotMode, s.CopyRiskAnalysis, s.UnloggedTables, s.PreserveDefaults, s.CleanOrphans, s.IdentifierCase, collisionModeOrDefault(s.TableCollisionMode), collisionModeOrDefault(s.ColumnCollisionMode))
 		fmt.Fprintln(w)
 		writePlanETAText(w, report.ETA)
 	}

--- a/plan.go
+++ b/plan.go
@@ -191,6 +191,7 @@ type PlanSummary struct {
 	PreserveDefaults    bool   `json:"preserve_defaults"`
 	CleanOrphans        bool   `json:"clean_orphans"`
 	IdentifierCase      string `json:"identifier_case"`
+	TableCollisionMode  string `json:"table_collision_mode"`
 	ColumnCollisionMode string `json:"column_collision_mode"`
 }
 
@@ -507,9 +508,9 @@ func runPlanWithConfig(cfg *MigrationConfig, out io.Writer, opts PlanOptions) er
 	if hasColumnFilters(cfg) {
 		logColumnFilterReport(columnFilterReport)
 	}
-	renamedSchema, err := applyColumnRenames(schema, cfg)
+	renamedSchema, err := applySchemaRenames(schema, cfg)
 	if err != nil {
-		return fmt.Errorf("apply column renames: %w", err)
+		return err
 	}
 	schema = renamedSchema
 
@@ -655,6 +656,7 @@ func buildPlanSummary(schema *Schema, cfg *MigrationConfig, dbName string, copyR
 		PreserveDefaults:    cfg.PreserveDefaults,
 		CleanOrphans:        cfg.CleanOrphans,
 		IdentifierCase:      cfg.IdentifierCase,
+		TableCollisionMode:  collisionModeOrDefault(cfg.TableCollisionMode),
 		ColumnCollisionMode: columnCollisionModeOrDefault(cfg.ColumnCollisionMode),
 	}
 	if schema != nil {
@@ -720,6 +722,10 @@ func planSummaryHasData(s PlanSummary) bool {
 }
 
 func columnCollisionModeOrDefault(mode string) string {
+	return collisionModeOrDefault(mode)
+}
+
+func collisionModeOrDefault(mode string) string {
 	if mode != "" {
 		return mode
 	}
@@ -978,8 +984,8 @@ func writePlanText(w io.Writer, report *PlanReport) {
 		}
 		fmt.Fprintf(w, "Config: workers=%d index_workers=%d chunk_size=%d resume=%t validation=%s\n",
 			s.Workers, s.IndexWorkers, s.ChunkSize, s.Resume, s.Validation)
-		fmt.Fprintf(w, "        source_snapshot_mode=%s copy_risk_analysis=%t unlogged_tables=%t preserve_defaults=%t clean_orphans=%t identifier_case=%s column_collision_mode=%s\n",
-			s.SnapshotMode, s.CopyRiskAnalysis, s.UnloggedTables, s.PreserveDefaults, s.CleanOrphans, s.IdentifierCase, columnCollisionModeOrDefault(s.ColumnCollisionMode))
+		fmt.Fprintf(w, "        source_snapshot_mode=%s copy_risk_analysis=%t unlogged_tables=%t preserve_defaults=%t clean_orphans=%t identifier_case=%s table_collision_mode=%s column_collision_mode=%s\n",
+			s.SnapshotMode, s.CopyRiskAnalysis, s.UnloggedTables, s.PreserveDefaults, s.CleanOrphans, s.IdentifierCase, collisionModeOrDefault(s.TableCollisionMode), columnCollisionModeOrDefault(s.ColumnCollisionMode))
 		fmt.Fprintln(w)
 		writePlanETAText(w, report.ETA)
 	}

--- a/plan_test.go
+++ b/plan_test.go
@@ -60,6 +60,9 @@ func TestBuildPlanSummary_TotalEstimatedRows(t *testing.T) {
 	if got := summary.ColumnCollisionMode; got != "error" {
 		t.Fatalf("ColumnCollisionMode = %q, want error", got)
 	}
+	if got := summary.TableCollisionMode; got != "error" {
+		t.Fatalf("TableCollisionMode = %q, want error", got)
+	}
 	if got := buildPlanSummary(schema, cfg, "main", risks, nil, true).TotalEstimatedRows; got != 1_000_000 {
 		t.Fatalf("copy risk enabled: TotalEstimatedRows = %d, want 1000000", got)
 	}

--- a/site/src/content/docs/get-started/advanced-options.md
+++ b/site/src/content/docs/get-started/advanced-options.md
@@ -100,23 +100,27 @@ exclude_columns = ["RowVersion", "audit_*.sys_*"]
 
 When a column is excluded, pgferry omits it from schema creation and data COPY. Primary keys, plain-column indexes, and foreign keys that reference excluded columns are skipped. pgferry cannot inspect arbitrary expression index definitions for excluded column references; expression indexes are already reported as unsupported and skipped separately.
 
-To keep a source column but choose its target PostgreSQL name explicitly, use `column_renames`:
+To keep source objects but choose their target PostgreSQL names explicitly, use `table_renames` and `column_renames`:
 
 ```toml
+[table_renames]
+KP_SUMINA = "reserve_summary"
+
 [column_renames]
 "KP_SUMINA.% ставка резерва по категории качества" = "reserve_rate_quality"
 "KP_SUMINA.% ставка резерва по категории качества КД" = "reserve_rate_quality_kd"
 ```
 
-Rename keys use source `TableName.ColumnName` values after table and column filters. Rename values are final PostgreSQL column names, so pgferry does not apply `identifier_case` to them, and they must fit PostgreSQL's 63-byte identifier limit. This is useful when two long source column names would otherwise collide after PostgreSQL's identifier limit.
+Rename keys use source table names and source `TableName.ColumnName` values after table and column filters. Rename values are final PostgreSQL table or column names, so pgferry does not apply `identifier_case` to them, and they must fit PostgreSQL's 63-byte identifier limit. This is useful when long source object names would otherwise collide after PostgreSQL's identifier limit.
 
-If many long columns collide only because PostgreSQL truncates identifiers to 63 bytes, opt into deterministic automatic names:
+If many long tables or columns collide only because PostgreSQL truncates identifiers to 63 bytes, opt into deterministic automatic names:
 
 ```toml
+table_collision_mode = "auto"
 column_collision_mode = "auto"
 ```
 
-Explicit `column_renames` still take precedence. Automatic renames are limited to truncation-only column collisions within a table; exact generated-name collisions and non-column object collisions still stop with an error so you can choose the target names deliberately.
+Explicit `table_renames` and `column_renames` still take precedence. Automatic renames are limited to truncation-only table collisions within the target schema and truncation-only column collisions within a table; exact generated-name collisions and other object collisions still stop with an error so you can choose the target names deliberately.
 
 - [How to read plan output](/operations/how-to-read-plan-output/)
 

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -144,7 +144,7 @@ Table filters always match source table names, not the transformed PostgreSQL na
 
 Column filters also match source names, not transformed PostgreSQL names. When a column is excluded, pgferry omits it from `CREATE TABLE`, source `SELECT`, and target `COPY`. Primary keys, plain-column indexes, and foreign keys that reference excluded columns are skipped. pgferry cannot inspect arbitrary expression index definitions for excluded column references; expression indexes are already reported as unsupported and skipped separately. If a filter entry matches no source column in the migrated schema, pgferry fails early.
 
-Table renames override the target PostgreSQL name for a source table without changing source reads. Keys are source table names matched case-insensitively after table filters. Values are not passed through `identifier_case`; they are used as the final quoted PostgreSQL names and must fit PostgreSQL's 63-byte identifier limit. Foreign keys are updated to reference renamed target tables.
+Table renames override the target PostgreSQL name for a source table without changing source reads. Keys are source table names matched case-insensitively after table filters; schema-qualified keys such as `dbo.Orders` are not supported. Values are not passed through `identifier_case`; they are used as the final quoted PostgreSQL names and must fit PostgreSQL's 63-byte identifier limit. Foreign keys are updated to reference renamed target tables.
 
 ```toml
 [table_renames]

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -115,6 +115,8 @@ Why: this is the fastest full-load path when the target schema can be dropped an
 | `include_tables` | array of strings | `[]` | If non-empty, only migrate these source tables. Entries are exact names by default, or glob patterns when `table_filter_mode = "glob"`. |
 | `exclude_tables` | array of strings | `[]` | Source tables to skip. Applied after `include_tables`, so excludes win when both match the same table. |
 | `exclude_columns` | array of strings | `[]` | Source columns to skip. Use `ColumnName` to skip matching columns in any table, or `TableName.ColumnName` to scope a rule to one source table. Entries are exact by default, or glob patterns in either the table or column part when `column_filter_mode = "glob"`. |
+| `[table_renames]` | table of strings | `{}` | Explicit target table names keyed by source table name. Values are final PostgreSQL table names and are applied after table filters. |
+| `table_collision_mode` | string | `"error"` | `"error"` reports generated PostgreSQL identifier collisions. `"auto"` automatically renames truncation-only table collisions within the target schema using deterministic hashed names. |
 | `[column_renames]` | table of strings | `{}` | Explicit target column names keyed by source `TableName.ColumnName`. Values are final PostgreSQL column names and are applied after table and column filters. |
 | `column_collision_mode` | string | `"error"` | `"error"` reports generated PostgreSQL identifier collisions. `"auto"` automatically renames truncation-only column collisions within a table using deterministic hashed names. |
 | `on_schema_exists` | string | `"error"` | `"error"` aborts if the schema exists. `"recreate"` drops and recreates it. `"use"` requires the schema to already exist and be empty, then pgferry creates objects inside it. |
@@ -142,6 +144,13 @@ Table filters always match source table names, not the transformed PostgreSQL na
 
 Column filters also match source names, not transformed PostgreSQL names. When a column is excluded, pgferry omits it from `CREATE TABLE`, source `SELECT`, and target `COPY`. Primary keys, plain-column indexes, and foreign keys that reference excluded columns are skipped. pgferry cannot inspect arbitrary expression index definitions for excluded column references; expression indexes are already reported as unsupported and skipped separately. If a filter entry matches no source column in the migrated schema, pgferry fails early.
 
+Table renames override the target PostgreSQL name for a source table without changing source reads. Keys are source table names matched case-insensitively after table filters. Values are not passed through `identifier_case`; they are used as the final quoted PostgreSQL names and must fit PostgreSQL's 63-byte identifier limit. Foreign keys are updated to reference renamed target tables.
+
+```toml
+[table_renames]
+KP_SUMINA = "reserve_summary"
+```
+
 Column renames override the target PostgreSQL name for a source column without changing source reads. Keys must be source-qualified as `TableName.ColumnName`, matched case-insensitively after table and column filters; schema-qualified keys such as `dbo.Table.Column` are not supported. Values are not passed through `identifier_case`; they are used as the final quoted PostgreSQL names and must fit PostgreSQL's 63-byte identifier limit. Primary keys, plain-column indexes, and foreign keys are updated to reference the renamed target columns.
 
 ```toml
@@ -150,15 +159,16 @@ Column renames override the target PostgreSQL name for a source column without c
 "KP_SUMINA.% ставка резерва по категории качества КД" = "reserve_rate_quality_kd"
 ```
 
-For large schemas with many long source column names, `column_collision_mode = "auto"` can resolve PostgreSQL truncation collisions without listing every column manually:
+For large schemas with many long source table or column names, the automatic collision modes can resolve PostgreSQL truncation collisions without listing every object manually:
 
 ```toml
+table_collision_mode = "auto"
 column_collision_mode = "auto"
 ```
 
-Automatic collision renames are applied after explicit `[column_renames]`, so explicit mappings take precedence. pgferry only auto-renames column groups whose generated names are distinct before PostgreSQL's 63-byte truncation but collide after that limit. Exact generated-name collisions, table/index/constraint/type collisions, and ambiguous column references still fail and require explicit renames or manual handling. Each generated target name uses a UTF-8-safe prefix plus a stable hash and is logged during planning, validation, and migration.
+Automatic collision renames are applied after explicit `[table_renames]` and `[column_renames]`, so explicit mappings take precedence. pgferry only auto-renames table groups or column groups whose generated names are distinct before PostgreSQL's 63-byte truncation but collide after that limit. Exact generated-name collisions, index/constraint/type collisions, and ambiguous references still fail and require explicit renames or manual handling. Each generated target name uses a UTF-8-safe prefix plus a stable hash and is logged during planning, validation, and migration.
 
-Changing `table_filter_mode`, `include_tables`, `exclude_tables`, `column_filter_mode`, `exclude_columns`, `column_renames`, or `column_collision_mode` can change the selected migration scope or target schema. When `resume = true`, that can invalidate the checkpoint fingerprint and force a fresh run.
+Changing `table_filter_mode`, `include_tables`, `exclude_tables`, `table_renames`, `table_collision_mode`, `column_filter_mode`, `exclude_columns`, `column_renames`, or `column_collision_mode` can change the selected migration scope or target schema. When `resume = true`, that can invalidate the checkpoint fingerprint and force a fresh run.
 
 `truncate_before_copy = true` follows the selected table scope after filters. Excluded tables are not named in pgferry's generated `TRUNCATE TABLE ...` statement. pgferry intentionally omits `CASCADE` so PostgreSQL will fail rather than silently truncating dependent tables outside the selected scope.
 

--- a/site/src/content/docs/reference/conventions-and-limitations.md
+++ b/site/src/content/docs/reference/conventions-and-limitations.md
@@ -26,9 +26,9 @@ Examples:
 
 PostgreSQL SQL is emitted as `"app"."users"` rather than `app.users` under all three modes.
 
-PostgreSQL compares only the first 63 bytes of an identifier. pgferry checks generated names using that effective PostgreSQL limit and reports collisions before running target DDL. If two source column names still collide after the selected `identifier_case` mode, use `[column_renames]` to choose explicit target names for those source columns.
+PostgreSQL compares only the first 63 bytes of an identifier. pgferry checks generated names using that effective PostgreSQL limit and reports collisions before running target DDL. If source table or column names still collide after the selected `identifier_case` mode, use `[table_renames]` or `[column_renames]` to choose explicit target names.
 
-For bulk cases where distinct long column names collide only after PostgreSQL truncation, set `column_collision_mode = "auto"` to let pgferry generate deterministic hashed target names. This mode is intentionally narrow: exact generated-name collisions and non-column object collisions still require explicit renames or manual handling.
+For bulk cases where distinct long table or column names collide only after PostgreSQL truncation, set `table_collision_mode = "auto"` or `column_collision_mode = "auto"` to let pgferry generate deterministic hashed target names. These modes are intentionally narrow: exact generated-name collisions and other object collisions still require explicit renames or manual handling.
 
 ## Auto-increment and sequences
 

--- a/table_rename_test.go
+++ b/table_rename_test.go
@@ -258,7 +258,7 @@ func TestApplyTableRenames_RejectsDuplicateSourceTableMapping(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), `both map to source table orders`) {
+	if !strings.Contains(err.Error(), `both map to source table "orders"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/table_rename_test.go
+++ b/table_rename_test.go
@@ -206,6 +206,21 @@ func TestApplyTableRenames_RejectsEmptyTargetName(t *testing.T) {
 	}
 }
 
+func TestApplyTableRenames_RejectsTargetNameOverPostgresLimit(t *testing.T) {
+	schema := &Schema{Tables: []Table{{SourceName: "Orders", PGName: "orders"}}}
+	cfg := &MigrationConfig{
+		TableRenames: map[string]string{"Orders": strings.Repeat("x", postgresMaxIdentifierBytes+1)},
+	}
+
+	_, err := applyTableRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "exceeds PostgreSQL's 63-byte identifier limit") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestApplyTableRenames_RejectsDuplicateSourceTableMapping(t *testing.T) {
 	schema := &Schema{Tables: []Table{{SourceName: "Orders", PGName: "orders"}}}
 	cfg := &MigrationConfig{

--- a/table_rename_test.go
+++ b/table_rename_test.go
@@ -154,6 +154,28 @@ func TestApplyTableRenames_AutoKeepsExplicitRename(t *testing.T) {
 	}
 }
 
+func TestApplyTableRenames_AutoDoesNotGuessExactGeneratedNameCollision(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{SourceName: "TableA", PGName: "same_name"},
+			{SourceName: "TableB", PGName: "same_name"},
+		},
+	}
+	cfg := &MigrationConfig{TableCollisionMode: "auto"}
+
+	renamed, err := applyTableRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyTableRenames() error: %v", err)
+	}
+	err = validateGeneratedIdentifiers(renamed, &MigrationConfig{}, defaultTypeMappingConfig())
+	if err == nil {
+		t.Fatal("expected exact generated-name collision to remain an error in auto mode")
+	}
+	if !strings.Contains(err.Error(), `schema relation names: final name "same_name"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestApplyTableRenames_RejectsUnknownTable(t *testing.T) {
 	schema := &Schema{Tables: []Table{{SourceName: "Orders", PGName: "orders"}}}
 	cfg := &MigrationConfig{

--- a/table_rename_test.go
+++ b/table_rename_test.go
@@ -154,6 +154,30 @@ func TestApplyTableRenames_AutoKeepsExplicitRename(t *testing.T) {
 	}
 }
 
+func TestApplyTableRenames_ExplicitRenameCollisionIsValidated(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{SourceName: "Orders", PGName: "orders"},
+			{SourceName: "Customers", PGName: "customer_records"},
+		},
+	}
+	cfg := &MigrationConfig{
+		TableRenames: map[string]string{"Orders": "customer_records"},
+	}
+
+	renamed, err := applyTableRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyTableRenames() error: %v", err)
+	}
+	err = validateGeneratedIdentifiers(renamed, &MigrationConfig{}, defaultTypeMappingConfig())
+	if err == nil {
+		t.Fatal("expected explicit rename collision to be rejected by identifier validation")
+	}
+	if !strings.Contains(err.Error(), `schema relation names: final name "customer_records"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestApplyTableRenames_AutoDoesNotGuessExactGeneratedNameCollision(t *testing.T) {
 	schema := &Schema{
 		Tables: []Table{

--- a/table_rename_test.go
+++ b/table_rename_test.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyTableRenames_UpdatesTableNamesAndForeignKeyReferences(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "Parents",
+				PGName:     "parents",
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+			{
+				SourceName: "Children",
+				PGName:     "children",
+				Columns:    []Column{{SourceName: "ParentID", PGName: "parent_id"}},
+				ForeignKeys: []ForeignKey{
+					{
+						Name:       "fk_children_parents",
+						Columns:    []string{"parent_id"},
+						RefTable:   "Parents",
+						RefPGTable: "parents",
+						RefColumns: []string{"id"},
+					},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{
+		TableRenames: map[string]string{
+			"Parents":  "parent_records",
+			"Children": "child_records",
+		},
+	}
+
+	renamed, err := applyTableRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyTableRenames() error: %v", err)
+	}
+
+	if got := renamed.Tables[0].PGName; got != "parent_records" {
+		t.Fatalf("parent table PGName = %q, want parent_records", got)
+	}
+	if got := renamed.Tables[1].PGName; got != "child_records" {
+		t.Fatalf("child table PGName = %q, want child_records", got)
+	}
+	if got := renamed.Tables[1].ForeignKeys[0].RefPGTable; got != "parent_records" {
+		t.Fatalf("child FK RefPGTable = %q, want parent_records", got)
+	}
+	if got := renamed.Tables[1].ForeignKeys[0].RefTable; got != "Parents" {
+		t.Fatalf("child FK RefTable = %q, want source name Parents", got)
+	}
+	if got := schema.Tables[0].PGName; got != "parents" {
+		t.Fatalf("original schema mutated: parent PGName = %q", got)
+	}
+	if got := schema.Tables[1].ForeignKeys[0].RefPGTable; got != "parents" {
+		t.Fatalf("original schema mutated: child FK RefPGTable = %q", got)
+	}
+}
+
+func TestApplyTableRenames_AutoResolvesPostgresTruncationCollision(t *testing.T) {
+	first := "orders_with_a_source_name_that_is_long_enough_to_collide_after_postgresql_truncation_a"
+	second := "orders_with_a_source_name_that_is_long_enough_to_collide_after_postgresql_truncation_b"
+	schema := &Schema{
+		Tables: []Table{
+			{
+				SourceName: "OrdersA",
+				PGName:     first,
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+			},
+			{
+				SourceName: "OrdersB",
+				PGName:     second,
+				Columns:    []Column{{SourceName: "ID", PGName: "id"}},
+				ForeignKeys: []ForeignKey{
+					{
+						Name:       "fk_orders_b_orders_a",
+						Columns:    []string{"id"},
+						RefTable:   "OrdersA",
+						RefPGTable: first,
+						RefColumns: []string{"id"},
+					},
+				},
+			},
+		},
+	}
+	cfg := &MigrationConfig{TableCollisionMode: "auto"}
+
+	renamed, err := applyTableRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyTableRenames() error: %v", err)
+	}
+
+	firstTarget := renamed.Tables[0].PGName
+	secondTarget := renamed.Tables[1].PGName
+	if firstTarget == first {
+		t.Fatalf("first colliding table was not renamed")
+	}
+	if secondTarget == second {
+		t.Fatalf("second colliding table was not renamed")
+	}
+	if len(firstTarget) > postgresMaxIdentifierBytes {
+		t.Fatalf("first auto-renamed table length = %d, want <= %d", len(firstTarget), postgresMaxIdentifierBytes)
+	}
+	if len(secondTarget) > postgresMaxIdentifierBytes {
+		t.Fatalf("second auto-renamed table length = %d, want <= %d", len(secondTarget), postgresMaxIdentifierBytes)
+	}
+	if postgresIdentifierKey(firstTarget) == postgresIdentifierKey(secondTarget) {
+		t.Fatalf("auto-renamed tables still collide: %q and %q", firstTarget, secondTarget)
+	}
+	if got := renamed.Tables[1].ForeignKeys[0].RefPGTable; got != firstTarget {
+		t.Fatalf("child FK RefPGTable = %q, want %q", got, firstTarget)
+	}
+	if got := schema.Tables[0].PGName; got != first {
+		t.Fatalf("original schema mutated: first PGName = %q", got)
+	}
+	if err := validateGeneratedIdentifiers(renamed, &MigrationConfig{}, defaultTypeMappingConfig()); err != nil {
+		t.Fatalf("validateGeneratedIdentifiers() error: %v", err)
+	}
+}
+
+func TestApplyTableRenames_AutoKeepsExplicitRename(t *testing.T) {
+	explicitTarget := strings.Repeat("t", postgresMaxIdentifierBytes)
+	collidingGeneratedName := explicitTarget + "_source_suffix"
+	schema := &Schema{
+		Tables: []Table{
+			{SourceName: "ExplicitOrders", PGName: "explicit_orders"},
+			{SourceName: "GeneratedOrders", PGName: collidingGeneratedName},
+		},
+	}
+	cfg := &MigrationConfig{
+		TableCollisionMode: "auto",
+		TableRenames: map[string]string{
+			"ExplicitOrders": explicitTarget,
+		},
+	}
+
+	renamed, err := applyTableRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyTableRenames() error: %v", err)
+	}
+
+	if got := renamed.Tables[0].PGName; got != explicitTarget {
+		t.Fatalf("explicitly renamed table PGName = %q, want %q", got, explicitTarget)
+	}
+	if got := renamed.Tables[1].PGName; got == collidingGeneratedName {
+		t.Fatalf("non-explicit colliding table was not auto-renamed")
+	}
+	if postgresIdentifierKey(renamed.Tables[0].PGName) == postgresIdentifierKey(renamed.Tables[1].PGName) {
+		t.Fatalf("auto-renamed table still collides with explicit rename: %q and %q", renamed.Tables[0].PGName, renamed.Tables[1].PGName)
+	}
+}
+
+func TestApplyTableRenames_RejectsUnknownTable(t *testing.T) {
+	schema := &Schema{Tables: []Table{{SourceName: "Orders", PGName: "orders"}}}
+	cfg := &MigrationConfig{
+		TableRenames: map[string]string{"Customers": "customer_records"},
+	}
+
+	_, err := applyTableRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "table_renames entries did not match any source table in the migrated schema") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyTableRenames_RejectsEmptyTargetName(t *testing.T) {
+	schema := &Schema{Tables: []Table{{SourceName: "Orders", PGName: "orders"}}}
+	cfg := &MigrationConfig{
+		TableRenames: map[string]string{"Orders": "   "},
+	}
+
+	_, err := applyTableRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `table_renames entry "Orders" has an empty target table name`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyTableRenames_RejectsDuplicateSourceTableMapping(t *testing.T) {
+	schema := &Schema{Tables: []Table{{SourceName: "Orders", PGName: "orders"}}}
+	cfg := &MigrationConfig{
+		TableRenames: map[string]string{
+			"Orders": "order_records",
+			"orders": "order_records_again",
+		},
+	}
+
+	_, err := applyTableRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `both map to source table orders`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyTableRenames_MatchesSourceNamesCaseInsensitively(t *testing.T) {
+	schema := &Schema{Tables: []Table{{SourceName: "Orders", PGName: "orders"}}}
+	cfg := &MigrationConfig{
+		TableRenames: map[string]string{"orders": "order_records"},
+	}
+
+	renamed, err := applyTableRenames(schema, cfg)
+	if err != nil {
+		t.Fatalf("applyTableRenames() error: %v", err)
+	}
+	if got := renamed.Tables[0].PGName; got != "order_records" {
+		t.Fatalf("table PGName = %q, want order_records", got)
+	}
+}
+
+func TestApplyTableRenames_RejectsAmbiguousTableNames(t *testing.T) {
+	schema := &Schema{
+		Tables: []Table{
+			{SourceName: "Orders", PGName: "orders"},
+			{SourceName: "orders", PGName: "orders_lower"},
+		},
+	}
+	cfg := &MigrationConfig{
+		TableRenames: map[string]string{"Orders": "order_records"},
+	}
+
+	_, err := applyTableRenames(schema, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "source schema contains ambiguous table names") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyTableRenames_NilSchemaReturnsNil(t *testing.T) {
+	renamed, err := applyTableRenames(nil, &MigrationConfig{
+		TableRenames: map[string]string{"Orders": "order_records"},
+	})
+	if err != nil {
+		t.Fatalf("applyTableRenames() error: %v", err)
+	}
+	if renamed != nil {
+		t.Fatalf("renamed schema = %#v, want nil", renamed)
+	}
+}

--- a/validate_cmd.go
+++ b/validate_cmd.go
@@ -143,9 +143,9 @@ func loadValidateSchema(ctx context.Context, src SourceDB, pgPool *pgxpool.Pool,
 	if hasColumnFilters(cfg) {
 		logColumnFilterReport(columnFilterReport)
 	}
-	renamedSchema, err := applyColumnRenames(filteredSchema, cfg)
+	renamedSchema, err := applySchemaRenames(filteredSchema, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("apply column renames: %w", err)
+		return nil, err
 	}
 	return renamedSchema, nil
 }


### PR DESCRIPTION
## Summary

Adds table name remapping support to match the existing column remapping behavior.

- Adds `table_renames` for explicit source-table to target-table names.
- Adds `table_collision_mode = "auto"` for deterministic automatic fixes for PostgreSQL 63-byte truncation table collisions.
- Remaps foreign key target table references after table renames so generated DDL points at renamed tables.
- Reuses the shared rename stage in migrate, plan, and standalone validate paths.
- Updates config docs and identifier collision guidance.

## Impact

Users can now resolve target table naming conflicts manually or automatically without changing source table reads. Explicit table renames are keyed by source table name and take precedence over automatic collision renames.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go build -o build/pgferry .`
- `cd site && bun run build`
- `cd site && bun run check-routes`

Note: the docs build emits the existing Astro markdown plugin deprecation warning, but exits successfully.