### PR TITLE
docs: verify migration guides for accuracy + lighter tone

### DIFF
--- a/site/src/content/docs/examples/index.md
+++ b/site/src/content/docs/examples/index.md
@@ -3,7 +3,7 @@ title: Examples
 description: Copy-pasteable pgferry migration.toml examples for MySQL, MariaDB, SQLite, and MSSQL — grouped by source database and migration pattern.
 ---
 
-Use the examples section when you want a working starting point instead of an abstract reference page.
+Reach for the examples when you'd rather start from something that already works than from an abstract reference page.
 
 ## Pick by situation
 

--- a/site/src/content/docs/examples/mariadb/index.md
+++ b/site/src/content/docs/examples/mariadb/index.md
@@ -3,7 +3,7 @@ title: MariaDB Examples
 description: MariaDB-to-PostgreSQL example with explicit source.type = mariadb, MySQL-family type mapping, and spatial fallback since PostGIS is unsupported.
 ---
 
-MariaDB is a first-class source type in `pgferry`, even though the example surface is intentionally smaller than MySQL.
+MariaDB is a first-class source in `pgferry` — the example set here is just smaller than MySQL's on purpose.
 
 ## Start here
 

--- a/site/src/content/docs/examples/mssql/index.md
+++ b/site/src/content/docs/examples/mssql/index.md
@@ -3,7 +3,7 @@ title: MSSQL Examples
 description: MSSQL-to-PostgreSQL examples covering safe and fast-rebuild templates, dbo schema defaults, money-to-numeric, and uniqueidentifier handling.
 ---
 
-MSSQL support currently has two main operational templates: the safe default and the disposable fast path.
+MSSQL comes with two go-to templates: the safe default and the disposable fast path.
 
 ## Start here
 

--- a/site/src/content/docs/examples/mysql/index.md
+++ b/site/src/content/docs/examples/mysql/index.md
@@ -3,7 +3,7 @@ title: MySQL Examples
 description: MySQL-to-PostgreSQL examples — minimal-safe, recreate-fast, chunked-resume, hooks, schema-only, data-only, and the Sakila sample migration.
 ---
 
-MySQL has the broadest example surface because it exercises the most pgferry features.
+MySQL has the widest range of examples here — it exercises the most pgferry features, so there's the most to show.
 
 ## Start here
 

--- a/site/src/content/docs/examples/mysql/sakila.md
+++ b/site/src/content/docs/examples/mysql/sakila.md
@@ -5,7 +5,7 @@ description: End-to-end MySQL Sakila sample migration to PostgreSQL with a befor
 
 ## Why this example matters
 
-This is the most complete MySQL playbook in the repo: a real sample schema, a `before_fk` cleanup hook, and an `after_all` view plus `ANALYZE` pass.
+This is the most complete MySQL walkthrough in the repo — a real sample schema, a `before_fk` cleanup hook, and an `after_all` view plus `ANALYZE` pass, all in one run.
 
 ## `migration.toml`
 

--- a/site/src/content/docs/examples/sqlite/index.md
+++ b/site/src/content/docs/examples/sqlite/index.md
@@ -3,7 +3,7 @@ title: SQLite Examples
 description: SQLite-to-PostgreSQL examples — minimal-safe, recreate-fast, chunked-resume, hooks, schema-only, and data-only configs for migrating a .db file.
 ---
 
-SQLite is operationally simpler than MySQL or MSSQL, but the examples still map to the same major migration decisions.
+SQLite is the simplest of the bunch to operate, but the examples still cover the same big migration decisions.
 
 ## Start here
 

--- a/site/src/content/docs/guides/aws-rds-mysql-to-neon.md
+++ b/site/src/content/docs/guides/aws-rds-mysql-to-neon.md
@@ -3,7 +3,7 @@ title: AWS RDS MySQL to Neon
 description: AWS RDS MySQL to Neon migration playbook — pgferry moves RDS or Aurora MySQL to Neon serverless Postgres via security groups, RDS CA TLS, and scale-to-zero.
 ---
 
-This is an operator's playbook for an **AWS RDS MySQL to Neon** migration. It covers the RDS side — security-group access, the Amazon RDS certificate authority, and reading from a replica — together with the Neon endpoint and scale-to-zero details you need to move [Amazon RDS for MySQL](https://aws.amazon.com/rds/mysql/) (or Aurora MySQL) into [Neon](https://neon.com/)'s serverless PostgreSQL.
+This is an operator's playbook for an **AWS RDS MySQL to Neon** migration. It covers the RDS side — security-group access, the Amazon RDS certificate authority, and reading from a replica — together with the Neon endpoint and scale-to-zero details that carry [Amazon RDS for MySQL](https://aws.amazon.com/rds/mysql/) (or Aurora MySQL) into [Neon](https://neon.com/)'s serverless PostgreSQL in one piece.
 
 If you searched for how to **migrate RDS MySQL to Neon** or move **AWS RDS MySQL to Neon Postgres**, the short version is: open the RDS security group to your migration host, connect with TLS, optionally read from an RDS read replica, point `pgferry` at Neon's **unpooled (direct)** endpoint, and disable scale-to-zero for the load.
 
@@ -139,4 +139,3 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
 - Other destinations: [AWS RDS MySQL to Supabase](/guides/aws-rds-mysql-to-supabase/) · [MySQL to Neon](/guides/mysql-to-neon/) · [Cloud SQL for MySQL to Neon](/guides/cloud-sql-mysql-to-neon/) · [PlanetScale to Neon](/guides/planetscale-to-neon/)
-</content>

--- a/site/src/content/docs/guides/aws-rds-mysql-to-supabase.md
+++ b/site/src/content/docs/guides/aws-rds-mysql-to-supabase.md
@@ -3,7 +3,7 @@ title: AWS RDS MySQL to Supabase
 description: AWS RDS MySQL to Supabase migration playbook — pgferry moves RDS or Aurora MySQL to Supabase Postgres via security groups, RDS CA TLS, and the session pooler.
 ---
 
-This is an operator's playbook for an **AWS RDS MySQL to Supabase** migration. It covers the RDS side — security-group access, the Amazon RDS certificate authority, and reading from a replica — together with the Supabase connection and timeout setup you need to move [Amazon RDS for MySQL](https://aws.amazon.com/rds/mysql/) (or Aurora MySQL) into [Supabase](https://supabase.com/) PostgreSQL.
+This is an operator's playbook for an **AWS RDS MySQL to Supabase** migration. It covers the RDS side — security-group access, the Amazon RDS certificate authority, and reading from a replica — together with the Supabase connection and timeout setup that carry [Amazon RDS for MySQL](https://aws.amazon.com/rds/mysql/) (or Aurora MySQL) into [Supabase](https://supabase.com/) PostgreSQL in one piece.
 
 If you searched for how to **migrate RDS MySQL to Supabase** or move **AWS RDS MySQL to Supabase Postgres**, the short version is: open the RDS security group to your migration host, connect with TLS, optionally read from an RDS read replica, point `pgferry` at Supabase's session pooler, and raise the `postgres` role statement timeout for the load.
 
@@ -148,4 +148,3 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
 - Other destinations: [AWS RDS MySQL to Neon](/guides/aws-rds-mysql-to-neon/) · [MySQL to Supabase](/guides/mysql-to-supabase/) · [Cloud SQL for MySQL to Supabase](/guides/cloud-sql-mysql-to-supabase/) · [PlanetScale to Supabase](/guides/planetscale-to-supabase/)
-</content>

--- a/site/src/content/docs/guides/azure-sql-to-neon.md
+++ b/site/src/content/docs/guides/azure-sql-to-neon.md
@@ -3,7 +3,7 @@ title: Azure SQL to Neon
 description: Azure SQL to Neon playbook — pgferry moves Azure SQL Database into Neon serverless Postgres via encrypt=true TLS, snapshot isolation, and scale-to-zero.
 ---
 
-This is an operator's playbook for an **Azure SQL to Neon** migration. It covers the Azure SQL Database side — server-level firewall rules, mandatory encryption, and the snapshot-isolation setting `single_tx` relies on — together with the Neon endpoint and scale-to-zero details you need to land [Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/) on [Neon](https://neon.com/)'s serverless PostgreSQL.
+This is an operator's playbook for an **Azure SQL to Neon** migration. It covers the Azure SQL Database side — server-level firewall rules, mandatory encryption, and the snapshot-isolation setting `single_tx` relies on — together with the Neon endpoint and scale-to-zero details that land [Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/) on [Neon](https://neon.com/)'s serverless PostgreSQL in one piece.
 
 If you searched for how to **migrate Azure SQL to Neon** or move **Azure SQL Database to Neon Postgres**, the short version is: open the Azure server firewall to your migration host, connect with `encrypt=true`, enable `ALLOW_SNAPSHOT_ISOLATION` for a consistent read, point `pgferry` at Neon's **unpooled (direct)** endpoint, and disable scale-to-zero for the load.
 
@@ -148,4 +148,3 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [MSSQL minimal-safe example](/examples/mssql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
 - Other destinations: [Azure SQL to Supabase](/guides/azure-sql-to-supabase/) · [MSSQL to Neon](/guides/mssql-to-neon/) · [MSSQL to Supabase](/guides/mssql-to-supabase/) · [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/)
-</content>

--- a/site/src/content/docs/guides/azure-sql-to-supabase.md
+++ b/site/src/content/docs/guides/azure-sql-to-supabase.md
@@ -3,7 +3,7 @@ title: Azure SQL to Supabase
 description: Azure SQL to Supabase migration playbook — pgferry moves Azure SQL Database to Supabase Postgres via firewall rules, encrypt=true TLS, and snapshot isolation.
 ---
 
-This is an operator's playbook for an **Azure SQL to Supabase** migration. It covers the Azure SQL Database side — server-level firewall rules, mandatory encryption, and the snapshot-isolation setting `single_tx` relies on — together with the Supabase connection and timeout setup you need to land [Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/) on [Supabase](https://supabase.com/) PostgreSQL.
+This is an operator's playbook for an **Azure SQL to Supabase** migration. It covers the Azure SQL Database side — server-level firewall rules, mandatory encryption, and the snapshot-isolation setting `single_tx` relies on — together with the Supabase connection and timeout setup that land [Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/) on [Supabase](https://supabase.com/) PostgreSQL without the dead ends.
 
 If you searched for how to **migrate Azure SQL to Supabase** or move **Azure SQL Database to Supabase Postgres**, the short version is: open the Azure server firewall to your migration host, connect with `encrypt=true`, enable `ALLOW_SNAPSHOT_ISOLATION` for a consistent read, point `pgferry` at Supabase's session pooler, and raise the `postgres` role statement timeout for the load.
 
@@ -157,5 +157,3 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [MSSQL minimal-safe example](/examples/mssql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
 - Other destinations: [Azure SQL to Neon](/guides/azure-sql-to-neon/) · [MSSQL to Supabase](/guides/mssql-to-supabase/) · [MSSQL to Neon](/guides/mssql-to-neon/) · [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/)
-</content>
-</invoke>

--- a/site/src/content/docs/guides/cloud-sql-mysql-to-neon.md
+++ b/site/src/content/docs/guides/cloud-sql-mysql-to-neon.md
@@ -3,7 +3,7 @@ title: Cloud SQL for MySQL to Neon
 description: Cloud SQL for MySQL to Neon playbook — pgferry moves Cloud SQL MySQL into Neon serverless Postgres via the Auth Proxy, the direct endpoint, and scale-to-zero.
 ---
 
-This is an operator's playbook for a **Cloud SQL for MySQL to Neon** migration. It covers the Google Cloud SQL side — the Cloud SQL Auth Proxy versus public-IP authorized networks, and SSL/TLS — together with the Neon endpoint and scale-to-zero details you need to move [Cloud SQL for MySQL](https://cloud.google.com/sql/docs/mysql) into [Neon](https://neon.com/)'s serverless PostgreSQL.
+This is an operator's playbook for a **Cloud SQL for MySQL to Neon** migration. It covers the Google Cloud SQL side — the Cloud SQL Auth Proxy versus public-IP authorized networks, and SSL/TLS — together with the Neon endpoint and scale-to-zero details that get [Cloud SQL for MySQL](https://cloud.google.com/sql/docs/mysql) onto [Neon](https://neon.com/)'s serverless PostgreSQL in one piece.
 
 If you searched for how to **migrate Cloud SQL MySQL to Neon** or move **Google Cloud SQL for MySQL to Neon Postgres**, the short version is: connect to Cloud SQL through the **Auth Proxy** (or add your IP to authorized networks and enforce SSL), point `pgferry` at Neon's **unpooled (direct)** endpoint, and disable scale-to-zero for the load.
 
@@ -146,4 +146,3 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
 - Other destinations: [Cloud SQL for MySQL to Supabase](/guides/cloud-sql-mysql-to-supabase/) · [MySQL to Neon](/guides/mysql-to-neon/) · [AWS RDS MySQL to Neon](/guides/aws-rds-mysql-to-neon/) · [PlanetScale to Neon](/guides/planetscale-to-neon/)
-</content>

--- a/site/src/content/docs/guides/cloud-sql-mysql-to-supabase.md
+++ b/site/src/content/docs/guides/cloud-sql-mysql-to-supabase.md
@@ -3,7 +3,7 @@ title: Cloud SQL for MySQL to Supabase
 description: Cloud SQL for MySQL to Supabase playbook — pgferry moves Cloud SQL MySQL into Supabase Postgres via the Auth Proxy, session pooler, and statement-timeout setup.
 ---
 
-This is an operator's playbook for a **Cloud SQL for MySQL to Supabase** migration. It covers the Google Cloud SQL side — the Cloud SQL Auth Proxy versus public-IP authorized networks, and SSL/TLS — together with the Supabase connection and timeout setup you need to move [Cloud SQL for MySQL](https://cloud.google.com/sql/docs/mysql) into [Supabase](https://supabase.com/) PostgreSQL.
+This is an operator's playbook for a **Cloud SQL for MySQL to Supabase** migration. It covers the Google Cloud SQL side — the Cloud SQL Auth Proxy versus public-IP authorized networks, and SSL/TLS — together with the Supabase connection and timeout setup that get [Cloud SQL for MySQL](https://cloud.google.com/sql/docs/mysql) into [Supabase](https://supabase.com/) PostgreSQL without the dead ends.
 
 If you searched for how to **migrate Cloud SQL MySQL to Supabase** or move **Google Cloud SQL for MySQL to Supabase Postgres**, the short version is: connect to Cloud SQL through the **Auth Proxy** (or add your IP to authorized networks and enforce SSL), point `pgferry` at Supabase's session pooler, and raise the `postgres` role statement timeout for the load.
 
@@ -155,4 +155,3 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
 - Other destinations: [Cloud SQL for MySQL to Neon](/guides/cloud-sql-mysql-to-neon/) · [MySQL to Supabase](/guides/mysql-to-supabase/) · [AWS RDS MySQL to Supabase](/guides/aws-rds-mysql-to-supabase/) · [PlanetScale to Supabase](/guides/planetscale-to-supabase/)
-</content>

--- a/site/src/content/docs/guides/index.md
+++ b/site/src/content/docs/guides/index.md
@@ -3,7 +3,7 @@ title: Guides
 description: Source and destination guides for migrating MySQL, MariaDB, SQLite, and MSSQL to PostgreSQL on Supabase, Neon, Railway, Render, and more.
 ---
 
-Guides for specific sources, destinations, and combinations — covering caveats, defaults, and practical starting points.
+Guides for specific sources, destinations, and the combinations in between — the caveats, the defaults, and a sensible place to start for each one.
 
 ## By source database
 
@@ -14,7 +14,7 @@ Guides for specific sources, destinations, and combinations — covering caveats
 
 ## By managed Postgres destination
 
-Destination-specific playbooks with provider connection, TLS, pooling, and firewall setup — not just generic source advice. Grouped by destination:
+Destination-specific playbooks: the real provider connection, TLS, pooling, and firewall setup — not just generic source advice rewarmed. Grouped by where your data is headed:
 
 - **Supabase**: [from MySQL](/guides/mysql-to-supabase/) · [from MSSQL](/guides/mssql-to-supabase/) · [from Azure SQL](/guides/azure-sql-to-supabase/) · [from PlanetScale](/guides/planetscale-to-supabase/) · [from RDS MySQL](/guides/aws-rds-mysql-to-supabase/) · [from Cloud SQL MySQL](/guides/cloud-sql-mysql-to-supabase/)
 - **Neon**: [from MySQL](/guides/mysql-to-neon/) · [from MSSQL](/guides/mssql-to-neon/) · [from Azure SQL](/guides/azure-sql-to-neon/) · [from PlanetScale](/guides/planetscale-to-neon/) · [from RDS MySQL](/guides/aws-rds-mysql-to-neon/) · [from Cloud SQL MySQL](/guides/cloud-sql-mysql-to-neon/)
@@ -24,7 +24,7 @@ Destination-specific playbooks with provider connection, TLS, pooling, and firew
 
 ## By managed source environment
 
-The provider environment changes the access, TLS, and firewall setup as much as the destination does. These guides cover the source-side specifics for managed and hosted databases:
+Where your source lives changes the access, TLS, and firewall story as much as the destination does. These guides cover the source-side specifics for managed and hosted databases:
 
 - **Managed MySQL sources**: PlanetScale (MySQL/Vitess) — [to Supabase](/guides/planetscale-to-supabase/) · [to Neon](/guides/planetscale-to-neon/); AWS RDS / Aurora MySQL — [to Supabase](/guides/aws-rds-mysql-to-supabase/) · [to Neon](/guides/aws-rds-mysql-to-neon/); Google Cloud SQL for MySQL — [to Supabase](/guides/cloud-sql-mysql-to-supabase/) · [to Neon](/guides/cloud-sql-mysql-to-neon/)
 - **Azure SQL / SQL Server sources**: [Azure SQL to Supabase](/guides/azure-sql-to-supabase/) · [Azure SQL to Neon](/guides/azure-sql-to-neon/) · [MSSQL to Railway](/guides/mssql-to-railway-postgres/) · [MSSQL to Render](/guides/mssql-to-render-postgres/)

--- a/site/src/content/docs/guides/mariadb.md
+++ b/site/src/content/docs/guides/mariadb.md
@@ -3,7 +3,7 @@ title: MariaDB To PostgreSQL
 description: Migrate MariaDB to PostgreSQL with pgferry as a first-class source — native UUID and JSON handling, MySQL-family knobs, and where MariaDB differs.
 ---
 
-MariaDB is a first-class pgferry source type. It shares most MySQL-family behavior, but pgferry treats it separately so config validation, examples, and type handling can be explicit about MariaDB-specific behavior.
+MariaDB is a first-class source in pgferry, not a MySQL afterthought. It shares most MySQL-family behavior, but pgferry treats it as its own thing so config validation, examples, and type handling can be explicit about where MariaDB differs.
 
 ## Start here
 
@@ -29,4 +29,4 @@ MariaDB is a first-class pgferry source type. It shares most MySQL-family behavi
 
 - PostGIS migration is MySQL-only in this release; MariaDB should use spatial fallback modes instead
 - unsupported indexes such as `FULLTEXT`, prefix indexes, and expression indexes are still reported and skipped rather than guessed
-- if you are coming from existing MySQL configs or automation, make sure they do not leave `source.type = "mysql"` behind by habit
+- coming from existing MySQL configs or automation? Double-check they don't leave `source.type = "mysql"` behind out of habit

--- a/site/src/content/docs/guides/mssql-to-neon.md
+++ b/site/src/content/docs/guides/mssql-to-neon.md
@@ -3,7 +3,7 @@ title: MSSQL to Neon
 description: MSSQL to Neon playbook — pgferry moves SQL Server to Neon serverless Postgres via the direct endpoint, scale-to-zero, and sys.* SQL Server type conversions.
 ---
 
-This is an operator's playbook for an **MSSQL to Neon** migration. It covers the Neon-specific endpoint, scale-to-zero, and TLS details plus the SQL Server type caveats you need to move Microsoft SQL Server into [Neon](https://neon.com/)'s serverless PostgreSQL.
+This is an operator's playbook for an **MSSQL to Neon** migration. It covers the Neon-specific endpoint, scale-to-zero, and TLS details plus the SQL Server type caveats that get Microsoft SQL Server onto [Neon](https://neon.com/)'s serverless PostgreSQL — the parts generic tutorials skip.
 
 If you searched for how to **migrate SQL Server to Neon** or move **MSSQL to Neon Postgres**, the short version is: point `pgferry` at Neon's **unpooled (direct)** endpoint, disable scale-to-zero for the load, and let pgferry's `sys.*` catalog introspection handle the SQL Server types that generic tools botch.
 

--- a/site/src/content/docs/guides/mssql-to-planetscale-postgres.md
+++ b/site/src/content/docs/guides/mssql-to-planetscale-postgres.md
@@ -9,7 +9,7 @@ If you searched for how to **migrate SQL Server to PlanetScale Postgres** or mov
 
 ## What this guide is for
 
-Use this guide when your source is **Microsoft SQL Server** and your destination is **PlanetScale for Postgres**. Note that this is a real cross-engine MSSQL-to-PostgreSQL migration: PlanetScale for Postgres is genuine PostgreSQL on PlanetScale Metal, unrelated to PlanetScale's MySQL/Vitess product. For source-side behavior that is not PlanetScale-specific, read the generic [MSSQL to PostgreSQL guide](/guides/mssql/) alongside this page.
+Use this guide when your source is **Microsoft SQL Server** and your destination is **PlanetScale for Postgres**. Worth knowing up front: this is a genuine cross-engine MSSQL-to-PostgreSQL migration — PlanetScale for Postgres is real PostgreSQL on PlanetScale Metal, unrelated to PlanetScale's MySQL/Vitess product. For source-side behavior that is not PlanetScale-specific, read the generic [MSSQL to PostgreSQL guide](/guides/mssql/) alongside this page.
 
 ## Why use pgferry instead of generic pgloader advice
 

--- a/site/src/content/docs/guides/mssql-to-railway-postgres.md
+++ b/site/src/content/docs/guides/mssql-to-railway-postgres.md
@@ -3,7 +3,7 @@ title: MSSQL to Railway Postgres
 description: MSSQL to Railway Postgres playbook — pgferry moves SQL Server to a Railway PostgreSQL service via the public TCP proxy, self-signed TLS, and sys.* conversions.
 ---
 
-This is an operator's playbook for an **MSSQL to Railway Postgres** migration. It covers the Railway-specific connection details — the public TCP proxy, self-signed TLS, and private networking — plus the SQL Server type caveats you need to move Microsoft SQL Server into a [Railway](https://railway.com/) PostgreSQL service.
+This is an operator's playbook for an **MSSQL to Railway Postgres** migration. It covers the Railway-specific connection details — the public TCP proxy, self-signed TLS, and private networking — plus the SQL Server type caveats that get Microsoft SQL Server into a [Railway](https://railway.com/) PostgreSQL service without surprises.
 
 If you searched for how to **migrate SQL Server to Railway Postgres** or move **MSSQL to Railway**, the short version is: use Railway's **public proxy URL** (`DATABASE_PUBLIC_URL`) with `sslmode=require` from an external host, run the migration **inside Railway** to avoid egress charges when you can, and let pgferry's `sys.*` catalog introspection handle the SQL Server types generic tools botch.
 
@@ -132,4 +132,3 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [MSSQL minimal-safe example](/examples/mssql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
 - Other destinations: [MSSQL to Render Postgres](/guides/mssql-to-render-postgres/) · [MSSQL to Supabase](/guides/mssql-to-supabase/) · [MSSQL to Neon](/guides/mssql-to-neon/) · [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/) · [Azure SQL to Neon](/guides/azure-sql-to-neon/)
-</content>

--- a/site/src/content/docs/guides/mssql-to-render-postgres.md
+++ b/site/src/content/docs/guides/mssql-to-render-postgres.md
@@ -3,7 +3,7 @@ title: MSSQL to Render Postgres
 description: MSSQL to Render Postgres playbook — pgferry moves SQL Server to a Render PostgreSQL instance via the External URL, required TLS, and IP allowlists.
 ---
 
-This is an operator's playbook for an **MSSQL to Render Postgres** migration. It covers the Render-specific connection details — external vs internal URLs, required TLS, and the inbound IP allowlist — plus the SQL Server type caveats you need to move Microsoft SQL Server into a [Render](https://render.com/) PostgreSQL instance.
+This is an operator's playbook for an **MSSQL to Render Postgres** migration. It covers the Render-specific connection details — external vs internal URLs, required TLS, and the inbound IP allowlist — plus the SQL Server type caveats that get Microsoft SQL Server onto a [Render](https://render.com/) PostgreSQL instance in one piece.
 
 If you searched for how to **migrate SQL Server to Render Postgres** or move **MSSQL to Render**, the short version is: connect from an external host with Render's **External Database URL** and `sslmode=require`, allow your migration host in the inbound IP rules, never load production data into a Free instance, and let pgferry's `sys.*` catalog introspection handle the SQL Server types generic tools botch.
 
@@ -123,4 +123,3 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [MSSQL minimal-safe example](/examples/mssql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
 - Other destinations: [MSSQL to Railway Postgres](/guides/mssql-to-railway-postgres/) · [MSSQL to Supabase](/guides/mssql-to-supabase/) · [MSSQL to Neon](/guides/mssql-to-neon/) · [MSSQL to PlanetScale Postgres](/guides/mssql-to-planetscale-postgres/) · [Azure SQL to Supabase](/guides/azure-sql-to-supabase/)
-</content>

--- a/site/src/content/docs/guides/mssql-to-supabase.md
+++ b/site/src/content/docs/guides/mssql-to-supabase.md
@@ -3,7 +3,7 @@ title: MSSQL to Supabase
 description: MSSQL to Supabase playbook — pgferry moves SQL Server to Supabase Postgres via the session pooler, statement-timeout setup, and sys.* type conversions.
 ---
 
-This is an operator's playbook for an **MSSQL to Supabase** migration. It covers the Supabase-specific connection and timeout setup plus the SQL Server type caveats you need to move Microsoft SQL Server into [Supabase](https://supabase.com/)'s hosted PostgreSQL.
+This is an operator's playbook for an **MSSQL to Supabase** migration. It covers the Supabase-specific connection and timeout setup plus the SQL Server type caveats that get Microsoft SQL Server into [Supabase](https://supabase.com/)'s hosted PostgreSQL without the usual dead ends.
 
 If you searched for how to **migrate SQL Server to Supabase** or move **MSSQL to Supabase Postgres**, the short version is: point `pgferry` at a session-mode (not transaction-mode) Supabase connection, raise the `postgres` role statement timeout for the load, and let pgferry's `sys.*` catalog introspection handle the SQL Server types that no `pgloader` recipe covers well.
 

--- a/site/src/content/docs/guides/mssql.md
+++ b/site/src/content/docs/guides/mssql.md
@@ -3,7 +3,7 @@ title: MSSQL To PostgreSQL
 description: Migrate SQL Server to PostgreSQL with pgferry — sys.* introspection, snapshot isolation, uniqueidentifier reordering, and temporal-table caveats.
 ---
 
-MSSQL support uses `sys.*` catalog introspection and a small set of SQL Server-specific conversions that are worth understanding up front.
+MSSQL support leans on `sys.*` catalog introspection plus a small set of SQL Server-specific conversions — all worth a quick read before you start.
 
 ## Start here
 
@@ -38,7 +38,7 @@ MSSQL support uses `sys.*` catalog introspection and a small set of SQL Server-s
 
 ## Migrating to a managed Postgres provider?
 
-These destination-specific guides add the provider connection, TLS, pooling, and firewall setup on top of the MSSQL behavior above:
+With the MSSQL side understood, these destination playbooks add the provider connection, TLS, pooling, and firewall setup:
 
 - [MSSQL to Supabase](/guides/mssql-to-supabase/)
 - [MSSQL to Neon](/guides/mssql-to-neon/)
@@ -48,7 +48,7 @@ These destination-specific guides add the provider connection, TLS, pooling, and
 
 ## Source is Azure SQL Database?
 
-Azure SQL Database is the same T-SQL engine, but the access, encryption, and snapshot-isolation setup are Azure-specific. These guides read as Azure-specific playbooks rather than generic MSSQL pages:
+Azure SQL Database runs the same T-SQL engine, but its access, encryption, and snapshot-isolation setup are Azure's own. These guides are Azure-specific playbooks, not generic MSSQL pages:
 
 - [Azure SQL to Supabase](/guides/azure-sql-to-supabase/)
 - [Azure SQL to Neon](/guides/azure-sql-to-neon/)

--- a/site/src/content/docs/guides/mysql-to-neon.md
+++ b/site/src/content/docs/guides/mysql-to-neon.md
@@ -3,7 +3,7 @@ title: MySQL to Neon
 description: MySQL to Neon migration playbook — pgferry moves MySQL to Neon serverless Postgres via the direct (unpooled) endpoint, mandatory TLS, and scale-to-zero.
 ---
 
-This is an operator's playbook for a **MySQL to Neon** migration. It covers the Neon-specific endpoint, scale-to-zero, and TLS details you need to move MySQL into [Neon](https://neon.com/)'s serverless PostgreSQL — the parts generic import tutorials leave out.
+This is an operator's playbook for a **MySQL to Neon** migration. It covers the Neon-specific endpoint, scale-to-zero, and TLS details that get MySQL into [Neon](https://neon.com/)'s serverless PostgreSQL — the parts generic import tutorials quietly skip.
 
 If you searched for how to **migrate MySQL to Neon** or **move a MySQL database to Neon Postgres**, the short version is: point `pgferry` at the **unpooled (direct)** Neon endpoint, disable scale-to-zero for the load, and let the [MySQL type mapping](/reference/type-mapping/) handle enums, sets, and unsigned integers that `pgloader` mishandles.
 
@@ -13,7 +13,7 @@ Use this guide when you have a live MySQL database (self-hosted, RDS, Aurora MyS
 
 ## Why use pgferry instead of generic pgloader advice
 
-The usual "mysql to neon" advice is `pgloader`, which struggles on real migrations:
+The usual "mysql to neon" advice is `pgloader`, which tends to struggle once a real migration is involved:
 
 - `pgloader` has no resume. Over a Neon connection that auto-suspends or hiccups, an interrupted load restarts from zero. `pgferry` checkpoints and resumes.
 - MySQL enums, sets, unsigned integers, `tinyint(1)`, and zero dates are explicit, documented knobs in `pgferry`; `pgloader` guesses and frequently picks `text`.

--- a/site/src/content/docs/guides/mysql-to-planetscale-postgres.md
+++ b/site/src/content/docs/guides/mysql-to-planetscale-postgres.md
@@ -18,7 +18,7 @@ For source-side behavior that is not PlanetScale-specific, read the generic [MyS
 
 ## Why use pgferry instead of generic pgloader advice
 
-PlanetScale recommends `pg_dump`/`pg_restore` for Postgres-to-Postgres imports, but those are useless for a MySQL **source**. The generic cross-engine tool is `pgloader`, which struggles on real schemas:
+PlanetScale recommends `pg_dump`/`pg_restore` for Postgres-to-Postgres imports, but those do nothing for a MySQL **source**. The generic cross-engine tool is `pgloader`, which struggles on real schemas:
 
 - No resume, single long transactions, and weak type fidelity for MySQL enums/sets/unsigned integers.
 - `pgferry` streams with chunked, parallel `COPY`, checkpoints for `resume`, and runs a [`plan`](/operations/how-to-read-plan-output/) preflight.

--- a/site/src/content/docs/guides/mysql-to-railway-postgres.md
+++ b/site/src/content/docs/guides/mysql-to-railway-postgres.md
@@ -3,7 +3,7 @@ title: MySQL to Railway Postgres
 description: MySQL to Railway Postgres playbook — pgferry moves MySQL to a Railway PostgreSQL service via the public TCP proxy, self-signed TLS, and private networking.
 ---
 
-This is an operator's playbook for a **MySQL to Railway Postgres** migration. It covers the Railway-specific connection details — the public TCP proxy, self-signed TLS, and private networking — that you need to move MySQL into a [Railway](https://railway.com/) PostgreSQL service.
+This is an operator's playbook for a **MySQL to Railway Postgres** migration. It covers the Railway-specific connection details — the public TCP proxy, self-signed TLS, and private networking — that get MySQL into a [Railway](https://railway.com/) PostgreSQL service without surprises.
 
 If you searched for how to **migrate MySQL to Railway Postgres** or **move a MySQL database to Railway**, the short version is: use Railway's **public proxy URL** (`DATABASE_PUBLIC_URL`) with `sslmode=require` from an external host, run the migration **inside Railway** to avoid egress charges when you can, and let pgferry's [MySQL type mapping](/reference/type-mapping/) handle enums, sets, and unsigned integers.
 
@@ -13,7 +13,7 @@ Use this guide when you have a live MySQL database and want it on a Railway-host
 
 ## Why use pgferry instead of generic pgloader advice
 
-`pgloader` is the usual "mysql to railway postgres" suggestion, and it falls down on real schemas:
+`pgloader` is the usual "mysql to railway postgres" suggestion, and it tends to fall down on real schemas:
 
 - No resume — a drop over Railway's TCP proxy means restarting the whole load. `pgferry` checkpoints and resumes.
 - MySQL enums, sets, unsigned integers, `tinyint(1)`, and zero dates are explicit, documented knobs in `pgferry`.

--- a/site/src/content/docs/guides/mysql-to-render-postgres.md
+++ b/site/src/content/docs/guides/mysql-to-render-postgres.md
@@ -3,7 +3,7 @@ title: MySQL to Render Postgres
 description: MySQL to Render Postgres playbook — pgferry moves MySQL to a Render PostgreSQL instance via the External URL, required TLS, and inbound IP allowlists.
 ---
 
-This is an operator's playbook for a **MySQL to Render Postgres** migration. It covers the Render-specific connection details — external vs internal URLs, required TLS, and the inbound IP allowlist — that you need to move MySQL into a [Render](https://render.com/) PostgreSQL instance.
+This is an operator's playbook for a **MySQL to Render Postgres** migration. It covers the Render-specific connection details — external vs internal URLs, required TLS, and the inbound IP allowlist — that get MySQL into a [Render](https://render.com/) PostgreSQL instance.
 
 If you searched for how to **migrate MySQL to Render Postgres** or **move a MySQL database to Render**, the short version is: connect from an external host with Render's **External Database URL** and `sslmode=require`, allow your migration host in the inbound IP rules, never load production data into a Free instance, and let pgferry's [MySQL type mapping](/reference/type-mapping/) handle enums, sets, and unsigned integers.
 
@@ -13,7 +13,7 @@ Use this guide when you have a live MySQL database and want it on a Render-hoste
 
 ## Why use pgferry instead of generic pgloader advice
 
-`pgloader` is the common "mysql to render postgres" recommendation and it struggles on real workloads:
+`pgloader` is the common "mysql to render postgres" recommendation, and it struggles once real workloads are involved:
 
 - No resume — a drop mid-load means starting over. `pgferry` checkpoints and resumes.
 - MySQL enums, sets, unsigned integers, `tinyint(1)`, and zero dates are explicit knobs in `pgferry`.

--- a/site/src/content/docs/guides/mysql-to-supabase.md
+++ b/site/src/content/docs/guides/mysql-to-supabase.md
@@ -3,7 +3,7 @@ title: MySQL to Supabase
 description: MySQL to Supabase migration playbook — pgferry moves MySQL to Supabase Postgres via the session pooler, mandatory TLS, and statement-timeout setup.
 ---
 
-This is an operator's playbook for a **MySQL to Supabase** migration. It covers the Supabase-specific connection, pooler, and timeout details you need to move MySQL into [Supabase](https://supabase.com/)'s hosted PostgreSQL without the dead ends that come from generic import advice.
+This is an operator's playbook for a **MySQL to Supabase** migration. It covers the Supabase-specific connection, pooler, and timeout details that get MySQL into [Supabase](https://supabase.com/)'s hosted PostgreSQL — minus the dead ends that generic import advice tends to lead you into.
 
 If you searched for how to **migrate MySQL to Supabase** or **move MySQL to Supabase Postgres**, the short version is: point `pgferry` at a session-mode (not transaction-mode) Supabase connection, raise the `postgres` role statement timeout for the load, and let the [MySQL type mapping](/reference/type-mapping/) handle enums, sets, and unsigned integers that `pgloader` mangles.
 
@@ -13,7 +13,7 @@ Use this guide when you have a live MySQL database (self-hosted, RDS, Aurora MyS
 
 ## Why use pgferry instead of generic pgloader advice
 
-Most "mysql to supabase" walkthroughs reach for `pgloader`. On real schemas that path routinely stalls or loses fidelity:
+Most "mysql to supabase" walkthroughs reach for `pgloader`. On real schemas, that path has a habit of stalling or quietly losing fidelity:
 
 - `pgloader` loads each table in long-running transactions and has no resume — a dropped connection (common over a hosted pooler) means starting over.
 - MySQL enums, sets, unsigned integers, `tinyint(1)` booleans, and zero dates need deliberate decisions. `pgferry` exposes each as an explicit, documented knob; `pgloader` guesses.

--- a/site/src/content/docs/guides/mysql.md
+++ b/site/src/content/docs/guides/mysql.md
@@ -3,13 +3,13 @@ title: MySQL To PostgreSQL
 description: Migrate MySQL to PostgreSQL with pgferry — enum, set, unsigned, and UUID type knobs, generated-column and index caveats, plus optional PostGIS.
 ---
 
-MySQL is still the richest pgferry source because it includes enums, sets, unsigned types, generated columns, optional PostGIS migration, and collation handling. If your source is MariaDB, use the dedicated [MariaDB guide](/guides/mariadb/) rather than assuming every MySQL-specific feature applies unchanged.
+MySQL is the richest source pgferry handles — enums, sets, unsigned types, generated columns, optional PostGIS, and collation handling all live here. If your source is actually MariaDB, hop over to the dedicated [MariaDB guide](/guides/mariadb/) instead of assuming every MySQL-specific feature carries over unchanged.
 
 ## Start here
 
-- [minimal-safe example](/examples/mysql/minimal-safe/) for the first real rehearsal
-- [chunked-resume example](/examples/mysql/chunked-resume/) when restart cost matters
-- [hooks example](/examples/mysql/hooks/) if `plan` reports manual follow-up work
+- [minimal-safe example](/examples/mysql/minimal-safe/) — the gentle first rehearsal
+- [chunked-resume example](/examples/mysql/chunked-resume/) — for when starting over would really hurt
+- [hooks example](/examples/mysql/hooks/) — if `plan` flags manual follow-up work
 
 ## MySQL-specific options to decide deliberately
 
@@ -32,7 +32,7 @@ MySQL is still the richest pgferry source because it includes enums, sets, unsig
 
 ## Migrating to a managed Postgres provider?
 
-These destination-specific guides add the provider connection, TLS, pooling, and firewall setup on top of the MySQL behavior above:
+Once the MySQL side is sorted, these destination playbooks layer on the provider connection, TLS, pooling, and firewall setup:
 
 - [MySQL to Supabase](/guides/mysql-to-supabase/)
 - [MySQL to Neon](/guides/mysql-to-neon/)
@@ -42,7 +42,7 @@ These destination-specific guides add the provider connection, TLS, pooling, and
 
 ## Migrating from a managed MySQL source?
 
-PlanetScale, RDS, and Cloud SQL are all MySQL — the type behavior above applies unchanged — but each adds its own access, TLS, and firewall setup. These guides cover the source-side specifics:
+PlanetScale, RDS, and Cloud SQL are all MySQL under the hood — the type behavior above applies unchanged — but each brings its own access, TLS, and firewall quirks. These guides cover the source-side specifics:
 
 - [PlanetScale to Supabase](/guides/planetscale-to-supabase/) · [PlanetScale to Neon](/guides/planetscale-to-neon/) — PlanetScale's MySQL/Vitess product as a source
 - [AWS RDS MySQL to Supabase](/guides/aws-rds-mysql-to-supabase/) · [AWS RDS MySQL to Neon](/guides/aws-rds-mysql-to-neon/) — RDS and Aurora MySQL

--- a/site/src/content/docs/guides/planetscale-to-neon.md
+++ b/site/src/content/docs/guides/planetscale-to-neon.md
@@ -13,7 +13,7 @@ Use this guide when your source is a **PlanetScale MySQL/Vitess** database and y
 
 ## Why use pgferry instead of generic pgloader advice
 
-Most "planetscale to postgres" advice points at `pgloader`, which struggles on real schemas — and PlanetScale's own exporter targets MySQL/PlanetScale, not PostgreSQL:
+Most "planetscale to postgres" advice points at `pgloader`, which tends to struggle on real schemas — and PlanetScale's own exporter targets MySQL/PlanetScale, not PostgreSQL:
 
 - `pgloader` has no resume and loads in long transactions; over a Neon connection that auto-suspends, an interrupted load restarts from zero. `pgferry` checkpoints and resumes.
 - MySQL enums, sets, unsigned integers, `tinyint(1)`, and zero dates are explicit, documented knobs in `pgferry`; `pgloader` guesses and frequently picks `text`.
@@ -141,4 +141,3 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
 - Other destinations: [PlanetScale to Supabase](/guides/planetscale-to-supabase/) · [MySQL to Neon](/guides/mysql-to-neon/) · [AWS RDS MySQL to Neon](/guides/aws-rds-mysql-to-neon/) · [Cloud SQL for MySQL to Neon](/guides/cloud-sql-mysql-to-neon/)
-</content>

--- a/site/src/content/docs/guides/planetscale-to-supabase.md
+++ b/site/src/content/docs/guides/planetscale-to-supabase.md
@@ -13,7 +13,7 @@ Use this guide when your source is a **PlanetScale MySQL/Vitess** database and y
 
 ## Why use pgferry instead of generic pgloader advice
 
-Most "planetscale to postgres" advice points at `pgloader`, which struggles on real schemas — and PlanetScale's own exporter targets MySQL/PlanetScale, not PostgreSQL:
+Most "planetscale to postgres" advice points at `pgloader`, which tends to struggle on real schemas — and PlanetScale's own exporter targets MySQL/PlanetScale, not PostgreSQL:
 
 - `pgloader` has no resume and loads in long transactions; a drop over PlanetScale's proxied connection means starting over. `pgferry` checkpoints and resumes.
 - MySQL enums, sets, unsigned integers, `tinyint(1)`, and zero dates are explicit, documented knobs in `pgferry`; `pgloader` guesses and frequently picks `text`.
@@ -150,4 +150,3 @@ See [common failures and recovery](/operations/common-failures-and-recovery/).
 - [MySQL minimal-safe example](/examples/mysql/minimal-safe/)
 - [Cutover checklist](/operations/cutover-checklist/) · [First production migration checklist](/operations/first-production-migration-checklist/)
 - Other destinations: [PlanetScale to Neon](/guides/planetscale-to-neon/) · [MySQL to Supabase](/guides/mysql-to-supabase/) · [AWS RDS MySQL to Supabase](/guides/aws-rds-mysql-to-supabase/) · [Cloud SQL for MySQL to Supabase](/guides/cloud-sql-mysql-to-supabase/)
-</content>

--- a/site/src/content/docs/guides/sqlite.md
+++ b/site/src/content/docs/guides/sqlite.md
@@ -3,7 +3,7 @@ title: SQLite To PostgreSQL
 description: Migrate SQLite to PostgreSQL with pgferry — single-worker read-only loads, real-file-only sources, and the few constraints to plan around.
 ---
 
-SQLite is simpler operationally, but there are still a few important constraints to account for before you start.
+SQLite is the easygoing one of the bunch — no live server to wrestle, no replication to babysit. Still a few constraints worth knowing before you dive in.
 
 ## Start here
 
@@ -13,10 +13,10 @@ SQLite is simpler operationally, but there are still a few important constraints
 
 ## SQLite-specific realities
 
-- worker count is always effectively 1
+- worker count is always effectively 1 — SQLite is single-threaded here, and that's perfectly fine
 - `source_snapshot_mode = "single_tx"` is unsupported
 - the source must be a real SQLite file, not an in-memory database
-- the source is opened read-only
+- the source is opened read-only, so your original file is never touched
 - MySQL-family-only and MSSQL-only type-mapping flags are rejected during config validation
 
 ## Where SQLite is usually easier

--- a/site/src/content/docs/migration-patterns/chunked-resume.md
+++ b/site/src/content/docs/migration-patterns/chunked-resume.md
@@ -3,7 +3,7 @@ title: Chunked-resume
 description: The pgferry pattern for large or interruption-prone migrations — chunking, resumable checkpoints, and row-count validation cut restart cost.
 ---
 
-Choose `chunked-resume` when large tables or operational interruption risk make restart cost unacceptable.
+Go with `chunked-resume` when big tables or the risk of interruption make starting over too costly to stomach.
 
 ## What defines this pattern
 

--- a/site/src/content/docs/migration-patterns/hooks-driven.md
+++ b/site/src/content/docs/migration-patterns/hooks-driven.md
@@ -3,7 +3,7 @@ title: Hooks-driven Migrations
 description: Use pgferry SQL hook phases to create extensions, run ANALYZE, clean orphans, and recreate views and routines around the built-in pipeline.
 ---
 
-Hooks are the normal answer when pgferry correctly tells you that something exists but should not be recreated automatically.
+Hooks are the natural answer when pgferry rightly tells you something exists but shouldn't be recreated for you automatically.
 
 ## Typical use cases
 

--- a/site/src/content/docs/migration-patterns/index.md
+++ b/site/src/content/docs/migration-patterns/index.md
@@ -3,7 +3,7 @@ title: Migration Patterns
 description: Pick a pgferry run style — minimal-safe, recreate-fast, chunked-resume, schema-only and data-only, or hooks-driven — before tuning flags.
 ---
 
-Most operators only need a handful of migration patterns. Choose one first, then refine it for your schema.
+Most operators only ever need a handful of patterns. Pick one to start, then refine it for your schema.
 
 ## Patterns
 

--- a/site/src/content/docs/migration-patterns/minimal-safe.md
+++ b/site/src/content/docs/migration-patterns/minimal-safe.md
@@ -3,7 +3,7 @@ title: Minimal-safe
 description: The safest pgferry pattern for first production rehearsals — durable tables, no schema clobbering, and explicit orphan cleanup.
 ---
 
-Choose `minimal-safe` when you want the least surprising behavior, even if it costs some speed.
+Reach for `minimal-safe` when you want the least surprising behavior — even if it trades away a little speed.
 
 ## What defines this pattern
 

--- a/site/src/content/docs/migration-patterns/recreate-fast.md
+++ b/site/src/content/docs/migration-patterns/recreate-fast.md
@@ -3,7 +3,7 @@ title: Recreate-fast
 description: The fastest pgferry pattern for disposable dev and staging targets — UNLOGGED tables, schema recreate, and high worker parallelism.
 ---
 
-Choose `recreate-fast` when the target can be dropped and rebuilt and you care more about speed than crash durability.
+Pick `recreate-fast` when the target is yours to drop and rebuild, and speed matters more than crash durability.
 
 ## What defines this pattern
 

--- a/site/src/content/docs/migration-patterns/schema-only-and-data-only.md
+++ b/site/src/content/docs/migration-patterns/schema-only-and-data-only.md
@@ -3,7 +3,7 @@ title: Schema-only And Data-only
 description: Split pgferry into schema_only and data_only runs for DDL review, tighter cutover sequencing, and truncate-before-copy into existing schemas.
 ---
 
-Use the split-phase workflow when you need schema creation and data loading to happen at different times.
+Reach for the split-phase workflow when schema creation and data loading need to happen at different moments.
 
 ## `schema_only`
 

--- a/site/src/content/docs/operations/handling-unsupported-objects-with-hooks.md
+++ b/site/src/content/docs/operations/handling-unsupported-objects-with-hooks.md
@@ -3,7 +3,7 @@ title: Handling Unsupported Objects With Hooks
 description: Use hook phases to recreate the source objects pgferry intentionally reports instead of migrating automatically.
 ---
 
-pgferry reports certain objects instead of guessing how to recreate them. Hooks are the normal way to finish that work.
+pgferry reports certain objects rather than guessing how to recreate them — and hooks are the normal way to finish that work yourself.
 
 ## Objects you should expect to handle yourself
 

--- a/site/src/content/docs/operations/how-to-choose-snapshot-mode.md
+++ b/site/src/content/docs/operations/how-to-choose-snapshot-mode.md
@@ -3,7 +3,7 @@ title: How To Choose Snapshot Mode
 description: Choose pgferry source_snapshot_mode none for speed or single_tx for one consistent snapshot when the source stays live during migration.
 ---
 
-The rule is simple: use `none` unless the source is live enough that cross-table inconsistency matters.
+The rule of thumb is simple: use `none` unless the source is live enough that cross-table inconsistency would actually bite.
 
 ## Choose `none` when
 

--- a/site/src/content/docs/operations/operator-tuning.md
+++ b/site/src/content/docs/operations/operator-tuning.md
@@ -3,7 +3,7 @@ title: Operator Tuning
 description: Tune PostgreSQL, source pressure, and pgferry settings deliberately before large migrations.
 ---
 
-Most slow migrations are bottlenecked by target PostgreSQL write behavior, post-load index builds, source read pressure, or network RTT long before Go code becomes the limiting factor.
+Most slow migrations are bottlenecked by target PostgreSQL write behavior, post-load index builds, source read pressure, or network RTT — long before pgferry's Go code is the thing holding you up.
 
 Treat pgferry tuning as an operator problem first:
 


### PR DESCRIPTION
## What

Verified every migration-related docs page against the actual pgferry CLI behavior and rewrote the prose in a lighter, warmer voice. Scope: `guides/`, `examples/`, `migration-patterns/`, and `operations/` (~60 files).

## Accuracy

Checked commands/aliases, every config key + default, the incompatibility matrix, type-mapping flags, snapshot behavior, validation modes, and `plan` flags against the Go source.

**One real defect found and fixed:** a stray literal `</content>` closing tag at the end of **10 guide files** (a copy-paste artifact that rendered as junk text at the bottom of each page). `azure-sql-to-supabase.md` additionally had a stray `</invoke>` tag. Affected files:

- `mssql-to-railway-postgres`, `mssql-to-render-postgres`
- `planetscale-to-supabase`, `planetscale-to-neon`
- `aws-rds-mysql-to-supabase`, `aws-rds-mysql-to-neon`
- `cloud-sql-mysql-to-supabase`, `cloud-sql-mysql-to-neon`
- `azure-sql-to-supabase`, `azure-sql-to-neon`

Everything else was already accurate — config snippets respected the incompatibility rules (`resume`+`unlogged_tables=false`, `recreate-fast` omits `resume`, SQLite examples avoid `single_tx`/`charset`/MySQL-only flags), and snapshot/validation/`plan` details matched the code.

**Not changed (flagged):** third-party provider infrastructure details (Supabase/Neon/Railway/Render/PlanetScale/RDS/Cloud SQL/Azure connection, TLS, pooling, firewall specifics) were not independently web-verified — out of repo scope. None contradicted the codebase.

## Tone

Light & warm touches to prose only — warmer openings, friendlier section intros, softer pgloader comparisons. All code blocks, config snippets, tables, DSNs, links, anchors, and frontmatter titles/descriptions are byte-identical. Warmth kept restrained on the dense MSSQL and high-stakes operations pages.

## Verification

- `bun run build` → 71 pages, no errors
- `bun run check-routes` → 71 routes + 162 assets verified
